### PR TITLE
Track resource dependencies through extraction (and more polishing of resource states)

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -531,12 +531,13 @@ void ezEngineProcessDocumentContext::OnGALEvent(const ezGALDeviceEvent& e)
 
   ezRenderGraphTextureHandle hTex = m_pRenderGraph->ImportTexture(m_hThumbnailColorRT);
 
-  auto pass = m_pRenderGraph->AddTransferPass("Thumbnail Readback");
-  pass.ReadTexture(hTex, {}, ezGALResourceState::CopySource);
-  pass.HasSideEffects();
-  pass.SetExecuteCallback([this, hTex](const ezRenderGraphContext& ctx)
-    { m_ThumbnailReadback.ReadbackTexture(*ctx.GetCommandEncoder(), ctx.ResolveTexture(hTex)); });
-
+  {
+    auto pass = m_pRenderGraph->AddTransferPass("Thumbnail Readback");
+    pass.ReadTexture(hTex, {}, ezGALResourceState::CopySource);
+    pass.HasSideEffects();
+    pass.SetExecuteCallback([this, hTex](const ezRenderGraphContext& ctx)
+      { m_ThumbnailReadback.ReadbackTexture(*ctx.GetCommandEncoder(), ctx.ResolveTexture(hTex)); });
+  }
   ezRenderGraphManager::EnqueueRenderGraph(m_pRenderGraph);
   m_bThumbnailReadbackInFlight = true;
 }

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -568,7 +568,7 @@ void ezEngineProcessDocumentContext::CreateThumbnailViewContext(const ezCreateTh
 
   // Create render target for picking
   ezGALTextureCreationDescription tcd;
-  tcd.m_TextureFlags = ezGALTextureUsageFlags::RenderTarget;
+  tcd.m_TextureFlags = ezGALTextureUsageFlags::RenderTarget | ezGALTextureUsageFlags::ShaderResource;
   tcd.m_Format = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
   tcd.m_Type = ezGALTextureType::Texture2D;
   tcd.m_uiWidth = m_uiThumbnailWidth;

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -87,6 +87,25 @@ ezStatus ezPickingRenderPass::AddRenderPasses(const ezViewData& viewData, const 
     pass.SetClearDepth().SetClearStencil();
     pass.HasSideEffects();
     ezClusteredDataGPU::AddReadDependencies(ref_graph, pass, viewData.m_uiSkyIrradianceIndex, viewData.m_CameraUsageHint);
+
+    DeclareRendererDependenciesForCategory(s_LitOpaqueWithoutSelection, ref_graph, pass);
+    DeclareRendererDependenciesForCategory(s_LitMaskedWithoutSelection, ref_graph, pass);
+    if (m_bPickTransparent)
+    {
+      DeclareRendererDependenciesForCategory(s_LitTransparentWithoutSelection, ref_graph, pass);
+      DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitForeground, ref_graph, pass);
+    }
+    if (m_bPickSelected)
+    {
+      DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::Selection, ref_graph, pass);
+    }
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::SimpleOpaque, ref_graph, pass);
+    if (m_bPickTransparent)
+    {
+      DeclareRendererDependenciesForCategory(s_SimpleTransparentWithoutSelection, ref_graph, pass);
+    }
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::SimpleForeground, ref_graph, pass);
+
     pass.SetExecuteCallback([this](const ezRenderGraphContext& ctx)
       {
         const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -252,7 +252,7 @@ void ezPickingRenderPass::CreateTarget()
 
   // Create render target for picking
   ezGALTextureCreationDescription tcd;
-  tcd.m_TextureFlags = ezGALTextureUsageFlags::RenderTarget;
+  tcd.m_TextureFlags = ezGALTextureUsageFlags::RenderTarget | ezGALTextureUsageFlags::ShaderResource;
   tcd.m_Format = ezGALResourceFormat::RGBAUByteNormalized;
   tcd.m_Type = ezGALTextureType::Texture2D;
   tcd.m_uiWidth = (ezUInt32)m_TargetRect.width;

--- a/Code/Engine/Foundation/Types/Delegate.h
+++ b/Code/Engine/Foundation/Types/Delegate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Foundation/Memory/Allocator.h>
+#include <Foundation/Memory/AllocatorWrapper.h>
 
 /// \brief Base class for ezDelegate
 class ezDelegateBase
@@ -81,7 +81,7 @@ protected:
 ///
 /// \note If you are wondering where the code is, the delegate is implemented with macro and template magic in
 /// Delegate_inl.h and DelegateHelper_inl.h.
-template <typename T, ezUInt32 DataSize = 16>
+template <typename T, ezUInt32 DataSize = 16, typename AllocatorWrapper = ezDefaultAllocatorWrapper>
 struct ezDelegate : public ezDelegateBase
 {
 };

--- a/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
@@ -72,11 +72,11 @@ public:
 };
 
 
-template <typename R, class... Args, ezUInt32 DataSize>
-struct ezDelegate<R(Args...), DataSize> : public ezDelegateBase
+template <typename R, class... Args, ezUInt32 DataSize, typename AllocatorWrapper>
+struct ezDelegate<R(Args...), DataSize, AllocatorWrapper> : public ezDelegateBase
 {
 private:
-  using SelfType = ezDelegate<R(Args...), DataSize>;
+  using SelfType = ezDelegate<R(Args...), DataSize, AllocatorWrapper>;
   constexpr const void* HeapLambda() const { return reinterpret_cast<const void*>((size_t)-1); }
   constexpr const void* InplaceLambda() const { return reinterpret_cast<const void*>((size_t)-2); }
 
@@ -112,7 +112,7 @@ public:
 
   /// \brief Constructs the delegate from a regular C function type.
   template <typename Function>
-  EZ_FORCE_INLINE ezDelegate(Function function, ezAllocator* pAllocator = ezFoundation::GetDefaultAllocator())
+  EZ_FORCE_INLINE ezDelegate(Function function, ezAllocator* pAllocator = AllocatorWrapper::GetAllocator())
   {
     static_assert(DataSize >= 16, "DataSize must be at least 16 bytes");
 

--- a/Code/Engine/GameEngine/GameApplication/Implementation/WindowOutputTargetGAL.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/WindowOutputTargetGAL.cpp
@@ -102,12 +102,13 @@ void ezWindowOutputTargetGAL::OnRenderEvent(const ezGALDeviceEvent& e)
 
   ezRenderGraphTextureHandle hTex = m_pRenderGraph->ImportTexture(hBackbuffer);
 
-  auto pass = m_pRenderGraph->AddTransferPass("CaptureImage");
-  pass.ReadTexture(hTex, {}, ezGALResourceState::CopySource);
-  pass.HasSideEffects();
-  pass.SetExecuteCallback([this, hTex](const ezRenderGraphContext& ctx)
-    { m_Readback.ReadbackTexture(*ctx.GetCommandEncoder(), ctx.ResolveTexture(hTex)); });
-
+  {
+    auto pass = m_pRenderGraph->AddTransferPass("CaptureImage");
+    pass.ReadTexture(hTex, {}, ezGALResourceState::CopySource);
+    pass.HasSideEffects();
+    pass.SetExecuteCallback([this, hTex](const ezRenderGraphContext& ctx)
+      { m_Readback.ReadbackTexture(*ctx.GetCommandEncoder(), ctx.ResolveTexture(hTex)); });
+  }
   ezRenderGraphManager::EnqueueRenderGraph(m_pRenderGraph);
   m_bCaptureInFlight = true;
 }

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
@@ -627,42 +627,42 @@ void ezDecalManager::OnRenderEvent(const ezRenderWorldRenderEvent& e)
   s_pData->m_pRenderGraph->Reset();
 
   ezRenderGraphTextureHandle hAtlas = s_pData->m_pRenderGraph->ImportTexture(s_pData->m_RuntimeAtlas.GetTexture());
-
-  auto pass = s_pData->m_pRenderGraph->AddGraphicsPass("Decal Atlas");
-  pass.AddColorTarget(hAtlas, {}, ezGALRenderTargetLoadOp::Load, ezGALRenderTargetStoreOp::Store);
-  pass.HasSideEffects();
-  pass.SetExecuteCallback(
-    [](const ezRenderGraphContext& ctx)
-    {
-      auto& decalsToUpdate = s_pData->m_DecalsToUpdate[ezRenderWorld::GetDataIndexForRendering()];
-      if (decalsToUpdate.IsEmpty())
-        return;
-
-      auto* pRenderContext = ctx.GetRenderContext();
-      auto* pCommandEncoder = ctx.GetCommandEncoder();
-
-      const bool bAllowAsyncShaderLoading = pRenderContext->GetAllowAsyncShaderLoading();
-      pRenderContext->SetAllowAsyncShaderLoading(false);
-      EZ_SCOPE_EXIT(pRenderContext->SetAllowAsyncShaderLoading(bAllowAsyncShaderLoading));
-
-      pRenderContext->BindMeshBuffer(s_pData->m_hPlaneMeshBuffer);
-
-      for (ezUInt32 i = 0; i < decalsToUpdate.GetCount(); ++i)
+  {
+    auto pass = s_pData->m_pRenderGraph->AddGraphicsPass("Decal Atlas");
+    pass.AddColorTarget(hAtlas, {}, ezGALRenderTargetLoadOp::Load, ezGALRenderTargetStoreOp::Store);
+    pass.HasSideEffects();
+    pass.SetExecuteCallback(
+      [](const ezRenderGraphContext& ctx)
       {
-        auto& updateInfo = decalsToUpdate[i];
-        ezRectFloat viewport = ezRectFloat(updateInfo.m_TargetRect.x, updateInfo.m_TargetRect.y, updateInfo.m_TargetRect.width, updateInfo.m_TargetRect.height);
+        auto& decalsToUpdate = s_pData->m_DecalsToUpdate[ezRenderWorld::GetDataIndexForRendering()];
+        if (decalsToUpdate.IsEmpty())
+          return;
 
-        pCommandEncoder->SetViewport(viewport);
+        auto* pRenderContext = ctx.GetRenderContext();
+        auto* pCommandEncoder = ctx.GetCommandEncoder();
 
-        pRenderContext->SetGlobalAndWorldTimeConstants(updateInfo.m_WorldTime);
-        pRenderContext->BindMaterial(updateInfo.m_hMaterial);
+        const bool bAllowAsyncShaderLoading = pRenderContext->GetAllowAsyncShaderLoading();
+        pRenderContext->SetAllowAsyncShaderLoading(false);
+        EZ_SCOPE_EXIT(pRenderContext->SetAllowAsyncShaderLoading(bAllowAsyncShaderLoading));
 
-        pRenderContext->DrawMeshBuffer().AssertSuccess();
-      }
+        pRenderContext->BindMeshBuffer(s_pData->m_hPlaneMeshBuffer);
 
-      decalsToUpdate.Clear();
-    });
+        for (ezUInt32 i = 0; i < decalsToUpdate.GetCount(); ++i)
+        {
+          auto& updateInfo = decalsToUpdate[i];
+          ezRectFloat viewport = ezRectFloat(updateInfo.m_TargetRect.x, updateInfo.m_TargetRect.y, updateInfo.m_TargetRect.width, updateInfo.m_TargetRect.height);
 
+          pCommandEncoder->SetViewport(viewport);
+
+          pRenderContext->SetGlobalAndWorldTimeConstants(updateInfo.m_WorldTime);
+          pRenderContext->BindMaterial(updateInfo.m_hMaterial);
+
+          pRenderContext->DrawMeshBuffer().AssertSuccess();
+        }
+
+        decalsToUpdate.Clear();
+      });
+  }
   ezRenderGraphManager::EnqueueRenderGraph(s_pData->m_pRenderGraph);
 }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -1009,21 +1009,22 @@ void ezShadowPool::OnRenderEvent(const ezRenderWorldRenderEvent& e)
 
     ezRenderGraphTextureHandle hShadowAtlas = s_pData->m_pRenderGraph->ImportTexture(s_pData->m_TextureAtlas.GetTexture());
 
-    auto pass = s_pData->m_pRenderGraph->AddGraphicsPass("Shadow Atlas");
-    pass.AddDepthStencilTarget(hShadowAtlas);
-    pass.SetClearDepth();
-    pass.HasSideEffects();
-    pass.SetExecuteCallback([](const ezRenderGraphContext& ctx)
-      {
-      ezUInt32 uiDataIndex = ezRenderWorld::GetDataIndexForRendering();
-      auto& packedShadowData = s_pData->m_PackedShadowData[uiDataIndex];
-      if (!packedShadowData.IsEmpty())
-      {
-        EZ_PROFILE_SCOPE("Shadow Data Buffer Update");
+    {
+      auto pass = s_pData->m_pRenderGraph->AddGraphicsPass("Shadow Atlas");
+      pass.AddDepthStencilTarget(hShadowAtlas);
+      pass.SetClearDepth();
+      pass.HasSideEffects();
+      pass.SetExecuteCallback([](const ezRenderGraphContext& ctx)
+        {
+        ezUInt32 uiDataIndex = ezRenderWorld::GetDataIndexForRendering();
+        auto& packedShadowData = s_pData->m_PackedShadowData[uiDataIndex];
+        if (!packedShadowData.IsEmpty())
+        {
+          EZ_PROFILE_SCOPE("Shadow Data Buffer Update");
 
-        ctx.GetCommandEncoder()->UpdateBuffer(s_pData->m_hShadowDataBuffer, 0, packedShadowData.GetByteArrayPtr(), ezGALUpdateMode::AheadOfTime);
-      } });
-
+          ctx.GetCommandEncoder()->UpdateBuffer(s_pData->m_hShadowDataBuffer, 0, packedShadowData.GetByteArrayPtr(), ezGALUpdateMode::AheadOfTime);
+        } });
+    }
     ezRenderGraphManager::EnqueueRenderGraph(s_pData->m_pRenderGraph);
   }
 }

--- a/Code/Engine/RendererCore/Pipeline/Declarations.h
+++ b/Code/Engine/RendererCore/Pipeline/Declarations.h
@@ -104,3 +104,25 @@ struct EZ_RENDERERCORE_DLL ezCameraUsageHint
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_RENDERERCORE_DLL, ezCameraUsageHint);
+
+/// Declares that a texture needs to be in a specific resource state when a render category is rendered.
+/// Recorded during extraction, applied during rendering to ensure correct barriers. m_uiCategory is the raw value of the ezRenderData::Category this dependency belongs to. View-level dependencies ignore the category value.
+struct ezTextureDependency
+{
+  EZ_DECLARE_POD_TYPE();
+  ezGALTextureHandle m_hTexture;
+  ezBitflags<ezGALResourceState> m_RequiredState;
+  ezBitflags<ezGALShaderStageFlags> m_Stage;
+  ezUInt16 m_uiCategory = 0xFFFF;
+};
+
+/// Declares that a buffer needs to be in a specific resource state when a render category is rendered.
+/// Recorded during extraction, applied during rendering to ensure correct barriers. m_uiCategory is the raw value of the ezRenderData::Category this dependency belongs to. View-level dependencies ignore the category value.
+struct ezBufferDependency
+{
+  EZ_DECLARE_POD_TYPE();
+  ezGALBufferHandle m_hBuffer;
+  ezBitflags<ezGALResourceState> m_RequiredState;
+  ezBitflags<ezGALShaderStageFlags> m_Stage;
+  ezUInt16 m_uiCategory = 0xFFFF;
+};

--- a/Code/Engine/RendererCore/Pipeline/ExtractedRenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/ExtractedRenderData.h
@@ -6,15 +6,6 @@
 #include <RendererCore/Pipeline/RenderDataBatch.h>
 #include <RendererCore/Pipeline/ViewData.h>
 
-/// Declares that a consumer view needs a texture in a specific resource state.
-/// Recorded during extraction, applied during rendering to ensure correct barriers.
-struct ezViewDependency
-{
-  ezGALTextureHandle m_hTexture;
-  ezBitflags<ezGALResourceState> m_RequiredState;
-  ezBitflags<ezGALShaderStageFlags> m_Stage;
-};
-
 /// Contains all render data extracted from a view for one frame.
 ///
 /// During the extraction phase, render components add their render data to this container,
@@ -43,15 +34,38 @@ public:
 
   EZ_ALWAYS_INLINE void AddViewDependency(ezGALTextureHandle hTexture, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto)
   {
-    auto& dep = m_ViewDependencies.ExpandAndGetRef();
+    auto& dep = m_ViewTextureDependencies.ExpandAndGetRef();
     dep.m_hTexture = hTexture;
     dep.m_RequiredState = requiredState;
     dep.m_Stage = stage;
   }
-  EZ_ALWAYS_INLINE ezArrayPtr<const ezViewDependency> GetViewDependencies() const { return m_ViewDependencies; }
+  EZ_ALWAYS_INLINE ezArrayPtr<const ezTextureDependency> GetTextureViewDependencies() const { return m_ViewTextureDependencies; }
+
+  EZ_ALWAYS_INLINE void AddViewDependency(ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto)
+  {
+    auto& dep = m_ViewBufferDependencies.ExpandAndGetRef();
+    dep.m_hBuffer = hBuffer;
+    dep.m_RequiredState = requiredState;
+    dep.m_Stage = stage;
+  }
+  EZ_ALWAYS_INLINE ezArrayPtr<const ezBufferDependency> GetBufferViewDependencies() const { return m_ViewBufferDependencies; }
 
   /// Adds render data for a specific rendering category.
   void AddRenderData(const ezRenderData* pRenderData, ezRenderData::Category category);
+
+  /// Adds a texture barrier dependency that applies when its category is rendered. The category is taken from the dependency itself.
+  /// Should not be called in user code, call ezMsgExtractRenderData::AddDependency instead during extraction of object or call AddViewDependency.
+  void AddDependency(const ezTextureDependency& dependency);
+
+  /// Adds a buffer barrier dependency that applies when its category is rendered. The category is taken from the dependency itself.
+  /// Should not be called in user code, call ezMsgExtractRenderData::AddDependency instead during extraction of object or call AddViewDependency.
+  void AddDependency(const ezBufferDependency& dependency);
+
+  /// Returns the texture barrier dependencies recorded for a specific category.
+  ezArrayPtr<const ezTextureDependency> GetTextureDependenciesWithCategory(ezRenderData::Category category) const;
+
+  /// Returns the buffer barrier dependencies recorded for a specific category.
+  ezArrayPtr<const ezBufferDependency> GetBufferDependenciesWithCategory(ezRenderData::Category category) const;
 
   /// Adds frame-level data that is not tied to a specific render category.
   void AddFrameData(const ezRenderData* pFrameData);
@@ -80,9 +94,10 @@ private:
   {
     ezDynamicArray<ezRenderDataBatch> m_Batches;
     ezDynamicArray<ezRenderDataBatch::SortableRenderData> m_SortableRenderData;
-
     ezDynamicArray<ezInstanceableRenderData::DataOffsets> m_DataOffsets;
     ezGALBufferHandle m_hDataOffsetsBuffer;
+    ezDynamicArray<ezTextureDependency> m_TextureDependencies;
+    ezDynamicArray<ezBufferDependency> m_BufferDependencies;
   };
 
   void SortAndBatchCategory(DataPerCategory& dataPerCategory, ezRenderData::Category category);
@@ -96,5 +111,6 @@ private:
 
   ezHybridArray<DataPerCategory, 32> m_DataPerCategory;
   ezHybridArray<const ezRenderData*, 16> m_FrameData;
-  ezHybridArray<ezViewDependency, 4> m_ViewDependencies;
+  ezHybridArray<ezTextureDependency, 4> m_ViewTextureDependencies;
+  ezHybridArray<ezBufferDependency, 4> m_ViewBufferDependencies;
 };

--- a/Code/Engine/RendererCore/Pipeline/Implementation/ExtractedRenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/ExtractedRenderData.cpp
@@ -31,6 +31,20 @@ void ezExtractedRenderData::AddFrameData(const ezRenderData* pFrameData)
   m_FrameData.PushBack(pFrameData);
 }
 
+void ezExtractedRenderData::AddDependency(const ezTextureDependency& dependency)
+{
+  EZ_ASSERT_DEBUG(dependency.m_uiCategory != ezInvalidRenderDataCategory.m_uiValue, "Per-category texture dependencies require a valid render data category. Use AddViewDependency for view-level dependencies.");
+  m_DataPerCategory.EnsureCount(dependency.m_uiCategory + 1);
+  m_DataPerCategory[dependency.m_uiCategory].m_TextureDependencies.PushBack(dependency);
+}
+
+void ezExtractedRenderData::AddDependency(const ezBufferDependency& dependency)
+{
+  EZ_ASSERT_DEBUG(dependency.m_uiCategory != ezInvalidRenderDataCategory.m_uiValue, "Per-category buffer dependencies require a valid render data category. Use AddViewDependency for view-level dependencies.");
+  m_DataPerCategory.EnsureCount(dependency.m_uiCategory + 1);
+  m_DataPerCategory[dependency.m_uiCategory].m_BufferDependencies.PushBack(dependency);
+}
+
 void ezExtractedRenderData::SortAndBatch()
 {
   EZ_PROFILE_SCOPE("ezExtractedRenderData::SortAndBatch");
@@ -52,10 +66,13 @@ void ezExtractedRenderData::Clear()
     dataPerCategory.m_Batches.Clear();
     dataPerCategory.m_SortableRenderData.Clear();
     dataPerCategory.m_DataOffsets.Clear();
+    dataPerCategory.m_TextureDependencies.Clear();
+    dataPerCategory.m_BufferDependencies.Clear();
   }
 
   m_FrameData.Clear();
-  m_ViewDependencies.Clear();
+  m_ViewTextureDependencies.Clear();
+  m_ViewBufferDependencies.Clear();
 }
 
 ezRenderDataBatchList ezExtractedRenderData::GetRenderDataBatchesWithCategory(ezRenderData::Category category) const
@@ -76,6 +93,26 @@ ezArrayPtr<const ezRenderDataBatch::SortableRenderData> ezExtractedRenderData::G
   if (category.m_uiValue < m_DataPerCategory.GetCount())
   {
     return m_DataPerCategory[category.m_uiValue].m_SortableRenderData;
+  }
+
+  return {};
+}
+
+ezArrayPtr<const ezTextureDependency> ezExtractedRenderData::GetTextureDependenciesWithCategory(ezRenderData::Category category) const
+{
+  if (category.m_uiValue < m_DataPerCategory.GetCount())
+  {
+    return m_DataPerCategory[category.m_uiValue].m_TextureDependencies;
+  }
+
+  return {};
+}
+
+ezArrayPtr<const ezBufferDependency> ezExtractedRenderData::GetBufferDependenciesWithCategory(ezRenderData::Category category) const
+{
+  if (category.m_uiValue < m_DataPerCategory.GetCount())
+  {
+    return m_DataPerCategory[category.m_uiValue].m_BufferDependencies;
   }
 
   return {};

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -165,11 +165,51 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
 #endif
   };
 
+  // Forwards the barrier dependencies recorded on the message into the extracted render data. The stored category is the (possibly redirected) category passed to msg.AddDependency; it is resolved here to the static/dynamic variant the same way render data categories are resolved, so dependencies land in the same category as the render data they accompany.
+  auto AddDependenciesFromMessage = [&](bool bDynamic) {
+    for (ezTextureDependency dep : msg.m_TextureDependencies)
+    {
+      dep.m_uiCategory = (msg.m_OverrideCategory != ezInvalidRenderDataCategory)
+                           ? msg.m_OverrideCategory.m_uiValue
+                           : ezRenderData::ResolveCategory(ezRenderData::Category(dep.m_uiCategory), bDynamic).m_uiValue;
+      extractedRenderData.AddDependency(dep);
+    }
+
+    for (ezBufferDependency dep : msg.m_BufferDependencies)
+    {
+      dep.m_uiCategory = (msg.m_OverrideCategory != ezInvalidRenderDataCategory)
+                           ? msg.m_OverrideCategory.m_uiValue
+                           : ezRenderData::ResolveCategory(ezRenderData::Category(dep.m_uiCategory), bDynamic).m_uiValue;
+      extractedRenderData.AddDependency(dep);
+    }
+  };
+
   if (pObject->IsStatic())
   {
     ezUInt16 uiComponentVersion = pObject->GetComponentVersion();
 
     auto cachedRenderData = ezRenderWorld::GetCachedRenderData(view, pObject->GetHandle(), uiComponentVersion);
+
+    // Apply per-object cached dependencies once. On cache-hit frames SendMessage is skipped for the owning components, so their dependencies must come from the cache here. On the frame the data is cached the dependencies are also applied through AddDependenciesFromMessage, but the per-object cache is still empty at that point, so there is no duplication.
+    {
+      ezArrayPtr<const ezTextureDependency> cachedTextureDependencies;
+      ezArrayPtr<const ezBufferDependency> cachedBufferDependencies;
+      ezRenderWorld::GetCachedDependencies(view, pObject->GetHandle(), uiComponentVersion, cachedTextureDependencies, cachedBufferDependencies);
+
+      for (ezTextureDependency dep : cachedTextureDependencies)
+      {
+        if (msg.m_OverrideCategory != ezInvalidRenderDataCategory)
+          dep.m_uiCategory = msg.m_OverrideCategory.m_uiValue;
+        extractedRenderData.AddDependency(dep);
+      }
+
+      for (ezBufferDependency dep : cachedBufferDependencies)
+      {
+        if (msg.m_OverrideCategory != ezInvalidRenderDataCategory)
+          dep.m_uiCategory = msg.m_OverrideCategory.m_uiValue;
+        extractedRenderData.AddDependency(dep);
+      }
+    }
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
     for (ezUInt32 i = 1; i < cachedRenderData.GetCount(); ++i)
@@ -213,6 +253,8 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
       const ezComponent* pComponent = components[uiComponentIndex];
 
       msg.m_ExtractedRenderData.Clear();
+      msg.m_TextureDependencies.Clear();
+      msg.m_BufferDependencies.Clear();
       msg.m_uiNumCacheIfStatic = 0;
 
       if (pComponent->SendMessage(msg))
@@ -231,10 +273,22 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
             newCacheEntry.m_uiPartIndex = static_cast<ezUInt16>(uiPartIndex);
           }
 
-          ezRenderWorld::CacheRenderData(view, pObject->GetHandle(), pComponent->GetHandle(), uiComponentVersion, newCacheEntries);
+          // Cache the dependencies with their resolved (static) category, matching how render data categories are cached without the override applied. The override is re-applied on read.
+          for (ezTextureDependency& dep : msg.m_TextureDependencies)
+          {
+            dep.m_uiCategory = ezRenderData::ResolveCategory(ezRenderData::Category(dep.m_uiCategory), false).m_uiValue;
+          }
+
+          for (ezBufferDependency& dep : msg.m_BufferDependencies)
+          {
+            dep.m_uiCategory = ezRenderData::ResolveCategory(ezRenderData::Category(dep.m_uiCategory), false).m_uiValue;
+          }
+
+          ezRenderWorld::CacheRenderData(view, pObject->GetHandle(), pComponent->GetHandle(), uiComponentVersion, newCacheEntries, msg.m_TextureDependencies, msg.m_BufferDependencies);
         }
 
         AddRenderDataFromMessage(msg);
+        AddDependenciesFromMessage(false);
       }
       else if (pComponent->IsActiveAndInitialized()) // component does not handle extract message at all
       {
@@ -253,9 +307,12 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
   else
   {
     msg.m_ExtractedRenderData.Clear();
+    msg.m_TextureDependencies.Clear();
+    msg.m_BufferDependencies.Clear();
     pObject->SendMessage(msg);
 
     AddRenderDataFromMessage(msg);
+    AddDependenciesFromMessage(true);
   }
 }
 
@@ -293,7 +350,7 @@ void ezVisibleObjectsExtractor::Extract(const ezView& view, const ezDynamicArray
 {
   ezMsgExtractRenderData msg;
   msg.m_pView = &view;
-  
+
   EZ_LOCK(view.GetWorld()->GetReadMarker());
   msg.m_pRenderDataManager = view.GetWorld()->GetModuleReadOnly<ezRenderDataManager>();
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -166,7 +166,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
   };
 
   // Forwards the barrier dependencies recorded on the message into the extracted render data. The stored category is the (possibly redirected) category passed to msg.AddDependency; it is resolved here to the static/dynamic variant the same way render data categories are resolved, so dependencies land in the same category as the render data they accompany.
-  auto AddDependenciesFromMessage = [&](bool bDynamic) {
+  auto AddDependenciesFromMessage = [&](const ezMsgExtractRenderData& msg, bool bDynamic) {
     for (ezTextureDependency dep : msg.m_TextureDependencies)
     {
       dep.m_uiCategory = (msg.m_OverrideCategory != ezInvalidRenderDataCategory)
@@ -288,7 +288,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
         }
 
         AddRenderDataFromMessage(msg);
-        AddDependenciesFromMessage(false);
+        AddDependenciesFromMessage(msg, false);
       }
       else if (pComponent->IsActiveAndInitialized()) // component does not handle extract message at all
       {
@@ -312,7 +312,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
     pObject->SendMessage(msg);
 
     AddRenderDataFromMessage(msg);
-    AddDependenciesFromMessage(true);
+    AddDependenciesFromMessage(msg, true);
   }
 }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -188,14 +188,12 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
   {
     ezUInt16 uiComponentVersion = pObject->GetComponentVersion();
 
-    auto cachedRenderData = ezRenderWorld::GetCachedRenderData(view, pObject->GetHandle(), uiComponentVersion);
+    ezArrayPtr<const ezTextureDependency> cachedTextureDependencies;
+    ezArrayPtr<const ezBufferDependency> cachedBufferDependencies;
+    auto cachedRenderData = ezRenderWorld::GetCachedRenderData(view, pObject->GetHandle(), uiComponentVersion, cachedTextureDependencies, cachedBufferDependencies);
 
     // Apply per-object cached dependencies once. On cache-hit frames SendMessage is skipped for the owning components, so their dependencies must come from the cache here. On the frame the data is cached the dependencies are also applied through AddDependenciesFromMessage, but the per-object cache is still empty at that point, so there is no duplication.
     {
-      ezArrayPtr<const ezTextureDependency> cachedTextureDependencies;
-      ezArrayPtr<const ezBufferDependency> cachedBufferDependencies;
-      ezRenderWorld::GetCachedDependencies(view, pObject->GetHandle(), uiComponentVersion, cachedTextureDependencies, cachedBufferDependencies);
-
       for (ezTextureDependency dep : cachedTextureDependencies)
       {
         if (msg.m_OverrideCategory != ezInvalidRenderDataCategory)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/CustomRenderDataPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/CustomRenderDataPass.cpp
@@ -50,6 +50,8 @@ ezStatus ezCustomRenderDataPass::AddRenderPasses(const ezViewData& viewData, con
   if (!hDepthStencil.IsInvalidated())
     pass.AddDepthStencilTarget(hDepthStencil);
   pass.SetStereoscopic(camera.IsStereoscopic());
+  if (m_RenderDataCategory.IsValid())
+    DeclareRendererDependenciesForCategory(m_RenderDataCategory, ref_graph, pass);
   pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
     {
     const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
@@ -48,6 +48,20 @@ ezStatus ezDepthOnlyPass::AddRenderPasses(const ezViewData& viewData, const ezCa
   auto pass = ref_graph.AddGraphicsPass(GetName());
   pass.AddDepthStencilTarget(hDepthStencil);
   pass.SetStereoscopic(camera.IsStereoscopic());
+  if (m_bRenderStaticObjects)
+  {
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitOpaqueStatic, ref_graph, pass);
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitMaskedStatic, ref_graph, pass);
+  }
+  if (m_bRenderDynamicObjects)
+  {
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitOpaqueDynamic, ref_graph, pass);
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitMaskedDynamic, ref_graph, pass);
+  }
+  if (m_bRenderTransparentObjects)
+  {
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitTransparent, ref_graph, pass);
+  }
   pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
     {
     const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ForwardRenderPass.cpp
@@ -57,6 +57,7 @@ ezStatus ezForwardRenderPass::AddRenderPasses(const ezViewData& viewData, const 
   pass.AddDepthStencilTarget(hDepthStencil);
   pass.SetStereoscopic(camera.IsStereoscopic());
   ezRenderPipelinePass::SetupResourceDependencies(viewData, ref_graph, pass, m_ShadingQuality);
+  DeclareRenderObjectDependencies(ref_graph, pass);
   pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
     {
     const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LensEffectsPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LensEffectsPass.cpp
@@ -49,6 +49,7 @@ ezStatus ezLensEffectsPass::AddRenderPasses(const ezViewData& viewData, const ez
     pass.ReadTexture(hResolvedDepth, {}, ezGALResourceState::ShaderResource);
   pass.SetStereoscopic(camera.IsStereoscopic());
   SetupResourceDependencies(viewData, ref_graph, pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LensEffects, ref_graph, pass);
   pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
     {
     const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/OpaqueForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/OpaqueForwardRenderPass.cpp
@@ -80,6 +80,7 @@ ezStatus ezOpaqueForwardRenderPass::AddRenderPasses(const ezViewData& viewData, 
     pass.ReadTexture(hShadowMask, {}, ezGALResourceState::ShaderResource, ezGALShaderStageFlags::PixelShader);
   pass.SetStereoscopic(camera.IsStereoscopic());
   ezRenderPipelinePass::SetupResourceDependencies(viewData, ref_graph, pass, m_ShadingQuality);
+  DeclareRenderObjectDependencies(ref_graph, pass);
   pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
     {
       const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();
@@ -127,6 +128,14 @@ void ezOpaqueForwardRenderPass::SetupPermutationVars(const ezRenderViewContext& 
   {
     renderViewContext.m_pRenderContext->SetShaderPermutationVariable("FORWARD_PASS_WRITE_DEPTH", "FALSE");
   }
+}
+
+void ezOpaqueForwardRenderPass::DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass)
+{
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitOpaqueStatic, ref_graph, ref_pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitOpaqueDynamic, ref_graph, ref_pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitMaskedStatic, ref_graph, ref_pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitMaskedDynamic, ref_graph, ref_pass);
 }
 
 void ezOpaqueForwardRenderPass::RenderObjects(const ezRenderViewContext& renderViewContext)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SelectionHighlightPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SelectionHighlightPass.cpp
@@ -74,6 +74,7 @@ ezStatus ezSelectionHighlightPass::AddRenderPasses(const ezViewData& viewData, c
     pass.SetClearDepth();
     pass.SetClearStencil();
     pass.SetStereoscopic(camera.IsStereoscopic());
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::Selection, ref_graph, pass);
     pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
       {
       const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SimpleRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SimpleRenderPass.cpp
@@ -76,6 +76,12 @@ ezStatus ezSimpleRenderPass::AddRenderPasses(const ezViewData& viewData, const e
   if (!hDepthStencil.IsInvalidated())
     pass.AddDepthStencilTarget(hDepthStencil);
   pass.SetStereoscopic(camera.IsStereoscopic());
+
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::SimpleOpaque, ref_graph, pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::SimpleTransparent, ref_graph, pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::SimpleForeground, ref_graph, pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::GUI, ref_graph, pass);
+
   pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
     {
     const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SkyRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SkyRenderPass.cpp
@@ -12,6 +12,11 @@ ezSkyRenderPass::ezSkyRenderPass(const char* szName)
 
 ezSkyRenderPass::~ezSkyRenderPass() = default;
 
+void ezSkyRenderPass::DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass)
+{
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::Sky, ref_graph, ref_pass);
+}
+
 void ezSkyRenderPass::RenderObjects(const ezRenderViewContext& renderViewContext)
 {
   RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::Sky);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TargetPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TargetPass.cpp
@@ -42,7 +42,7 @@ ezStatus ezTargetPass::AddRenderPasses(const ezViewData& viewData, const ezCamer
   m_hSwapChain = viewData.m_hSwapChain;
   m_RenderTargets = viewData.m_RenderTargets;
 
-  const char* pinNames[] = {
+  ezTempHashedString pinNames[] = {
     "Color0",
     "Color1",
     "Color2",
@@ -87,11 +87,11 @@ ezGALTextureHandle ezTargetPass::QueryTextureProvider(const ezRenderPipelineNode
   }
 }
 
-ezStatus ezTargetPass::VerifyInput(ezRenderGraph& graph, const ezArrayPtr<const ezRenderPipelinePinConnection> inputs, const char* szPinName)
+ezStatus ezTargetPass::VerifyInput(ezRenderGraph& graph, const ezArrayPtr<const ezRenderPipelinePinConnection> inputs, ezTempHashedString sPinName)
 {
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
-  const ezRenderPipelineNodePin* pPin = GetPinByName(szPinName);
+  const ezRenderPipelineNodePin* pPin = GetPinByName(sPinName);
   if (inputs[pPin->m_uiInputIndex].m_Connectivity == ezRenderPipelinePinConnection::Connectivity::Texture)
   {
     const ezGALTextureCreationDescription& desc = graph.GetTextureDesc(inputs[pPin->m_uiInputIndex].m_TextureHandle);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
@@ -64,6 +64,7 @@ ezStatus ezTransparentForwardRenderPass::AddRenderPasses(const ezViewData& viewD
     pass.SetStereoscopic(camera.IsStereoscopic());
     // BEGIN-DOCS-CODE-SNIPPET: renderpass-render-objects
     ezRenderPipelinePass::SetupResourceDependencies(viewData, ref_graph, pass, m_ShadingQuality);
+    DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitMeshDecal, ref_graph, pass);
     pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
       {
         const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();
@@ -102,6 +103,7 @@ ezStatus ezTransparentForwardRenderPass::AddRenderPasses(const ezViewData& viewD
       pass.ReadTexture(hResolvedDepth, {}, ezGALResourceState::ShaderResource);
     pass.SetStereoscopic(camera.IsStereoscopic());
     ezRenderPipelinePass::SetupResourceDependencies(viewData, ref_graph, pass, m_ShadingQuality);
+    DeclareRenderObjectDependencies(ref_graph, pass);
     pass.SetExecuteCallback([=](const ezRenderGraphContext& ctx)
       {
       const ezRenderViewContext& renderViewContext = *ctx.GetUserData<ezRenderViewContext>();
@@ -124,6 +126,12 @@ ezStatus ezTransparentForwardRenderPass::AddRenderPasses(const ezViewData& viewD
   }
 
   return EZ_SUCCESS;
+}
+
+void ezTransparentForwardRenderPass::DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass)
+{
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitTransparent, ref_graph, ref_pass);
+  DeclareRendererDependenciesForCategory(ezDefaultRenderDataCategories::LitForeground, ref_graph, ref_pass);
 }
 
 void ezTransparentForwardRenderPass::RenderObjects(const ezRenderViewContext& renderViewContext)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -171,4 +171,28 @@ void ezMsgExtractRenderData::AddRenderData(const ezRenderData* pRenderData, ezRe
   }
 }
 
+void ezMsgExtractRenderData::AddDependency(ezGALTextureHandle hTexture, ezRenderData::Category category, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage)
+{
+  EZ_ASSERT_DEBUG(requiredState != ezGALResourceState::Unknown, "The required state must be valid");
+  if (hTexture.IsInvalidated())
+    return;
+  auto& dep = m_TextureDependencies.ExpandAndGetRef();
+  dep.m_hTexture = hTexture;
+  dep.m_RequiredState = requiredState;
+  dep.m_Stage = stage;
+  dep.m_uiCategory = category.m_uiValue;
+}
+
+void ezMsgExtractRenderData::AddDependency(ezGALBufferHandle hBuffer, ezRenderData::Category category, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage)
+{
+  EZ_ASSERT_DEBUG(requiredState != ezGALResourceState::Unknown, "The required state must be valid");
+  if (hBuffer.IsInvalidated())
+    return;
+  auto& dep = m_BufferDependencies.ExpandAndGetRef();
+  dep.m_hBuffer = hBuffer;
+  dep.m_RequiredState = requiredState;
+  dep.m_Stage = stage;
+  dep.m_uiCategory = category.m_uiValue;
+}
+
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Pipeline_Implementation_RenderData);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -69,6 +69,16 @@ void ezRenderPipeline::OnRenderEvent(const ezRenderGraphRenderEvent& e)
   }
   else if (e.m_Type == ezRenderGraphRenderEvent::Type::AfterGraphExecution && e.m_pGraph == m_pRenderGraph)
   {
+    {
+      ezRenderWorldRenderEvent renderEvent;
+      renderEvent.m_Type = ezRenderWorldRenderEvent::Type::AfterPipelineExecution;
+      renderEvent.m_pRenderViewContext = &m_RenderViewContext;
+      renderEvent.m_uiFrameCounter = ezRenderWorld::GetFrameCounter();
+
+      EZ_PROFILE_SCOPE("AfterPipelineExecution");
+      ezRenderWorld::s_RenderEvent.Broadcast(renderEvent);
+    }
+
     auto& data = m_Data[ezRenderWorld::GetDataIndexForRendering()];
     data.Clear();
     m_CurrentRenderThread = (ezThreadID)0;
@@ -1121,6 +1131,16 @@ void ezRenderPipeline::UpdateRenderContext(ezRenderGraphContext& ctx)
   for (auto& var : m_PermutationVars)
   {
     pRenderContext->SetShaderPermutationVariable(var.m_sName, var.m_sValue);
+  }
+
+  {
+    ezRenderWorldRenderEvent renderEvent;
+    renderEvent.m_Type = ezRenderWorldRenderEvent::Type::BeforePipelineExecution;
+    renderEvent.m_pRenderViewContext = &m_RenderViewContext;
+    renderEvent.m_uiFrameCounter = ezRenderWorld::GetFrameCounter();
+
+    EZ_PROFILE_SCOPE("BeforePipelineExecution");
+    ezRenderWorld::s_RenderEvent.Broadcast(renderEvent);
   }
 }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -566,7 +566,8 @@ bool ezRenderPipeline::AddRenderPasses(const ezViewData& viewData, const ezCamer
 
 bool ezRenderPipeline::UpdateTextureProviders()
 {
-  ezMap<ezRenderGraphTextureHandle, const ezRenderPipelineNodePin*> updates;
+  ezHashTable<ezRenderGraphTextureHandle, const ezRenderPipelineNodePin*, ezHashHelper<ezRenderGraphTextureHandle>, ezTempAllocatorWrapper> updates;
+  updates.Reserve(m_TextureProviderPins.GetCount());
   for (const ezRenderPipelineNodePin* pPin : m_TextureProviderPins)
   {
     const ezRenderPipelinePass* pPass = static_cast<const ezRenderPipelinePass*>(pPin->m_pParent);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1049,9 +1049,15 @@ void ezRenderPipeline::EnqueueRenderGraph(ezRenderContext* pRenderContext)
   }
 
   // Apply view dependencies: import shared textures with the required initial state.
-  for (const ezViewDependency& dep : data.GetViewDependencies())
+  for (const ezTextureDependency& dep : data.GetTextureViewDependencies())
   {
     m_pRenderGraph->ImportTexture(dep.m_hTexture, dep.m_RequiredState, dep.m_Stage);
+  }
+
+  // Apply view dependencies: import shared buffers with the required initial state.
+  for (const ezBufferDependency& dep : data.GetBufferViewDependencies())
+  {
+    m_pRenderGraph->ImportBuffer(dep.m_hBuffer, dep.m_RequiredState, dep.m_Stage);
   }
 
   EZ_ASSERT_DEV(m_CurrentRenderThread == (ezThreadID)0, "Render must not be called from multiple threads.");
@@ -1154,10 +1160,27 @@ void ezRenderPipeline::AddViewDependency(ezGALTextureHandle hTexture, ezBitflags
   m_Data[ezRenderWorld::GetDataIndexForExtraction()].AddViewDependency(hTexture, requiredState, stage);
 }
 
+void ezRenderPipeline::AddViewDependency(ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage)
+{
+  m_Data[ezRenderWorld::GetDataIndexForExtraction()].AddViewDependency(hBuffer, requiredState, stage);
+}
+
 ezRenderDataBatchList ezRenderPipeline::GetRenderDataBatchesWithCategory(ezRenderData::Category category) const
 {
   auto& data = m_Data[ezRenderWorld::GetDataIndexForRendering()];
   return data.GetRenderDataBatchesWithCategory(category);
+}
+
+ezArrayPtr<const ezTextureDependency> ezRenderPipeline::GetTextureDependenciesWithCategory(ezRenderData::Category category) const
+{
+  auto& data = m_Data[ezRenderWorld::GetDataIndexForRendering()];
+  return data.GetTextureDependenciesWithCategory(category);
+}
+
+ezArrayPtr<const ezBufferDependency> ezRenderPipeline::GetBufferDependenciesWithCategory(ezRenderData::Category category) const
+{
+  auto& data = m_Data[ezRenderWorld::GetDataIndexForRendering()];
+  return data.GetBufferDependenciesWithCategory(category);
 }
 
 ezUInt32 ezRenderPipeline::AddRenderDataProcessor(RenderDataProcessor processor)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelineNode.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelineNode.cpp
@@ -91,14 +91,7 @@ ezHashedString ezRenderPipelineNode::GetPinName(const ezRenderPipelineNodePin* p
   return ezHashedString();
 }
 
-const ezRenderPipelineNodePin* ezRenderPipelineNode::GetPinByName(const char* szName) const
-{
-  ezHashedString sHashedName;
-  sHashedName.Assign(szName);
-  return GetPinByName(sHashedName);
-}
-
-const ezRenderPipelineNodePin* ezRenderPipelineNode::GetPinByName(ezHashedString sName) const
+const ezRenderPipelineNodePin* ezRenderPipelineNode::GetPinByName(ezTempHashedString sName) const
 {
   const ezRenderPipelineNodePin* pin;
   if (m_NameToPin.TryGetValue(sName, pin))

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelinePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelinePass.cpp
@@ -72,6 +72,19 @@ ezResult ezRenderPipelinePass::Deserialize(ezStreamReader& inout_stream)
   return EZ_SUCCESS;
 }
 
+void ezRenderPipelinePass::DeclareRendererDependenciesForCategory(ezRenderData::Category category, ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_passBuilder)
+{
+  for (const ezTextureDependency& dep : m_pPipeline->GetTextureDependenciesWithCategory(category))
+  {
+    ref_passBuilder.ReadTexture(ref_graph.ImportTexture(dep.m_hTexture), {}, dep.m_RequiredState, dep.m_Stage);
+  }
+
+  for (const ezBufferDependency& dep : m_pPipeline->GetBufferDependenciesWithCategory(category))
+  {
+    ref_passBuilder.ReadBuffer(ref_graph.ImportBuffer(dep.m_hBuffer), dep.m_RequiredState, dep.m_Stage);
+  }
+}
+
 void ezRenderPipelinePass::RenderDataWithCategory(const ezRenderViewContext& renderViewContext, ezRenderData::Category category)
 {
   EZ_PROFILE_AND_MARKER(renderViewContext.m_pRenderContext->GetCommandEncoder(), ezRenderData::GetCategoryName(category));

--- a/Code/Engine/RendererCore/Pipeline/Passes/ForwardRenderPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/ForwardRenderPass.h
@@ -27,6 +27,11 @@ protected:
   /// Configures shader permutation variables based on render settings.
   virtual void SetupPermutationVars(const ezRenderViewContext& renderViewContext);
 
+  /// Declares the renderer dependencies for the render data categories that RenderObjects will render.
+  ///
+  /// Must declare the same set of categories that RenderObjects passes to RenderDataWithCategory.
+  virtual void DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass) = 0;
+
   /// Renders the objects for this pass. Must be implemented by derived classes.
   virtual void RenderObjects(const ezRenderViewContext& renderViewContext) = 0;
 

--- a/Code/Engine/RendererCore/Pipeline/Passes/OpaqueForwardRenderPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/OpaqueForwardRenderPass.h
@@ -19,6 +19,8 @@ public:
 protected:
   virtual void SetupPermutationVars(const ezRenderViewContext& renderViewContext) override;
 
+  virtual void DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass) override;
+
   virtual void RenderObjects(const ezRenderViewContext& renderViewContext) override;
 
   ezRenderPipelineNodeInputPin m_PinSSAO;        ///< Optional SSAO input for ambient occlusion.

--- a/Code/Engine/RendererCore/Pipeline/Passes/SkyRenderPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/SkyRenderPass.h
@@ -15,5 +15,6 @@ public:
   ~ezSkyRenderPass();
 
 protected:
+  virtual void DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass) override;
   virtual void RenderObjects(const ezRenderViewContext& renderViewContext) override;
 };

--- a/Code/Engine/RendererCore/Pipeline/Passes/TargetPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/TargetPass.h
@@ -25,7 +25,7 @@ public:
 
 private:
   /// Validates that an input pin's texture matches expected dimensions and format.
-  ezStatus VerifyInput(ezRenderGraph& graph, const ezArrayPtr<const ezRenderPipelinePinConnection> inputs, const char* szPinName);
+  ezStatus VerifyInput(ezRenderGraph& graph, const ezArrayPtr<const ezRenderPipelinePinConnection> inputs, ezTempHashedString sPinName);
 
 protected:
   ezRenderPipelineNodeInputProviderPin m_PinColor0;       ///< Color target 0 input.

--- a/Code/Engine/RendererCore/Pipeline/Passes/TransparentForwardRenderPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/TransparentForwardRenderPass.h
@@ -16,6 +16,7 @@ public:
   virtual ezStatus AddRenderPasses(const ezViewData& viewData, const ezCamera& camera, ezRenderGraph& ref_graph, const ezArrayPtr<const ezRenderPipelinePinConnection> inputs, ezArrayPtr<ezRenderPipelinePinConnection> outputs) override;
 
 protected:
+  virtual void DeclareRenderObjectDependencies(ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_pass) override;
   virtual void RenderObjects(const ezRenderViewContext& renderViewContext) override;
 
   void CreateSamplerState();

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -175,6 +175,7 @@ struct EZ_RENDERERCORE_DLL ezMsgExtractRenderData : public ezMessage
   /// Like render data, dependencies are cached for static objects when the component's render data is cached.
   /// /// \sa ezRenderPipelinePass::DeclareRendererDependenciesForCategory
   void AddDependency(ezGALBufferHandle hBuffer, ezRenderData::Category category, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
+
 private:
   friend class ezExtractor;
 

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -186,8 +186,8 @@ private:
   };
 
   ezHybridArray<Data, 16> m_ExtractedRenderData;
-  ezHybridArray<ezTextureDependency, 4> m_TextureDependencies;
-  ezHybridArray<ezBufferDependency, 4> m_BufferDependencies;
+  ezSmallArray<ezTextureDependency, 4> m_TextureDependencies;
+  ezSmallArray<ezBufferDependency, 4> m_BufferDependencies;
 
   ezUInt32 m_uiNumCacheIfStatic = 0;
 };

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -166,6 +166,15 @@ struct EZ_RENDERERCORE_DLL ezMsgExtractRenderData : public ezMessage
   /// function.
   void AddRenderData(const ezRenderData* pRenderData, ezRenderData::Category category, ezRenderData::Caching::Enum cachingBehavior);
 
+  /// \brief Records that the given texture must be in `requiredState` when `category` is rendered. Invalid handles are ignored so safe to pass in without checking.
+  /// Like render data, dependencies are cached for static objects when the component's render data is cached.
+  /// \sa ezRenderPipelinePass::DeclareRendererDependenciesForCategory
+  void AddDependency(ezGALTextureHandle hTexture, ezRenderData::Category category, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
+
+  /// \brief Records that the given buffer must be in `requiredState` when `category` is rendered. Invalid handles are ignored so safe to pass in without checking.
+  /// Like render data, dependencies are cached for static objects when the component's render data is cached.
+  /// /// \sa ezRenderPipelinePass::DeclareRendererDependenciesForCategory
+  void AddDependency(ezGALBufferHandle hBuffer, ezRenderData::Category category, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
 private:
   friend class ezExtractor;
 
@@ -176,6 +185,9 @@ private:
   };
 
   ezHybridArray<Data, 16> m_ExtractedRenderData;
+  ezHybridArray<ezTextureDependency, 4> m_TextureDependencies;
+  ezHybridArray<ezBufferDependency, 4> m_BufferDependencies;
+
   ezUInt32 m_uiNumCacheIfStatic = 0;
 };
 

--- a/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
@@ -65,9 +65,19 @@ public:
   const ezExtractedRenderData& GetRenderData() const;
   ezRenderDataBatchList GetRenderDataBatchesWithCategory(ezRenderData::Category category) const;
 
+  /// Returns the texture barrier dependencies recorded during extraction for a specific category.
+  ezArrayPtr<const ezTextureDependency> GetTextureDependenciesWithCategory(ezRenderData::Category category) const;
+
+  /// Returns the buffer barrier dependencies recorded during extraction for a specific category.
+  ezArrayPtr<const ezBufferDependency> GetBufferDependenciesWithCategory(ezRenderData::Category category) const;
+
   /// Adds a texture dependency to the current extraction frame's data.
   /// Must only be called during extraction.
   void AddViewDependency(ezGALTextureHandle hTexture, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
+
+  /// Adds a buffer dependency to the current extraction frame's data.
+  /// Must only be called during extraction.
+  void AddViewDependency(ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
 
   using RenderDataProcessor = ezDelegate<void(ezExtractedRenderData&)>;
   ezUInt32 AddRenderDataProcessor(RenderDataProcessor processor);

--- a/Code/Engine/RendererCore/Pipeline/RenderPipelineNode.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipelineNode.h
@@ -98,8 +98,7 @@ public:
   void InitializePins();
 
   ezHashedString GetPinName(const ezRenderPipelineNodePin* pPin) const;
-  const ezRenderPipelineNodePin* GetPinByName(const char* szName) const;
-  const ezRenderPipelineNodePin* GetPinByName(ezHashedString sName) const;
+  const ezRenderPipelineNodePin* GetPinByName(ezTempHashedString sName) const;
   const ezArrayPtr<const ezRenderPipelineNodePin* const> GetInputPins() const { return m_InputPins; }
   const ezArrayPtr<const ezRenderPipelineNodePin* const> GetOutputPins() const { return m_OutputPins; }
 

--- a/Code/Engine/RendererCore/Pipeline/RenderPipelinePass.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipelinePass.h
@@ -109,6 +109,10 @@ public:
   virtual ezResult Serialize(ezStreamWriter& inout_stream) const;
   virtual ezResult Deserialize(ezStreamReader& inout_stream);
 
+  /// Imports and declares the render-graph barrier dependencies that were recorded during extraction for `category` (via ezMsgExtractRenderData::AddDependency).
+  /// Call this in AddRenderPasses for every category you want to call `RenderDataWithCategory` on in the execution callback.
+  void DeclareRendererDependenciesForCategory(ezRenderData::Category category, ezRenderGraph& ref_graph, ezRenderGraphPassBuilder& ref_passBuilder);
+
   void RenderDataWithCategory(const ezRenderViewContext& renderViewContext, ezRenderData::Category category);
 
   void BindDataProviderResources(const ezRenderViewContext& renderViewContext, ezForwardRenderShadingQuality::Enum quality = ezForwardRenderShadingQuality::Normal);

--- a/Code/Engine/RendererCore/RenderGraph/Declarations.h
+++ b/Code/Engine/RendererCore/RenderGraph/Declarations.h
@@ -32,6 +32,36 @@ class ezRenderGraphBufferHandle
   friend class ezRenderGraphManager;
 };
 
+template <>
+struct ezHashHelper<ezRenderGraphTextureHandle>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(ezRenderGraphTextureHandle value)
+  {
+    return ezHashHelper<ezRenderGraphTextureHandle::IdType::StorageType>::Hash(value.GetInternalID().m_Data);
+  }
+
+  EZ_ALWAYS_INLINE static bool Equal(ezRenderGraphTextureHandle a, ezRenderGraphTextureHandle b)
+  {
+    return a == b;
+  }
+};
+
+template <>
+struct ezHashHelper<ezRenderGraphBufferHandle>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(ezRenderGraphBufferHandle value)
+  {
+    return ezHashHelper<ezRenderGraphBufferHandle::IdType::StorageType>::Hash(value.GetInternalID().m_Data);
+  }
+
+  EZ_ALWAYS_INLINE static bool Equal(ezRenderGraphBufferHandle a, ezRenderGraphBufferHandle b)
+  {
+    return a == b;
+  }
+};
+
+
+
 /// Coarse execution phase for render graphs. Graphs within the same phase execute in registration (FIFO) order.
 struct ezRenderGraphPhase
 {

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraph.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraph.cpp
@@ -183,7 +183,7 @@ ezStatus ezRenderGraph::ReplaceImportedTexture(ezRenderGraphTextureHandle hGraph
   // if (oldDesc.m_Type != newDesc.m_Type)
   //   return ezStatus(ezFmt("Replacement texture type {} is different from original texture type {}", ezArgEnum(newDesc.m_Type), ezArgEnum(oldDesc.m_Type)));
 
-  if (!newDesc.m_TextureFlags.AreAllSet(newDesc.m_TextureFlags))
+  if (!newDesc.m_TextureFlags.AreAllSet(oldDesc.m_TextureFlags))
     return ezStatus(ezFmt("Replacement texture flags {} does not contain some of the original flags {}", ezArgEnum(newDesc.m_TextureFlags), ezArgEnum(oldDesc.m_TextureFlags)));
 
   // Is the target graph texture not imported yet?

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -100,6 +100,7 @@ void ezRenderGraphManager::DeinitPool(ezGALDevice* pDevice)
 void ezRenderGraphManager::EnqueueRenderGraph(const ezSharedPtr<ezRenderGraph>& pRenderGraph)
 {
   EZ_LOCK(s_Mutex);
+  EZ_ASSERT_DEV(pRenderGraph->m_pCurrentPass == nullptr, "Can't enqueue a render graph that still has a pass open for recording");
   s_EnqueuedRenderGraphs[pRenderGraph->m_Phase.GetValue()].PushBack(pRenderGraph);
 }
 

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -185,8 +185,8 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
 
   for (s_uiCurrentGraphIndex = 0; s_uiCurrentGraphIndex < s_ExecutingGraphs.GetCount(); ++s_uiCurrentGraphIndex)
   {
-    // Barriers are only valid for one execution as they cross graph boundaries. Next frame the initial states may be different.
-    s_ExecutingGraphs[s_uiCurrentGraphIndex]->ResetInternal(ezRenderGraph::RenderGraphState::Compiled);
+    // Graphs can only be executed ones and then need to be re-recorded.
+    s_ExecutingGraphs[s_uiCurrentGraphIndex]->ResetInternal(ezRenderGraph::RenderGraphState::Recording);
   }
   s_ExecutingGraphs.Clear();
 

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphContext.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphContext.h
@@ -55,4 +55,4 @@ private:
 };
 
 /// Execution callback type for render graph passes.
-using ezRenderGraphExecuteFunction = ezDelegate<void(const ezRenderGraphContext&), 16, ezAlignedAllocatorWrapper>;
+using ezRenderGraphExecuteFunction = ezDelegate<void(const ezRenderGraphContext&), 16, ezTempAllocatorWrapper>;

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphContext.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphContext.h
@@ -55,4 +55,4 @@ private:
 };
 
 /// Execution callback type for render graph passes.
-using ezRenderGraphExecuteFunction = ezDelegate<void(const ezRenderGraphContext&)>;
+using ezRenderGraphExecuteFunction = ezDelegate<void(const ezRenderGraphContext&), 16, ezAlignedAllocatorWrapper>;

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -99,12 +99,13 @@ namespace ezInternal
 
       ezHybridArray<RenderDataCacheEntry, 4> m_Entries;
       ezUInt16 m_uiVersion = 0;
+      bool m_bHasDependencies = false;
     };
 
     struct PerObjectDependenciesCache
     {
-      ezHybridArray<ezTextureDependency, 4> m_TextureDependencies;
-      ezHybridArray<ezBufferDependency, 4> m_BufferDependencies;
+      ezSmallArray<ezTextureDependency, 4> m_TextureDependencies;
+      ezSmallArray<ezBufferDependency, 4> m_BufferDependencies;
       ezUInt16 m_uiVersion = 0;
     };
 
@@ -400,7 +401,7 @@ void ezRenderWorld::DeleteCachedRenderDataForObjectRecursive(const ezGameObject*
   }
 }
 
-ezArrayPtr<const ezInternal::RenderDataCacheEntry> ezRenderWorld::GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion)
+ezArrayPtr<const ezInternal::RenderDataCacheEntry> ezRenderWorld::GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion, ezArrayPtr<const ezTextureDependency>& out_textureDependencies, ezArrayPtr<const ezBufferDependency>& out_bufferDependencies)
 {
   if (cvar_RenderingCachingStaticObjects)
   {
@@ -411,31 +412,25 @@ ezArrayPtr<const ezInternal::RenderDataCacheEntry> ezRenderWorld::GetCachedRende
       auto& perObjectCache = perObjectCaches[uiCacheIndex];
       if (perObjectCache.m_uiVersion == uiComponentVersion)
       {
+        if (perObjectCache.m_bHasDependencies)
+        {
+          const auto& perObjectDependenciesCaches = view.m_pRenderDataCache->m_PerObjectDependenciesCache;
+          ezUInt32 uiCacheIndex = hOwner.GetInternalID().m_InstanceIndex;
+
+          auto it = perObjectDependenciesCaches.Find(uiCacheIndex);
+          if (it.IsValid() && it.Value().m_uiVersion == uiComponentVersion)
+          {
+            out_textureDependencies = it.Value().m_TextureDependencies;
+            out_bufferDependencies = it.Value().m_BufferDependencies;
+          }
+        }
+
         return perObjectCache.m_Entries;
       }
     }
   }
 
   return ezArrayPtr<const ezInternal::RenderDataCacheEntry>();
-}
-
-void ezRenderWorld::GetCachedDependencies(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion, ezArrayPtr<const ezTextureDependency>& out_textureDependencies, ezArrayPtr<const ezBufferDependency>& out_bufferDependencies)
-{
-  out_textureDependencies = {};
-  out_bufferDependencies = {};
-
-  if (cvar_RenderingCachingStaticObjects)
-  {
-    const auto& perObjectDependenciesCaches = view.m_pRenderDataCache->m_PerObjectDependenciesCache;
-    ezUInt32 uiCacheIndex = hOwner.GetInternalID().m_InstanceIndex;
-
-    auto it = perObjectDependenciesCaches.Find(uiCacheIndex);
-    if (it.IsValid() && it.Value().m_uiVersion == uiComponentVersion)
-    {
-      out_textureDependencies = it.Value().m_TextureDependencies;
-      out_bufferDependencies = it.Value().m_BufferDependencies;
-    }
-  }
 }
 
 void ezRenderWorld::AddViewToRender(const ezViewHandle& hView)
@@ -807,8 +802,9 @@ void ezRenderWorld::UpdateRenderDataCache()
       // add entry for this view
       const ezUInt32 uiCacheIndex = newEntries.m_hOwnerObject.GetInternalID().m_InstanceIndex;
       perObjectCaches.EnsureCount(uiCacheIndex + 1);
-
+      const bool bHasDependencies = !newEntries.m_TextureDependencies.IsEmpty() || !newEntries.m_BufferDependencies.IsEmpty();
       auto& perObjectCache = perObjectCaches[uiCacheIndex];
+      perObjectCache.m_bHasDependencies = bHasDependencies;
       if (perObjectCache.m_uiVersion != newEntries.m_Cache.m_uiVersion)
       {
         perObjectCache.m_Entries.Clear();
@@ -824,7 +820,7 @@ void ezRenderWorld::UpdateRenderDataCache()
       }
 
       // Dependencies are sparse, so they are stored in a separate map keyed by the object's cache index.
-      if (!newEntries.m_TextureDependencies.IsEmpty() || !newEntries.m_BufferDependencies.IsEmpty())
+      if (bHasDependencies)
       {
         auto& perObjectDependenciesCache = pView->m_pRenderDataCache->m_PerObjectDependenciesCache[uiCacheIndex];
         if (perObjectDependenciesCache.m_uiVersion != newEntries.m_Cache.m_uiVersion)

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -101,7 +101,15 @@ namespace ezInternal
       ezUInt16 m_uiVersion = 0;
     };
 
+    struct PerObjectDependenciesCache
+    {
+      ezHybridArray<ezTextureDependency, 4> m_TextureDependencies;
+      ezHybridArray<ezBufferDependency, 4> m_BufferDependencies;
+      ezUInt16 m_uiVersion = 0;
+    };
+
     ezDynamicArray<PerObjectCache> m_PerObjectCaches;
+    ezHashTable<ezUInt32, PerObjectDependenciesCache> m_PerObjectDependenciesCache;
 
     struct NewEntryPerComponent
     {
@@ -113,6 +121,8 @@ namespace ezInternal
       ezGameObjectHandle m_hOwnerObject;
       ezComponentHandle m_hOwnerComponent;
       PerObjectCache m_Cache;
+      ezHybridArray<ezTextureDependency, 2> m_TextureDependencies;
+      ezHybridArray<ezBufferDependency, 2> m_BufferDependencies;
     };
 
     ezStaticArray<NewEntryPerComponent, MaxNumNewCacheEntries> m_NewEntriesPerComponent;
@@ -261,7 +271,7 @@ bool ezRenderWorld::IsRenderingScheduled()
   return !s_MainViews.IsEmpty() || !s_FilteredRenderPipelines[GetDataIndexForRendering()].IsEmpty();
 }
 
-void ezRenderWorld::CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries)
+void ezRenderWorld::CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries, ezArrayPtr<const ezTextureDependency> textureDependencies, ezArrayPtr<const ezBufferDependency> bufferDependencies)
 {
   if (cvar_RenderingCachingStaticObjects)
   {
@@ -279,6 +289,8 @@ void ezRenderWorld::CacheRenderData(const ezView& view, const ezGameObjectHandle
       newEntry.m_hOwnerComponent = hOwnerComponent;
       newEntry.m_Cache.m_Entries = cacheEntries;
       newEntry.m_Cache.m_uiVersion = uiComponentVersion;
+      newEntry.m_TextureDependencies = textureDependencies;
+      newEntry.m_BufferDependencies = bufferDependencies;
     }
   }
 }
@@ -296,6 +308,7 @@ void ezRenderWorld::DeleteAllCachedRenderData()
     {
       ezView* pView = it.Value();
       pView->m_pRenderDataCache->m_PerObjectCaches.Clear();
+      pView->m_pRenderDataCache->m_PerObjectDependenciesCache.Clear();
     }
   }
 
@@ -339,6 +352,7 @@ void ezRenderWorld::DeleteCachedRenderData(const ezGameObjectHandle& hOwnerObjec
 void ezRenderWorld::ResetRenderDataCache(ezView& ref_view)
 {
   ref_view.m_pRenderDataCache->m_PerObjectCaches.Clear();
+  ref_view.m_pRenderDataCache->m_PerObjectDependenciesCache.Clear();
   ref_view.m_pRenderDataCache->m_NewEntriesCount = 0;
 
   if (ref_view.GetWorld() != nullptr)
@@ -405,6 +419,25 @@ ezArrayPtr<const ezInternal::RenderDataCacheEntry> ezRenderWorld::GetCachedRende
   return ezArrayPtr<const ezInternal::RenderDataCacheEntry>();
 }
 
+void ezRenderWorld::GetCachedDependencies(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion, ezArrayPtr<const ezTextureDependency>& out_textureDependencies, ezArrayPtr<const ezBufferDependency>& out_bufferDependencies)
+{
+  out_textureDependencies = {};
+  out_bufferDependencies = {};
+
+  if (cvar_RenderingCachingStaticObjects)
+  {
+    const auto& perObjectDependenciesCaches = view.m_pRenderDataCache->m_PerObjectDependenciesCache;
+    ezUInt32 uiCacheIndex = hOwner.GetInternalID().m_InstanceIndex;
+
+    auto it = perObjectDependenciesCaches.Find(uiCacheIndex);
+    if (it.IsValid() && it.Value().m_uiVersion == uiComponentVersion)
+    {
+      out_textureDependencies = it.Value().m_TextureDependencies;
+      out_bufferDependencies = it.Value().m_BufferDependencies;
+    }
+  }
+}
+
 void ezRenderWorld::AddViewToRender(const ezViewHandle& hView)
 {
   ezView* pView = nullptr;
@@ -453,6 +486,16 @@ void ezRenderWorld::AddViewDependency(const ezView& consumerView, ezGALTextureHa
   if (consumerView.m_pRenderPipeline)
   {
     consumerView.m_pRenderPipeline->AddViewDependency(hTexture, requiredState, stage);
+  }
+}
+
+void ezRenderWorld::AddViewDependency(const ezView& consumerView, ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage)
+{
+  EZ_ASSERT_DEV(s_bInExtract, "AddViewDependency must be called during extraction");
+
+  if (consumerView.m_pRenderPipeline)
+  {
+    consumerView.m_pRenderPipeline->AddViewDependency(hBuffer, requiredState, stage);
   }
 }
 
@@ -694,6 +737,8 @@ void ezRenderWorld::DeleteCachedRenderDataInternal(const ezGameObjectHandle& hOw
         perObjectCaches[uiCacheIndex].m_Entries.Clear();
         perObjectCaches[uiCacheIndex].m_uiVersion = 0;
       }
+
+      pView->m_pRenderDataCache->m_PerObjectDependenciesCache.Remove(uiCacheIndex);
     }
   }
 }
@@ -775,6 +820,28 @@ void ezRenderWorld::UpdateRenderDataCache()
         if (!perObjectCache.m_Entries.Contains(newEntry))
         {
           perObjectCache.m_Entries.PushBack(newEntry);
+        }
+      }
+
+      // Dependencies are sparse, so they are stored in a separate map keyed by the object's cache index.
+      if (!newEntries.m_TextureDependencies.IsEmpty() || !newEntries.m_BufferDependencies.IsEmpty())
+      {
+        auto& perObjectDependenciesCache = pView->m_pRenderDataCache->m_PerObjectDependenciesCache[uiCacheIndex];
+        if (perObjectDependenciesCache.m_uiVersion != newEntries.m_Cache.m_uiVersion)
+        {
+          perObjectDependenciesCache.m_TextureDependencies.Clear();
+          perObjectDependenciesCache.m_BufferDependencies.Clear();
+          perObjectDependenciesCache.m_uiVersion = newEntries.m_Cache.m_uiVersion;
+        }
+
+        for (const ezTextureDependency& dep : newEntries.m_TextureDependencies)
+        {
+          perObjectDependenciesCache.m_TextureDependencies.PushBack(dep);
+        }
+
+        for (const ezBufferDependency& dep : newEntries.m_BufferDependencies)
+        {
+          perObjectDependenciesCache.m_BufferDependencies.PushBack(dep);
         }
       }
 

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -121,8 +121,8 @@ namespace ezInternal
       ezGameObjectHandle m_hOwnerObject;
       ezComponentHandle m_hOwnerComponent;
       PerObjectCache m_Cache;
-      ezHybridArray<ezTextureDependency, 2> m_TextureDependencies;
-      ezHybridArray<ezBufferDependency, 2> m_BufferDependencies;
+      ezSmallArray<ezTextureDependency, 2> m_TextureDependencies;
+      ezSmallArray<ezBufferDependency, 2> m_BufferDependencies;
     };
 
     ezStaticArray<NewEntryPerComponent, MaxNumNewCacheEntries> m_NewEntriesPerComponent;

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -27,10 +27,13 @@ struct ezRenderWorldRenderEvent
   enum class Type
   {
     BeginRender,             ///< Fired before rendering begins.
+    BeforePipelineExecution, ///< Fired before executing a render pipeline.
+    AfterPipelineExecution,  ///< Fired after executing a render pipeline.
     EndRender,               ///< Fired after rendering is complete.
   };
 
   Type m_Type;
+  const ezRenderViewContext* m_pRenderViewContext = nullptr;
   ezUInt64 m_uiFrameCounter = 0;
 };
 

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -80,10 +80,7 @@ public:
   static void ResetRenderDataCache(ezView& ref_view);
 
   /// Retrieves cached render data if available and still valid.
-  static ezArrayPtr<const ezInternal::RenderDataCacheEntry> GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion);
-
-  /// Retrieves cached per-object render-graph barrier dependencies if available and still valid.
-  static void GetCachedDependencies(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion, ezArrayPtr<const ezTextureDependency>& out_textureDependencies, ezArrayPtr<const ezBufferDependency>& out_bufferDependencies);
+  static ezArrayPtr<const ezInternal::RenderDataCacheEntry> GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion, ezArrayPtr<const ezTextureDependency>& out_textureDependencies, ezArrayPtr<const ezBufferDependency>& out_bufferDependencies);
 
   static void AddViewToRender(const ezViewHandle& hView);
 

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -61,8 +61,8 @@ public:
 
   /// Caches render data for an object to avoid re-extraction if unchanged.
   ///
-  /// Cached render data needs to be deleted/invalidated manually if any data changes.
-  static void CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries);
+  /// Cached render data needs to be deleted/invalidated manually if any data changes. The dependency arrays carry per-category render-graph barrier dependencies that were recorded during extraction and are cached alongside the render data.
+  static void CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries, ezArrayPtr<const ezTextureDependency> textureDependencies = {}, ezArrayPtr<const ezBufferDependency> bufferDependencies = {});
 
   /// Deletes all cached render data globally.
   static void DeleteAllCachedRenderData();
@@ -82,11 +82,18 @@ public:
   /// Retrieves cached render data if available and still valid.
   static ezArrayPtr<const ezInternal::RenderDataCacheEntry> GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion);
 
+  /// Retrieves cached per-object render-graph barrier dependencies if available and still valid.
+  static void GetCachedDependencies(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion, ezArrayPtr<const ezTextureDependency>& out_textureDependencies, ezArrayPtr<const ezBufferDependency>& out_bufferDependencies);
+
   static void AddViewToRender(const ezViewHandle& hView);
 
-  /// Declares that the given view needs the specified texture in the given resource
-  /// state when its render graph executes. Must be called during extraction.
+  /// Declares that the given view needs the specified texture in the given resource state when its render graph executes. Must be called during extraction.
+  /// Usually this function is called alongside ezRenderWorld::AddViewToRender to declare the required state of the output the view produced.
   static void AddViewDependency(const ezView& consumerView, ezGALTextureHandle hTexture, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
+
+  /// Declares that the given view needs the specified buffer in the given resource state when its render graph executes. Must be called during extraction.
+  /// Usually this function is called alongside ezRenderWorld::AddViewToRender to declare the required state of the output the view produced.
+  static void AddViewDependency(const ezView& consumerView, ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> requiredState, ezBitflags<ezGALShaderStageFlags> stage = ezGALShaderStageFlags::Auto);
 
   static void ExtractMainViews();
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -75,12 +75,18 @@ public:
   /// - Texture ranges: Mip levels and array slices within bounds
   /// - Make sure no proxy texture is present
   ///
+  /// **Resource State Validation:**
+  /// - Constant buffer bindings must be in ezGALResourceState::ConstantBuffer
+  /// - SRV texture and buffer bindings must be in ezGALResourceState::ShaderResource, except depth textures which must be in ezGALResourceState::DepthStencilRead
+  /// - UAV texture and buffer bindings must be in ezGALResourceState::UnorderedAccess
+  ///
   /// \param uiBindGroup The bind group set index to set
   /// \param bindGroup Description containing the layout and resource items to bind
   void SetBindGroup(ezUInt32 uiBindGroup, const ezGALBindGroupCreationDescription& bindGroup);
 
   /// \brief Sets a bind group resource to the given bind group index.
   /// As there are two functions to set bind groups (this one and the overload for transient bind groups) the last call takes precedence if both functions are called for the same index.
+  /// Resources in hBindGroup must be in the states required by their shader binding when the bind group is used by a draw or dispatch call.
   /// \param uiBindGroup The bind group set index to set
   /// \param hBindGroup Handle to the bind group that is to be used.
   void SetBindGroup(ezUInt32 uiBindGroup, ezGALBindGroupHandle hBindGroup);
@@ -114,19 +120,30 @@ public:
 
   // Update functions
 
+  /// hDest must be in ezGALResourceState::CopyDestination. hSource must be in ezGALResourceState::CopySource.
   void CopyBuffer(ezGALBufferHandle hDest, ezGALBufferHandle hSource);
+
+  /// hDest must be in ezGALResourceState::CopyDestination. hSource must be in ezGALResourceState::CopySource.
   void CopyBufferRegion(ezGALBufferHandle hDest, ezUInt32 uiDestOffset, ezGALBufferHandle hSource, ezUInt32 uiSourceOffset, ezUInt32 uiByteCount);
 
   void UpdateBuffer(ezGALBufferHandle hDest, ezUInt32 uiDestOffset, ezArrayPtr<const ezUInt8> sourceData, ezGALUpdateMode::Enum updateMode = ezGALUpdateMode::TransientConstantBuffer);
 
+  /// hDest must be in ezGALResourceState::CopyDestination. hSource must be in ezGALResourceState::CopySource.
   void CopyTexture(ezGALTextureHandle hDest, ezGALTextureHandle hSource);
+
+  /// destinationSubResource of hDest must be in ezGALResourceState::CopyDestination. sourceSubResource of hSource must be in ezGALResourceState::CopySource.
   void CopyTextureRegion(ezGALTextureHandle hDest, const ezGALTextureSubresource& destinationSubResource, const ezVec3U32& vDestinationPoint, ezGALTextureHandle hSource, const ezGALTextureSubresource& sourceSubResource, const ezBoundingBoxu32& box);
 
+  /// destinationSubResource of hDest must be in ezGALResourceState::CopyDestination.
   void UpdateTexture(ezGALTextureHandle hDest, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox, const ezGALSystemMemoryDescription& sourceData);
 
+  /// destinationSubResource of hDest must be in ezGALResourceState::ResolveDestination. sourceSubResource of hSource must be in ezGALResourceState::ResolveSource.
   void ResolveTexture(ezGALTextureHandle hDest, const ezGALTextureSubresource& destinationSubResource, ezGALTextureHandle hSource, const ezGALTextureSubresource& sourceSubResource);
 
+  /// hSource must be in ezGALResourceState::CopySource.
   void ReadbackTexture(ezGALReadbackTextureHandle hDestination, ezGALTextureHandle hSource);
+
+  /// hSource must be in ezGALResourceState::CopySource.
   void ReadbackBuffer(ezGALReadbackBufferHandle hDestination, ezGALBufferHandle hSource);
 
   // Barriers
@@ -135,10 +152,12 @@ public:
   ///
   /// All barriers in a single call are batched into one API-level barrier command.
   /// Must be called outside of rendering and compute scopes.
+  /// Each texture must currently be in the barrier's m_StateBefore state.
   void TextureBarrier(ezArrayPtr<const ezGALTextureBarrier> barriers);
 
   /// Inserts a single texture barrier for a layout/state transition.
   /// Must be called outside of rendering and compute scopes.
+  /// hTexture must currently be in stateBefore.
   void TextureBarrier(
     ezGALTextureHandle hTexture,
     ezGALTextureRange range = {},
@@ -151,10 +170,12 @@ public:
   ///
   /// All barriers in a single call are batched into one API-level barrier command.
   /// Must be called outside of rendering and compute scopes.
+  /// Each buffer must currently be in the barrier's m_StateBefore state.
   void BufferBarrier(ezArrayPtr<const ezGALBufferBarrier> barriers);
 
   /// Inserts a single buffer barrier for a state transition.
   /// Must be called outside of rendering and compute scopes.
+  /// hBuffer must currently be in stateBefore.
   void BufferBarrier(
     ezGALBufferHandle hBuffer,
     ezBitflags<ezGALResourceState> stateBefore = ezGALResourceState::Default,
@@ -180,10 +201,12 @@ public:
   void EndCompute();
 
   ezResult Dispatch(ezUInt32 uiThreadGroupCountX, ezUInt32 uiThreadGroupCountY, ezUInt32 uiThreadGroupCountZ);
+  /// hIndirectArgumentBuffer must be in ezGALResourceState::DrawIndirect.
   ezResult DispatchIndirect(ezGALBufferHandle hIndirectArgumentBuffer, ezUInt32 uiArgumentOffsetInBytes);
 
   // Draw functions
 
+  /// Color targets in renderingSetup must be in ezGALResourceState::RenderTarget. The depth target must be in ezGALResourceState::DepthStencilRead or ezGALResourceState::DepthStencilWrite depending on the render target view.
   void BeginRendering(const ezGALRenderingSetup& renderingSetup, const char* szName = "");
   void EndRendering();
   bool IsInRenderingScope() const;
@@ -194,15 +217,29 @@ public:
   ///   Each bit represents a bound color target. If all bits are set, all bound color targets will be cleared.
   void Clear(const ezColor& clearColor, ezUInt32 uiRenderTargetClearMask = 0xFFFFFFFFu, bool bClearDepth = true, bool bClearStencil = true, float fDepthClear = 1.0f, ezUInt8 uiStencilClear = 0x0u);
 
+  /// Bound vertex buffers must be in ezGALResourceState::VertexBuffer.
   ezResult Draw(ezUInt32 uiVertexCount, ezUInt32 uiStartVertex);
+
+  /// Bound vertex buffers must be in ezGALResourceState::VertexBuffer. The bound index buffer must be in ezGALResourceState::IndexBuffer.
   ezResult DrawIndexed(ezUInt32 uiIndexCount, ezUInt32 uiStartIndex);
+
+  /// Bound vertex buffers must be in ezGALResourceState::VertexBuffer. The bound index buffer must be in ezGALResourceState::IndexBuffer.
   ezResult DrawIndexedInstanced(ezUInt32 uiIndexCountPerInstance, ezUInt32 uiInstanceCount, ezUInt32 uiStartIndex);
+
+  /// Bound vertex buffers must be in ezGALResourceState::VertexBuffer. The bound index buffer must be in ezGALResourceState::IndexBuffer. hIndirectArgumentBuffer must be in ezGALResourceState::DrawIndirect.
   ezResult DrawIndexedInstancedIndirect(ezGALBufferHandle hIndirectArgumentBuffer, ezUInt32 uiArgumentOffsetInBytes);
+
+  /// Bound vertex buffers must be in ezGALResourceState::VertexBuffer.
   ezResult DrawInstanced(ezUInt32 uiVertexCountPerInstance, ezUInt32 uiInstanceCount, ezUInt32 uiStartVertex);
+
+  /// Bound vertex buffers must be in ezGALResourceState::VertexBuffer. hIndirectArgumentBuffer must be in ezGALResourceState::DrawIndirect.
   ezResult DrawInstancedIndirect(ezGALBufferHandle hIndirectArgumentBuffer, ezUInt32 uiArgumentOffsetInBytes);
 
   // State Functions
+  /// hIndexBuffer must be invalidated or in ezGALResourceState::IndexBuffer.
   void SetIndexBuffer(ezGALBufferHandle hIndexBuffer);
+
+  /// hVertexBuffer must be invalidated or in ezGALResourceState::VertexBuffer.
   void SetVertexBuffer(ezUInt32 uiSlot, ezGALBufferHandle hVertexBuffer, ezUInt32 uiOffset = 0);
 
   void SetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline);
@@ -282,6 +319,10 @@ private:
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   ezResult ValidateBindGroupResourceStates(const ezGALShader* pShader);
   ezResult ValidateBindGroupItemResourceState(ezUInt32 uiBindGroup, const ezShaderResourceBinding& binding, const ezGALBindGroupItem& item);
+  ezResult ValidateTextureState(ezGALTextureHandle hTexture, ezGALTextureRange range, ezBitflags<ezGALResourceState> expectedState, ezBitflags<ezGALShaderStageFlags> expectedStages, ezUInt32 uiBindGroup = 0, const ezHashedString& sBinding = ezHashedString());
+  ezResult ValidateBufferState(ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> expectedState, ezBitflags<ezGALShaderStageFlags> expectedStages, ezUInt32 uiBindGroup = 0, const ezHashedString& sBinding = ezHashedString());
+  ezResult ValidateVertexBufferState();
+  ezResult ValidateIndexBufferState();
   ezResult ValidateGraphicsPipelineResources();
   ezResult ValidateComputePipelineResources();
   void ValidateTextureBarriers(ezArrayPtr<const ezGALTextureBarrier> barriers);
@@ -291,6 +332,8 @@ private:
   ezGALResourceStateTracker m_ResourceStateTracker;
   ezGALBindGroupCreationDescription m_BindGroups[EZ_GAL_MAX_BIND_GROUPS];
   ezUInt8 m_uiBindGroupsMask = 0;
+  bool m_bVertexBufferStatesDirty = true;
+  bool m_bIndexBufferStateDirty = true;
 
   struct ValidationHash
   {

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -14,11 +14,25 @@
 #include <RendererFoundation/Shader/Shader.h>
 #include <RendererFoundation/State/ComputePipeline.h>
 #include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererFoundation/Resources/ProxyTexture.h>
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
 
 namespace
 {
+  void ResolveProxyTexture(ezGALDevice* pDevice, ezGALTextureHandle& ref_hTexture, ezGALTextureRange& ref_range)
+  {
+    const ezGALTexture* pTexture = pDevice->GetTexture(ref_hTexture);
+    EZ_ASSERT_DEBUG(pTexture != nullptr, "Invalid texture handle.");
+    // Resolve proxy texture as they only cause pain down the pipeline.
+    if (pTexture->GetDescription().m_Type == ezGALTextureType::Texture2DProxy)
+    {
+      const auto pProxy = static_cast<const ezGALProxyTexture*>(pTexture);
+      ref_hTexture = pProxy->GetParentTextureHandle();
+      ref_range = {pProxy->GetSlice(), 1, ref_range.m_uiBaseMipLevel, ref_range.m_uiMipLevels};
+    }
+  }
+
   /// Maps a shader resource type to the expected ezGALResourceState for validation.
   /// For texture SRVs, depth textures expect DepthStencilRead instead of ShaderResource.
   ezBitflags<ezGALResourceState> GetExpectedResourceState(ezGALShaderResourceType::Enum resourceType, const ezGALDevice& device, ezGALTextureHandle hTexture = {})
@@ -92,6 +106,11 @@ namespace
       }
     }
     return EZ_SUCCESS;
+  }
+
+  ezGALTextureRange MakeSingleSubresourceRange(const ezGALTextureSubresource& subResource)
+  {
+    return {static_cast<ezUInt16>(subResource.m_uiArraySlice), 1, static_cast<ezUInt8>(subResource.m_uiMipLevel), 1};
   }
 } // namespace
 
@@ -211,6 +230,10 @@ void ezGALCommandEncoder::CopyBuffer(ezGALBufferHandle hDest, ezGALBufferHandle 
   if (pDest != nullptr && pSource != nullptr)
   {
     EZ_ASSERT_DEBUG(!pDest->GetDescription().m_ResourceAccess.m_bImmutable, "Can't update immutable textures");
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateBufferState(hDest, ezGALResourceState::CopyDestination, ezGALShaderStageFlags::Auto).IgnoreResult();
+    ValidateBufferState(hSource, ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiCopyBuffer++;
     m_CommonImpl.CopyBufferPlatform(pDest, pSource);
   }
@@ -240,6 +263,10 @@ void ezGALCommandEncoder::CopyBufferRegion(
     EZ_IGNORE_UNUSED(uiSourceSize);
     EZ_ASSERT_DEV(uiSourceSize >= uiSourceOffset + uiByteCount, "Source buffer too small (or offset too big)");
 
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateBufferState(hDest, ezGALResourceState::CopyDestination, ezGALShaderStageFlags::Auto).IgnoreResult();
+    ValidateBufferState(hSource, ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiCopyBuffer++;
     m_CommonImpl.CopyBufferRegionPlatform(pDest, uiDestOffset, pSource, uiSourceOffset, uiByteCount);
   }
@@ -327,6 +354,10 @@ void ezGALCommandEncoder::CopyTexture(ezGALTextureHandle hDest, ezGALTextureHand
     EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiMipLevelCount == pSource->GetDescription().m_uiMipLevelCount, "CopyTexture mip levels must match");
     EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiArraySize == pSource->GetDescription().m_uiArraySize, "CopyTexture array size must match");
 
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateTextureState(hDest, {}, ezGALResourceState::CopyDestination, ezGALShaderStageFlags::Auto).IgnoreResult();
+    ValidateTextureState(hSource, {}, ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiCopyTexture++;
     m_CommonImpl.CopyTexturePlatform(pDest, pSource);
   }
@@ -348,6 +379,10 @@ void ezGALCommandEncoder::CopyTextureRegion(ezGALTextureHandle hDest, const ezGA
   if (pDest != nullptr && pSource != nullptr)
   {
     EZ_ASSERT_DEBUG(!pDest->GetDescription().m_ResourceAccess.m_bImmutable, "Can't update immutable textures");
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateTextureState(hDest, MakeSingleSubresourceRange(destinationSubResource), ezGALResourceState::CopyDestination, ezGALShaderStageFlags::Auto).IgnoreResult();
+    ValidateTextureState(hSource, MakeSingleSubresourceRange(sourceSubResource), ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiCopyTexture++;
     m_CommonImpl.CopyTextureRegionPlatform(pDest, destinationSubResource, vDestinationPoint, pSource, sourceSubResource, box);
   }
@@ -368,6 +403,9 @@ void ezGALCommandEncoder::UpdateTexture(ezGALTextureHandle hDest, const ezGALTex
   if (pDest != nullptr)
   {
     EZ_ASSERT_DEBUG(!pDest->GetDescription().m_ResourceAccess.m_bImmutable, "Can't update immutable textures");
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateTextureState(hDest, MakeSingleSubresourceRange(destinationSubResource), ezGALResourceState::CopyDestination, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiUpdateTexture++;
     m_CommonImpl.UpdateTexturePlatform(pDest, destinationSubResource, destinationBox, sourceData);
   }
@@ -389,6 +427,10 @@ void ezGALCommandEncoder::ResolveTexture(ezGALTextureHandle hDest, const ezGALTe
   if (pDest != nullptr && pSource != nullptr)
   {
     EZ_ASSERT_DEBUG(!pDest->GetDescription().m_ResourceAccess.m_bImmutable, "Can't update immutable textures");
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateTextureState(hDest, MakeSingleSubresourceRange(destinationSubResource), ezGALResourceState::ResolveDestination, ezGALShaderStageFlags::Auto).IgnoreResult();
+    ValidateTextureState(hSource, MakeSingleSubresourceRange(sourceSubResource), ezGALResourceState::ResolveSource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiResolveTexture++;
     m_CommonImpl.ResolveTexturePlatform(pDest, destinationSubResource, pSource, sourceSubResource);
   }
@@ -417,6 +459,9 @@ void ezGALCommandEncoder::ReadbackTexture(ezGALReadbackTextureHandle hDestinatio
 
   if (pDestination != nullptr && pSource != nullptr)
   {
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateTextureState(hSource, {}, ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiReadbackTexture++;
     m_CommonImpl.ReadbackTexturePlatform(pDestination, pSource);
   }
@@ -436,6 +481,9 @@ void ezGALCommandEncoder::ReadbackBuffer(ezGALReadbackBufferHandle hDestination,
 
   if (pDestination != nullptr && pSource != nullptr)
   {
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+    ValidateBufferState(hSource, ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto).IgnoreResult();
+#endif
     m_Stats.m_uiReadbackBuffer++;
     m_CommonImpl.ReadbackBufferPlatform(pDestination, pSource);
   }
@@ -588,6 +636,8 @@ void ezGALCommandEncoder::InvalidateState()
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   m_ResourceStateTracker.Clear();
   m_uiBindGroupsMask = 0;
+  m_bVertexBufferStatesDirty = true;
+  m_bIndexBufferStateDirty = true;
 #endif
 }
 
@@ -616,6 +666,7 @@ ezResult ezGALCommandEncoder::DispatchIndirect(ezGALBufferHandle hIndirectArgume
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateComputePipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateBufferState(hIndirectArgumentBuffer, ezGALResourceState::DrawIndirect, ezGALShaderStageFlags::Auto));
 #endif
 
   m_Stats.m_uiDispatch++;
@@ -637,6 +688,7 @@ ezResult ezGALCommandEncoder::Draw(ezUInt32 uiVertexCount, ezUInt32 uiStartVerte
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateGraphicsPipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateVertexBufferState());
 #endif
 
   m_Stats.m_uiDraw++;
@@ -650,6 +702,8 @@ ezResult ezGALCommandEncoder::DrawIndexed(ezUInt32 uiIndexCount, ezUInt32 uiStar
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateGraphicsPipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateVertexBufferState());
+  EZ_SUCCEED_OR_RETURN(ValidateIndexBufferState());
 #endif
 
   m_Stats.m_uiDraw++;
@@ -663,6 +717,8 @@ ezResult ezGALCommandEncoder::DrawIndexedInstanced(ezUInt32 uiIndexCountPerInsta
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateGraphicsPipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateVertexBufferState());
+  EZ_SUCCEED_OR_RETURN(ValidateIndexBufferState());
 #endif
 
   m_Stats.m_uiDraw++;
@@ -678,6 +734,9 @@ ezResult ezGALCommandEncoder::DrawIndexedInstancedIndirect(ezGALBufferHandle hIn
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateGraphicsPipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateVertexBufferState());
+  EZ_SUCCEED_OR_RETURN(ValidateIndexBufferState());
+  EZ_SUCCEED_OR_RETURN(ValidateBufferState(hIndirectArgumentBuffer, ezGALResourceState::DrawIndirect, ezGALShaderStageFlags::Auto));
 #endif
 
   m_Stats.m_uiDraw++;
@@ -691,6 +750,7 @@ ezResult ezGALCommandEncoder::DrawInstanced(ezUInt32 uiVertexCountPerInstance, e
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateGraphicsPipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateVertexBufferState());
 #endif
 
   m_Stats.m_uiDraw++;
@@ -706,6 +766,8 @@ ezResult ezGALCommandEncoder::DrawInstancedIndirect(ezGALBufferHandle hIndirectA
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   EZ_SUCCEED_OR_RETURN(ValidateGraphicsPipelineResources());
+  EZ_SUCCEED_OR_RETURN(ValidateVertexBufferState());
+  EZ_SUCCEED_OR_RETURN(ValidateBufferState(hIndirectArgumentBuffer, ezGALResourceState::DrawIndirect, ezGALShaderStageFlags::Auto));
 #endif
 
   m_Stats.m_uiDraw++;
@@ -720,8 +782,14 @@ void ezGALCommandEncoder::SetIndexBuffer(ezGALBufferHandle hIndexBuffer)
   }
 
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hIndexBuffer);
-  /// \todo Assert on index buffer type (if non nullptr)
-  // Note that GL4 can bind arbitrary buffer to arbitrary binding points (index/vertex/transform-feedback/indirect-draw/...)
+
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+  if (!hIndexBuffer.IsInvalidated())
+  {
+    ValidateBufferState(hIndexBuffer, ezGALResourceState::IndexBuffer, ezGALShaderStageFlags::Auto).IgnoreResult();
+  }
+  m_bIndexBufferStateDirty = true;
+#endif
 
   m_Stats.m_uiSetIndexBuffer++;
   m_CommonImpl.SetIndexBufferPlatform(pBuffer);
@@ -737,8 +805,14 @@ void ezGALCommandEncoder::SetVertexBuffer(ezUInt32 uiSlot, ezGALBufferHandle hVe
   }
 
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hVertexBuffer);
-  // Assert on vertex buffer type (if non-zero)
-  // Note that GL4 can bind arbitrary buffer to arbitrary binding points (index/vertex/transform-feedback/indirect-draw/...)
+
+#if EZ_ENABLED(EZ_BARRIER_VALIDATION)
+  if (!hVertexBuffer.IsInvalidated())
+  {
+    ValidateBufferState(hVertexBuffer, ezGALResourceState::VertexBuffer, ezGALShaderStageFlags::Auto).IgnoreResult();
+  }
+  m_bVertexBufferStatesDirty = true;
+#endif
 
   m_Stats.m_uiSetVertexBuffer++;
   m_CommonImpl.SetVertexBufferPlatform(uiSlot, pBuffer, uiOffset);
@@ -854,6 +928,8 @@ void ezGALCommandEncoder::BeginRendering(const ezGALRenderingSetup& renderingSet
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
   ValidateRenderTargetStates(renderingSetup);
+  m_bVertexBufferStatesDirty = true;
+  m_bIndexBufferStateDirty = true;
 #endif
 
   m_Stats.m_uiBeginRendering++;
@@ -910,6 +986,39 @@ ezResult ezGALCommandEncoder::ValidateComputePipelineResources()
   return EZ_SUCCESS;
 }
 
+ezResult ezGALCommandEncoder::ValidateVertexBufferState()
+{
+  if (m_bVertexBufferStatesDirty)
+  {
+    for (ezGALBufferHandle hVertexBuffer : m_State.m_hVertexBuffers)
+    {
+      if (!hVertexBuffer.IsInvalidated())
+      {
+        EZ_SUCCEED_OR_RETURN(ValidateBufferState(hVertexBuffer, ezGALResourceState::VertexBuffer, ezGALShaderStageFlags::Auto));
+      }
+    }
+
+    m_bVertexBufferStatesDirty = false;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALCommandEncoder::ValidateIndexBufferState()
+{
+  if (m_bIndexBufferStateDirty)
+  {
+    if (!m_State.m_hIndexBuffer.IsInvalidated())
+    {
+      EZ_SUCCEED_OR_RETURN(ValidateBufferState(m_State.m_hIndexBuffer, ezGALResourceState::IndexBuffer, ezGALShaderStageFlags::Auto));
+    }
+
+    m_bIndexBufferStateDirty = false;
+  }
+
+  return EZ_SUCCESS;
+}
+
 ezResult ezGALCommandEncoder::ValidateBindGroupResourceStates(const ezGALShader* pShader)
 {
   if (pShader == nullptr)
@@ -961,77 +1070,103 @@ ezResult ezGALCommandEncoder::ValidateBindGroupItemResourceState(ezUInt32 uiBind
   {
     const ezBitflags<ezGALResourceState> expectedState = GetExpectedResourceState(binding.m_ResourceType, m_Device, item.m_Texture.m_hTexture);
     EZ_ASSERT_DEBUG(!expectedState.IsNoFlagSet(), "At least one flag should e set in the expected resource state.");
-
-    const ezGALResourceStateTracker::TextureState* pState = m_ResourceStateTracker.GetTextureState(item.m_Texture.m_hTexture);
-    ezGALResourceStateTracker::TextureState dummy;
-    if (pState == nullptr)
-    {
-      // Nothing is tracked, compare to default state.
-      const ezGALTexture* pTexture = m_Device.GetTexture(item.m_Texture.m_hTexture);
-      if (pTexture == nullptr)
-      {
-        ezLog::Error("Can't validate bind group {} binding '{}' as the texture is invalid.", uiBindGroup, binding.m_sName);
-        return EZ_FAILURE;
-      }
-      dummy.m_FullRange = pTexture->ClampRange({});
-      dummy.m_SubResourceStates.PushBack({pTexture->GetDescription().GetDefaultState(), ezGALShaderStageFlags::Auto});
-      pState = &dummy;
-    }
-
-    ezTextureValidationError error;
-    error.m_uiBindGroup = uiBindGroup;
-    error.m_sBinding = binding.m_sName;
-    error.m_hTexture = item.m_Texture.m_hTexture;
-    error.m_expectedState = expectedState;
-    error.m_expectedStages = binding.m_Stages;
-
-
-    if (CheckTextureSubResourceState(*pState, item.m_Texture.m_TextureRange, error).Failed())
-    {
-      if (!m_TextureErrors.Insert(error))
-        s_TextureBarrierValidationFailed.Broadcast(error);
-      return EZ_FAILURE;
-    }
+    return ValidateTextureState(item.m_Texture.m_hTexture, item.m_Texture.m_TextureRange, expectedState, binding.m_Stages, uiBindGroup, binding.m_sName);
   }
   else if (typeFlags.IsSet(ezGALBindGroupItemFlags::Buffer))
   {
     const ezBitflags<ezGALResourceState> expectedState = GetExpectedResourceState(binding.m_ResourceType, m_Device);
-    if (expectedState.IsNoFlagSet())
-      return EZ_SUCCESS;
-
-    const ezGALResourceStateTracker::SubResourceState* pState = m_ResourceStateTracker.GetBufferState(item.m_Buffer.m_hBuffer);
-    ezGALResourceStateTracker::SubResourceState dummy;
-    if (pState == nullptr)
-    {
-      // Nothing is tracked, compare to default state.
-      const ezGALBuffer* pBuffer = m_Device.GetBuffer(item.m_Buffer.m_hBuffer);
-      if (pBuffer == nullptr)
-      {
-        ezLog::Error("Can't validate bind group {} binding '{}' as the buffer is invalid.", uiBindGroup, binding.m_sName);
-        return EZ_FAILURE;
-      }
-      dummy.m_State = pBuffer->GetDescription().GetDefaultState();
-      dummy.m_Stages = ezGALShaderStageFlags::Auto;
-      pState = &dummy;
-    }
-
-    if (ezGALResourceStateTracker::IsBufferBarrierNeeded(*pState, {expectedState, binding.m_Stages}, false))
-    {
-      ezBufferValidationError error;
-      error.m_uiBindGroup = uiBindGroup;
-      error.m_sBinding = binding.m_sName;
-      error.m_hBuffer = item.m_Buffer.m_hBuffer;
-      error.m_expectedState = expectedState;
-      error.m_expectedStages = binding.m_Stages;
-      error.m_actualState = pState->m_State;
-      error.m_actualStages = pState->m_Stages;
-
-      if (!m_BufferErrors.Insert(error))
-        s_BufferBarrierValidationFailed.Broadcast(error);
-      return EZ_FAILURE;
-    }
+    return ValidateBufferState(item.m_Buffer.m_hBuffer, expectedState, binding.m_Stages, uiBindGroup, binding.m_sName);
   }
   // Samplers and push constants have no resource state to validate.
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALCommandEncoder::ValidateTextureState(ezGALTextureHandle hTexture, ezGALTextureRange range, ezBitflags<ezGALResourceState> expectedState, ezBitflags<ezGALShaderStageFlags> expectedStages, ezUInt32 uiBindGroup, const ezHashedString& sBinding)
+{
+  if (expectedState.IsNoFlagSet())
+    return EZ_SUCCESS;
+
+  ResolveProxyTexture(&m_Device, hTexture, range);
+
+  const ezGALTexture* pTexture = m_Device.GetTexture(hTexture);
+  if (pTexture == nullptr)
+  {
+    if (sBinding.IsEmpty())
+      ezLog::Error("Can't validate texture state as the texture is invalid.");
+    else
+      ezLog::Error("Can't validate bind group {} binding '{}' as the texture is invalid.", uiBindGroup, sBinding);
+    return EZ_FAILURE;
+  }
+
+  range = pTexture->ClampRange(range);
+
+  const ezGALResourceStateTracker::TextureState* pState = m_ResourceStateTracker.GetTextureState(hTexture);
+  ezGALResourceStateTracker::TextureState dummy;
+  if (pState == nullptr)
+  {
+    // Nothing is tracked, compare to default state.
+    dummy.m_FullRange = pTexture->ClampRange({});
+    dummy.m_SubResourceStates.PushBack({pTexture->GetDescription().GetDefaultState(), ezGALShaderStageFlags::Auto});
+    pState = &dummy;
+  }
+
+  ezTextureValidationError error;
+  error.m_uiBindGroup = uiBindGroup;
+  error.m_sBinding = sBinding;
+  error.m_hTexture = hTexture;
+  error.m_expectedState = expectedState;
+  error.m_expectedStages = expectedStages;
+
+  if (CheckTextureSubResourceState(*pState, range, error).Failed())
+  {
+    if (!m_TextureErrors.Insert(error))
+      s_TextureBarrierValidationFailed.Broadcast(error);
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALCommandEncoder::ValidateBufferState(ezGALBufferHandle hBuffer, ezBitflags<ezGALResourceState> expectedState, ezBitflags<ezGALShaderStageFlags> expectedStages, ezUInt32 uiBindGroup, const ezHashedString& sBinding)
+{
+  if (expectedState.IsNoFlagSet())
+    return EZ_SUCCESS;
+
+  const ezGALResourceStateTracker::SubResourceState* pState = m_ResourceStateTracker.GetBufferState(hBuffer);
+  ezGALResourceStateTracker::SubResourceState dummy;
+  if (pState == nullptr)
+  {
+    // Nothing is tracked, compare to default state.
+    const ezGALBuffer* pBuffer = m_Device.GetBuffer(hBuffer);
+    if (pBuffer == nullptr)
+    {
+      if (sBinding.IsEmpty())
+        ezLog::Error("Can't validate buffer state as the buffer is invalid.");
+      else
+        ezLog::Error("Can't validate bind group {} binding '{}' as the buffer is invalid.", uiBindGroup, sBinding);
+      return EZ_FAILURE;
+    }
+    dummy.m_State = pBuffer->GetDescription().GetDefaultState();
+    dummy.m_Stages = ezGALShaderStageFlags::Auto;
+    pState = &dummy;
+  }
+
+  if (ezGALResourceStateTracker::IsBufferBarrierNeeded(*pState, {expectedState, expectedStages}, false))
+  {
+    ezBufferValidationError error;
+    error.m_uiBindGroup = uiBindGroup;
+    error.m_sBinding = sBinding;
+    error.m_hBuffer = hBuffer;
+    error.m_expectedState = expectedState;
+    error.m_expectedStages = expectedStages;
+    error.m_actualState = pState->m_State;
+    error.m_actualStages = pState->m_Stages;
+
+    if (!m_BufferErrors.Insert(error))
+      s_BufferBarrierValidationFailed.Broadcast(error);
+    return EZ_FAILURE;
+  }
+
   return EZ_SUCCESS;
 }
 
@@ -1107,31 +1242,8 @@ void ezGALCommandEncoder::ValidateRenderTargetStates(const ezGALRenderingSetup& 
       continue;
 
     const auto& viewDesc = pView->GetDescription();
-    const ezGALResourceStateTracker::TextureState* pState = m_ResourceStateTracker.GetTextureState(viewDesc.m_hTexture);
-    ezGALResourceStateTracker::TextureState dummy;
-    if (pState == nullptr)
-    {
-      // Nothing is tracked, compare to default state.
-      const ezGALTexture* pTexture = m_Device.GetTexture(viewDesc.m_hTexture);
-      if (pTexture == nullptr)
-        continue;
-      dummy.m_FullRange = pTexture->ClampRange({});
-      dummy.m_SubResourceStates.PushBack({pTexture->GetDescription().GetDefaultState(), ezGALShaderStageFlags::Auto});
-      pState = &dummy;
-    }
-
     const ezGALTextureRange colorRange = ezGALTextureRange::MakeFromRenderTargetRange({static_cast<ezUInt16>(viewDesc.m_uiFirstSlice), static_cast<ezUInt16>(viewDesc.m_uiSliceCount), static_cast<ezUInt8>(viewDesc.m_uiMipLevel)});
-
-    ezTextureValidationError error;
-    error.m_hTexture = viewDesc.m_hTexture;
-    error.m_expectedState = ezGALResourceState::RenderTarget;
-    error.m_expectedStages = ezGALShaderStageFlags::Auto;
-
-    if (CheckTextureSubResourceState(*pState, colorRange, error).Failed())
-    {
-      if (!m_TextureErrors.Insert(error))
-        s_TextureBarrierValidationFailed.Broadcast(error);
-    }
+    ValidateTextureState(viewDesc.m_hTexture, colorRange, ezGALResourceState::RenderTarget, ezGALShaderStageFlags::Auto).IgnoreResult();
   }
 
   if (!fb.m_hDepthTarget.IsInvalidated())
@@ -1141,31 +1253,8 @@ void ezGALCommandEncoder::ValidateRenderTargetStates(const ezGALRenderingSetup& 
     {
       const auto& viewDesc = pView->GetDescription();
       const ezBitflags<ezGALResourceState> expectedState = viewDesc.m_bReadOnly ? ezGALResourceState::DepthStencilRead : ezGALResourceState::DepthStencilWrite;
-      const ezGALResourceStateTracker::TextureState* pState = m_ResourceStateTracker.GetTextureState(viewDesc.m_hTexture);
-      ezGALResourceStateTracker::TextureState dummy;
-      if (pState == nullptr)
-      {
-        // Nothing is tracked, compare to default state.
-        const ezGALTexture* pTexture = m_Device.GetTexture(viewDesc.m_hTexture);
-        if (pTexture == nullptr)
-          return;
-        dummy.m_FullRange = pTexture->ClampRange({});
-        dummy.m_SubResourceStates.PushBack({pTexture->GetDescription().GetDefaultState(), ezGALShaderStageFlags::Auto});
-        pState = &dummy;
-      }
-
       const ezGALTextureRange depthRange = ezGALTextureRange::MakeFromRenderTargetRange({static_cast<ezUInt16>(viewDesc.m_uiFirstSlice), static_cast<ezUInt16>(viewDesc.m_uiSliceCount), static_cast<ezUInt8>(viewDesc.m_uiMipLevel)});
-
-      ezTextureValidationError error;
-      error.m_hTexture = viewDesc.m_hTexture;
-      error.m_expectedState = expectedState;
-      error.m_expectedStages = ezGALShaderStageFlags::Auto;
-
-      if (CheckTextureSubResourceState(*pState, depthRange, error).Failed())
-      {
-        if (!m_TextureErrors.Insert(error))
-          s_TextureBarrierValidationFailed.Broadcast(error);
-      }
+      ValidateTextureState(viewDesc.m_hTexture, depthRange, expectedState, ezGALShaderStageFlags::Auto).IgnoreResult();
     }
   }
 }

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -784,10 +784,6 @@ void ezGALCommandEncoder::SetIndexBuffer(ezGALBufferHandle hIndexBuffer)
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hIndexBuffer);
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
-  if (!hIndexBuffer.IsInvalidated())
-  {
-    ValidateBufferState(hIndexBuffer, ezGALResourceState::IndexBuffer, ezGALShaderStageFlags::Auto).IgnoreResult();
-  }
   m_bIndexBufferStateDirty = true;
 #endif
 
@@ -807,10 +803,6 @@ void ezGALCommandEncoder::SetVertexBuffer(ezUInt32 uiSlot, ezGALBufferHandle hVe
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hVertexBuffer);
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
-  if (!hVertexBuffer.IsInvalidated())
-  {
-    ValidateBufferState(hVertexBuffer, ezGALResourceState::VertexBuffer, ezGALShaderStageFlags::Auto).IgnoreResult();
-  }
   m_bVertexBufferStatesDirty = true;
 #endif
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -4,6 +4,7 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Buffer.h>
+#include <RendererFoundation/Resources/ProxyTexture.h>
 #include <RendererFoundation/Resources/ReadbackBuffer.h>
 #include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
@@ -14,7 +15,6 @@
 #include <RendererFoundation/Shader/Shader.h>
 #include <RendererFoundation/State/ComputePipeline.h>
 #include <RendererFoundation/State/GraphicsPipeline.h>
-#include <RendererFoundation/Resources/ProxyTexture.h>
 
 #if EZ_ENABLED(EZ_BARRIER_VALIDATION)
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1031,7 +1031,8 @@ ezGALTextureHandle ezGALDevice::CreateProxyTexture(ezGALTextureHandle hParentTex
   const auto& parentDesc = pParentTexture->GetDescription();
   EZ_IGNORE_UNUSED(parentDesc);
   EZ_ASSERT_DEV(parentDesc.m_Type == ezGALTextureType::TextureCube || parentDesc.m_Type == ezGALTextureType::Texture2DArray || parentDesc.m_Type == ezGALTextureType::TextureCubeArray, "Proxy textures can only be created for cubemaps or array textures.");
-
+  const ezUInt32 uiSliceCount = parentDesc.m_Type == ezGALTextureType::TextureCube || parentDesc.m_Type == ezGALTextureType::TextureCubeArray ? parentDesc.m_uiArraySize * 6 : parentDesc.m_uiArraySize;
+  EZ_ASSERT_DEV(uiSlice < uiSliceCount, "Proxy slice {} is out of bounds. Parent texture only has {} slices", uiSlice, uiSliceCount);
   ezGALProxyTexture* pProxyTexture = EZ_NEW(&m_Allocator, ezGALProxyTexture, hParentTexture, *pParentTexture, (ezUInt16)uiSlice);
   ezGALTextureHandle hProxyTexture(m_Textures.Insert(pProxyTexture));
 

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -672,12 +672,23 @@ void ezGALCommandEncoderImplVulkan::SetGraphicsPipelinePlatform(const ezGALGraph
 {
   if (m_pGraphicsPipeline != pGraphicsPipeline)
   {
+    const vk::PipelineLayout oldLayout = m_pShader ? m_pShader->GetVkPipelineLayout() : vk::PipelineLayout{};
     m_pGraphicsPipeline = static_cast<const ezGALGraphicsPipelineVulkan*>(pGraphicsPipeline);
     bool bScissorEnabled = false;
     if (m_pGraphicsPipeline)
     {
       m_pShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_pGraphicsPipeline->GetDescription().m_hShader));
       bScissorEnabled = m_GALDeviceVulkan.GetRasterizerState(m_pGraphicsPipeline->GetDescription().m_hRasterizerState)->GetDescription().m_bScissorTest;
+    }
+    // When the pipeline layout changes, previously bound descriptor sets are invalidated by Vulkan
+    // (see Vulkan spec 14.2.2 "compatibility for set N"). Force a full rebind.
+    const vk::PipelineLayout newLayout = m_pShader ? m_pShader->GetVkPipelineLayout() : vk::PipelineLayout{};
+    if (newLayout != oldLayout)
+    {
+      for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; i++)
+      {
+        m_BindGroupDirty[i] = true;
+      }
     }
     if (bScissorEnabled != m_bScissorEnabled)
     {
@@ -693,10 +704,19 @@ void ezGALCommandEncoderImplVulkan::SetComputePipelinePlatform(const ezGALComput
 {
   if (m_pComputePipeline != pComputePipeline)
   {
+    const vk::PipelineLayout oldLayout = m_pShader ? m_pShader->GetVkPipelineLayout() : vk::PipelineLayout{};
     m_pComputePipeline = static_cast<const ezGALComputePipelineVulkan*>(pComputePipeline);
     if (m_pComputePipeline)
     {
       m_pShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_pComputePipeline->GetDescription().m_hShader));
+    }
+    const vk::PipelineLayout newLayout = m_pShader ? m_pShader->GetVkPipelineLayout() : vk::PipelineLayout{};
+    if (newLayout != oldLayout)
+    {
+      for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; i++)
+      {
+        m_BindGroupDirty[i] = true;
+      }
     }
     m_bPipelineStateDirty = true;
   }
@@ -932,13 +952,13 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
   // Push Constants
   if (m_bPushConstantsDirty && m_pShader->GetPushConstantRange().size > 0)
   {
-    if (m_pShader->GetPushConstantRange().size == m_PushConstants.GetCount())
+    if (m_pShader->GetPushConstantRange().size <= m_PushConstants.GetCount())
     {
-      m_pCommandBuffer->pushConstants(m_pShader->GetVkPipelineLayout(), m_pShader->GetPushConstantRange().stageFlags, m_pShader->GetPushConstantRange().offset, m_PushConstants.GetCount(), m_PushConstants.GetData());
+      m_pCommandBuffer->pushConstants(m_pShader->GetVkPipelineLayout(), m_pShader->GetPushConstantRange().stageFlags, m_pShader->GetPushConstantRange().offset, m_pShader->GetPushConstantRange().size, m_PushConstants.GetData());
     }
     else
     {
-      ezLog::Warning("Push constant size mismatch: shader expects {} bytes but {} bytes were provided. Skipping push constants.",
+      ezLog::Warning("Push constant size mismatch: shader expects {} bytes but only {} bytes were provided. Skipping push constants.",
         m_pShader->GetPushConstantRange().size, m_PushConstants.GetCount());
     }
   }

--- a/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
@@ -1,11 +1,19 @@
 #include <FoundationTest/FoundationTestPCH.h>
 
+#include <Foundation/Memory/CommonAllocators.h>
 #include <Foundation/Types/Delegate.h>
 #include <Foundation/Types/RefCounted.h>
 #include <Foundation/Types/SharedPtr.h>
 
 namespace
 {
+  ezAllocator* g_pTestAllocator;
+
+  struct ezTestAllocatorWrapper
+  {
+    static ezAllocator* GetAllocator() { return g_pTestAllocator; }
+  };
+
   struct TestType
   {
     TestType(){}; // NOLINT: Allow default construction
@@ -261,6 +269,27 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
     EZ_TEST_BOOL(!d.IsComparable());
 
     d.Invalidate();
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - capture lots of things - allocator wrapper")
+  {
+    ezProxyAllocator proxy("DelegateTestAllocator", ezFoundation::GetDefaultAllocator());
+    g_pTestAllocator = &proxy;
+
+    ezInt64 a = 10;
+    ezInt64 b = 20;
+    ezInt64 c = 30;
+
+    using TestDelegateWithAllocator = ezDelegate<ezInt32(ezInt32), 16, ezTestAllocatorWrapper>;
+    TestDelegateWithAllocator d2 = [a, b, c](ezInt32 i) -> ezInt32
+    { return static_cast<ezInt32>(a + b + c + i); };
+
+    EZ_TEST_INT(d2(6), 66);
+    EZ_TEST_BOOL(!d2.IsComparable());
+    EZ_TEST_BOOL(proxy.GetStats().m_uiNumAllocations > 0);
+
+    d2.Invalidate();
+    g_pTestAllocator = nullptr;
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Move semantics")

--- a/Code/UnitTests/RendererTest/Advanced/RenderGraphTest.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/RenderGraphTest.cpp
@@ -449,12 +449,13 @@ void ezRenderGraphTest::EmptyGraph()
     auto desc = MakeColorRT();
     auto hTex = graph.CreateTexture(desc);
 
-    auto pass = graph.AddGraphicsPass("AllCulled");
-    pass.AddColorTarget(hTex, {}, ezGALRenderTargetLoadOp::Clear);
-    pass.SetClearColor(0);
-    // No HasSideEffects, no downstream consumer -> culled.
-    pass.SetExecuteCallback(NoopCallback());
-
+    {
+      auto pass = graph.AddGraphicsPass("AllCulled");
+      pass.AddColorTarget(hTex, {}, ezGALRenderTargetLoadOp::Clear);
+      pass.SetClearColor(0);
+      // No HasSideEffects, no downstream consumer -> culled.
+      pass.SetExecuteCallback(NoopCallback());
+    }
     ezRenderGraphManager::EnqueueRenderGraph(m_pRenderGraph);
     ezRenderGraphManager::ExecuteRenderGraphs(m_pDevice);
     EndFrame();

--- a/Data/UnitTests/GameEngineTest/Animations/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/Animations/RuntimeConfigs/Window.ddl
@@ -4,7 +4,7 @@ WindowDesc
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
 	bool %ClipMouseCursor{false}
-	bool %ShowMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
 	bool %CenterWindowOnDisplay{true}
 }

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: 5C8A5DB904E-A23127-426D-4D6D-ESA93071E0893
+Change me: 5CQ8A5DB904E-A23127-426D-4D6D-ESA93071E0893


### PR DESCRIPTION
- Add texture and buffer dependency records to `ezMsgExtractRenderData` via the new methods `AddDependency(ezGALTextureHandle hTexture, ezRenderData::Category category, ...)` and `AddDependency(ezGALBufferHandle hBuffer, ezRenderData::Category category, ...)`. You do not need to validate the handle, the functions will ignore invalid handles. When ever you are extracting `ezRenderData`, call these functions if you are using resources that are mutable on the GPU.
These will be cached for static objects like the render data.
  - You will need to declare the dependencies in the render graph passes before rendering each category. Wherever you called `RenderDataWithCategory` you now must call with the same category `DeclareRendererDependenciesForCategory` when declaring the pass.
- Added `ezRenderWorld::AddViewDependency` overload for buffers.
- Extend barrier validation to copy, readback, resolve, update, draw, dispatch, vertex/index buffer and fixed proxy texture validation.
- Rebinding Vulkan descriptor sets after pipeline layout changes, and clamping pushed constant bytes to the shader range to fix validation errors.
- Add allocator-wrapper template support to `ezDelegate` and use an aligned allocator wrapper for render graph execute callbacks to be able to capture structs declared via the shaders which are 16byte aligned and will fail to be captured otherwise.
- Show the mouse cursor for the GameEngine animation test window runtime config.