### PR TITLE
Fixed #1954: Added CVar to change the default texture filtering mode

### DIFF
--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
@@ -78,7 +78,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     desc.m_AddressW = ezImageAddressMode::Clamp;
 
     ezTextureUtils::ConfigureSampler(ezTextureFilterSetting::DefaultQuality, desc);
-    desc.m_uiMaxAnisotropy = ezMath::Min(desc.m_uiMaxAnisotropy, 4u);
+    desc.m_uiMaxAnisotropy = ezMath::Min<ezUInt8>(desc.m_uiMaxAnisotropy, 4u);
 
     m_hDecalAtlasSampler = pDevice->CreateSamplerState(desc);
   }

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
@@ -305,7 +305,7 @@ namespace
     out_perReflectionProbeData.WorldToProbeProjectionMatrix = inverse;
 
     out_perReflectionProbeData.ProbePosition = pReflectionProbeRenderData->m_vGlobalPosition.GetAsVec4(1.0f); // W isn't used.
-    out_perReflectionProbeData.Scale = scale.GetAsVec4(0.0f);                                                // W isn't used.
+    out_perReflectionProbeData.Scale = scale.GetAsVec4(0.0f);                                                 // W isn't used.
 
     out_perReflectionProbeData.InfluenceScale = pReflectionProbeRenderData->m_vInfluenceScale.GetAsVec4(0.0f);
     out_perReflectionProbeData.InfluenceShift = pReflectionProbeRenderData->m_vInfluenceShift.CompMul(ezVec3(1.0f) - pReflectionProbeRenderData->m_vInfluenceScale).GetAsVec4(0.0f);

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -1210,59 +1210,59 @@ void ezRenderContext::SetDefaultTextureQuality(ezGALTextureQuality::Enum quality
     switch (m_DefaultTextureQuality)
     {
       case ezGALTextureQuality::Nearest:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Nearest);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Nearest);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Nearest);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Nearest);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Nearest);
         break;
 
       case ezGALTextureQuality::Bilinear:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Bilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Bilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Bilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Trilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Anisotropic2x);
         break;
 
       case ezGALTextureQuality::Trilinear:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Bilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Bilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Trilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic2x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Anisotropic4x);
         break;
 
       case ezGALTextureQuality::Anisotropic2x:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Bilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Trilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic2x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic4x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Anisotropic8x);
         break;
 
       case ezGALTextureQuality::Anisotropic4x:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Trilinear);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Anisotropic2x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic4x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic8x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Anisotropic16x);
         break;
 
       case ezGALTextureQuality::Anisotropic8x:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Anisotropic2x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Anisotropic4x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic8x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic16x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Anisotropic16x);
         break;
 
       case ezGALTextureQuality::Anisotropic16x:
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Anisotropic4x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Anisotropic8x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic16x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic16x);
-        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowestQuality, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::LowQuality, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::DefaultQuality, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighQuality, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(ezGALTextureQualitySlot::HighestQuality, ezGALTextureQuality::Anisotropic16x);
         break;
     }
 

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -3,6 +3,7 @@
 #include <RendererCore/RendererCorePCH.h>
 
 #include <Foundation/Algorithm/HashStream.h>
+#include <Foundation/Configuration/CVar.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/Time/Clock.h>
 #include <Foundation/Types/ScopeExit.h>
@@ -30,6 +31,9 @@
 ezRenderContext* ezRenderContext::s_pDefaultInstance = nullptr;
 ezGALCommandEncoder* ezRenderContext::s_pCommandEncoder = nullptr;
 ezHybridArray<ezRenderContext*, 4> ezRenderContext::s_Instances;
+
+// 0=Nearest, 1=Bilinear, 2=Trilinear, 3=Aniso2x, 4=Aniso4x, 5=Aniso8x, 6=Aniso16x
+ezCVarInt cvar_RenderingTextureQuality("Rendering.TextureQuality", 4, ezCVarFlags::Save, "Default texture filtering quality. 0=Nearest, 1=Bilinear, 2=Trilinear, 3=Anisotropic2x, 4=Anisotropic4x, 5=Anisotropic8x, 6=Anisotropic16x.");
 
 ezMap<ezRenderContext::ShaderVertexDecl, ezGALVertexDeclarationHandle> ezRenderContext::s_GALVertexDeclarations;
 
@@ -133,7 +137,6 @@ ezRenderContext::ezRenderContext(ezGALCommandEncoder* pCommandEncoder)
   m_StateFlags = ezRenderContextFlags::AllStatesInvalid;
   m_GraphicsPipeline.m_Topology = ezGALPrimitiveTopology::ENUM_COUNT; // Set to something invalid
   m_uiMeshBufferPrimitiveCount = 0;
-  m_DefaultTextureFilter = ezTextureFilterSetting::FixedAnisotropic4x;
   m_bAllowAsyncShaderLoading = false;
 
   m_hGlobalConstantBufferStorage = CreateConstantBufferStorage<ezGlobalConstants>();
@@ -912,6 +915,10 @@ void ezRenderContext::GALStaticDeviceEventHandler(const ezGALDeviceEvent& e)
         s_pDefaultInstance->m_bDirtyBindGroups[i] = true;
       }
       s_pDefaultInstance->m_pGALCommandEncoder = e.m_pCommandEncoder;
+
+      // this is executed every frame
+      const ezInt32 iQuality = ezMath::Clamp<ezInt32>(cvar_RenderingTextureQuality, 0, ezGALTextureQuality::Anisotropic16x);
+      s_pDefaultInstance->SetDefaultTextureQuality(static_cast<ezGALTextureQuality::Enum>(iQuality));
     }
   }
   else if (e.m_Type == ezGALDeviceEvent::Type::BeforeEndCommands)
@@ -1190,46 +1197,77 @@ ezResult ezRenderContext::ApplyBindGroup(const ezGALShader* pShader, ezUInt32 ui
   return EZ_SUCCESS;
 }
 
-void ezRenderContext::SetDefaultTextureFilter(ezTextureFilterSetting::Enum filter)
+void ezRenderContext::SetDefaultTextureQuality(ezGALTextureQuality::Enum quality, bool bForce)
 {
-  EZ_ASSERT_DEBUG(
-    filter >= ezTextureFilterSetting::FixedBilinear && filter <= ezTextureFilterSetting::FixedAnisotropic16x, "Invalid default texture filter");
-  filter = ezMath::Clamp(filter, ezTextureFilterSetting::FixedBilinear, ezTextureFilterSetting::FixedAnisotropic16x);
-
-  if (m_DefaultTextureFilter == filter)
+  if (!bForce && m_DefaultTextureQuality == quality)
     return;
 
-  m_DefaultTextureFilter = filter;
-}
+  m_DefaultTextureQuality = quality;
+  cvar_RenderingTextureQuality = static_cast<ezInt32>(quality);
 
-ezTextureFilterSetting::Enum ezRenderContext::GetSpecificTextureFilter(ezTextureFilterSetting::Enum configuration) const
-{
-  if (configuration >= ezTextureFilterSetting::FixedNearest && configuration <= ezTextureFilterSetting::FixedAnisotropic16x)
-    return configuration;
-
-  int iFilter = m_DefaultTextureFilter;
-
-  switch (configuration)
+  if (m_pGALCommandEncoder)
   {
-    case ezTextureFilterSetting::LowestQuality:
-      iFilter -= 2;
-      break;
-    case ezTextureFilterSetting::LowQuality:
-      iFilter -= 1;
-      break;
-    case ezTextureFilterSetting::HighQuality:
-      iFilter += 1;
-      break;
-    case ezTextureFilterSetting::HighestQuality:
-      iFilter += 2;
-      break;
-    default:
-      break;
+    switch (m_DefaultTextureQuality)
+    {
+      case ezGALTextureQuality::Nearest:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Nearest);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Nearest);
+        break;
+
+      case ezGALTextureQuality::Bilinear:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic2x);
+        break;
+
+      case ezGALTextureQuality::Trilinear:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic4x);
+        break;
+
+      case ezGALTextureQuality::Anisotropic2x:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Bilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic8x);
+        break;
+
+      case ezGALTextureQuality::Anisotropic4x:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Trilinear);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic16x);
+        break;
+
+      case ezGALTextureQuality::Anisotropic8x:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Anisotropic2x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic16x);
+        break;
+
+      case ezGALTextureQuality::Anisotropic16x:
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(0, ezGALTextureQuality::Anisotropic4x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(1, ezGALTextureQuality::Anisotropic8x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(2, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(3, ezGALTextureQuality::Anisotropic16x);
+        m_pGALCommandEncoder->GetDevice().SetTextureQualityMode(4, ezGALTextureQuality::Anisotropic16x);
+        break;
+    }
+
+    m_pGALCommandEncoder->GetDevice().UpdateTextureQuality();
   }
-
-  iFilter = ezMath::Clamp<int>(iFilter, ezTextureFilterSetting::FixedBilinear, ezTextureFilterSetting::FixedAnisotropic16x);
-
-  return (ezTextureFilterSetting::Enum)iFilter;
 }
 
 void ezRenderContext::SetAllowAsyncShaderLoading(bool bAllow)

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -171,22 +171,15 @@ public:
   const ezGlobalConstants& ReadGlobalConstants() const;
   void SetGlobalAndWorldTimeConstants(ezTime worldTime);
 
-  /// \brief Sets the texture filter mode that is used by default for texture resources.
+  /// \brief Sets the texture filtering quality for all quality-adjustable samplers.
   ///
-  /// The built in default is Anisotropic 4x.
-  /// If the default setting is changed, already loaded textures might not adjust.
-  /// Nearest filtering is not allowed as a default filter.
-  void SetDefaultTextureFilter(ezTextureFilterSetting::Enum filter);
+  /// The default quality is Anisotropic4x and is controlled via the Rendering.TextureQuality CVar.
+  /// Changing quality triggers immediate recreation of all affected sampler states.
+  /// Pass bForce = true to force recreation even if the quality value did not change.
+  void SetDefaultTextureQuality(ezGALTextureQuality::Enum quality, bool bForce = false);
 
   /// \brief Returns the texture filter mode that is used by default for textures.
-  ezTextureFilterSetting::Enum GetDefaultTextureFilter() const { return m_DefaultTextureFilter; }
-
-  /// \brief Returns the 'fixed' texture filter setting that the combination of default texture filter and given \a configuration defines.
-  ///
-  /// If \a configuration is set to a fixed filter, that setting is returned.
-  /// If it is one of LowestQuality to HighestQuality, the adjusted default filter is returned.
-  /// When the default filter is used (with adjustments), the allowed range is Bilinear to Aniso16x, the Nearest filter is never used.
-  ezTextureFilterSetting::Enum GetSpecificTextureFilter(ezTextureFilterSetting::Enum configuration) const;
+  ezGALTextureQuality::Enum GetDefaultTextureQuality() const { return m_DefaultTextureQuality; }
 
   /// \brief Set async shader loading. During runtime all shaders should be preloaded so this is off by default.
   void SetAllowAsyncShaderLoading(bool bAllow);
@@ -289,7 +282,7 @@ private:
   ezSmallArray<ezGALVertexAttribute, 16> m_VertexAttributes;
 
   ezUInt32 m_uiMeshBufferPrimitiveCount;
-  ezEnum<ezTextureFilterSetting> m_DefaultTextureFilter;
+  ezEnum<ezGALTextureQuality> m_DefaultTextureQuality;
   bool m_bAllowAsyncShaderLoading;
   bool m_bStereoRendering = false;
 

--- a/Code/Engine/RendererCore/Textures/TextureUtils.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.cpp
@@ -332,11 +332,11 @@ void ezTextureUtils::ConfigureSampler(ezTextureFilterSetting::Enum filter, ezGAL
 
   if (filter >= ezTextureFilterSetting::LowestQuality)
   {
-    out_sampler.m_uiUseTextureQualityMode = (filter - ezTextureFilterSetting::LowestQuality);
+    out_sampler.m_useTextureQualitySlot = static_cast<ezGALTextureQualitySlot::Enum>(filter - ezTextureFilterSetting::LowestQuality);
   }
   else
   {
-    out_sampler.m_uiUseTextureQualityMode = 0xFF;
+    out_sampler.m_useTextureQualitySlot = ezGALTextureQualitySlot::None;
   }
 
   switch (filter)

--- a/Code/Engine/RendererCore/Textures/TextureUtils.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.cpp
@@ -325,45 +325,59 @@ ezImageFormat::Enum ezTextureUtils::GalFormatToImageFormat(ezGALResourceFormat::
 
 void ezTextureUtils::ConfigureSampler(ezTextureFilterSetting::Enum filter, ezGALSamplerStateCreationDescription& out_sampler)
 {
-  const ezTextureFilterSetting::Enum thisFilter = ezRenderContext::GetDefaultInstance()->GetSpecificTextureFilter(filter);
-
   out_sampler.m_MinFilter = ezGALTextureFilterMode::Linear;
   out_sampler.m_MagFilter = ezGALTextureFilterMode::Linear;
   out_sampler.m_MipFilter = ezGALTextureFilterMode::Linear;
   out_sampler.m_uiMaxAnisotropy = 1;
 
-  switch (thisFilter)
+  if (filter >= ezTextureFilterSetting::LowestQuality)
+  {
+    out_sampler.m_uiUseTextureQualityMode = (filter - ezTextureFilterSetting::LowestQuality);
+  }
+  else
+  {
+    out_sampler.m_uiUseTextureQualityMode = 0xFF;
+  }
+
+  switch (filter)
   {
     case ezTextureFilterSetting::FixedNearest:
       out_sampler.m_MinFilter = ezGALTextureFilterMode::Point;
       out_sampler.m_MagFilter = ezGALTextureFilterMode::Point;
       out_sampler.m_MipFilter = ezGALTextureFilterMode::Point;
       break;
+
     case ezTextureFilterSetting::FixedBilinear:
       out_sampler.m_MipFilter = ezGALTextureFilterMode::Point;
       break;
+
     case ezTextureFilterSetting::FixedTrilinear:
       break;
+
     case ezTextureFilterSetting::FixedAnisotropic2x:
       out_sampler.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_uiMaxAnisotropy = 2;
       break;
+
     case ezTextureFilterSetting::FixedAnisotropic4x:
       out_sampler.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_uiMaxAnisotropy = 4;
       break;
+
     case ezTextureFilterSetting::FixedAnisotropic8x:
       out_sampler.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_uiMaxAnisotropy = 8;
       break;
+
     case ezTextureFilterSetting::FixedAnisotropic16x:
       out_sampler.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
       out_sampler.m_uiMaxAnisotropy = 16;
       break;
+
     default:
       break;
   }

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -88,6 +88,7 @@ protected:
 
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) override;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
+  virtual void RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) override;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) override;

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -471,8 +471,15 @@ ezGALSamplerState* ezGALDeviceDX11::CreateSamplerStatePlatform(const ezGALSample
 void ezGALDeviceDX11::DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState)
 {
   ezGALSamplerStateDX11* pDX11SamplerState = static_cast<ezGALSamplerStateDX11*>(pSamplerState);
-  pDX11SamplerState->DeInitPlatform(this).IgnoreResult();
+  pDX11SamplerState->DeInitPlatform(this).AssertSuccess();
   EZ_DELETE(&m_Allocator, pDX11SamplerState);
+}
+
+void ezGALDeviceDX11::RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState)
+{
+  ezGALSamplerStateDX11* pDX11SamplerState = static_cast<ezGALSamplerStateDX11*>(pSamplerState);
+  pDX11SamplerState->DeInitPlatform(this).AssertSuccess();
+  pDX11SamplerState->InitPlatform(this).AssertSuccess();
 }
 
 ezGALBindGroupLayout* ezGALDeviceDX11::CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description)

--- a/Code/Engine/RendererDX11/State/Implementation/StateDX11.cpp
+++ b/Code/Engine/RendererDX11/State/Implementation/StateDX11.cpp
@@ -271,20 +271,23 @@ ezGALSamplerStateDX11::~ezGALSamplerStateDX11() = default;
 
 ezResult ezGALSamplerStateDX11::InitPlatform(ezGALDevice* pDevice)
 {
-  D3D11_SAMPLER_DESC DXDesc;
-  DXDesc.AddressU = GALTextureAddressModeToDX11[m_Description.m_AddressU];
-  DXDesc.AddressV = GALTextureAddressModeToDX11[m_Description.m_AddressV];
-  DXDesc.AddressW = GALTextureAddressModeToDX11[m_Description.m_AddressW];
-  DXDesc.BorderColor[0] = m_Description.m_BorderColor.r;
-  DXDesc.BorderColor[1] = m_Description.m_BorderColor.g;
-  DXDesc.BorderColor[2] = m_Description.m_BorderColor.b;
-  DXDesc.BorderColor[3] = m_Description.m_BorderColor.a;
-  DXDesc.ComparisonFunc = GALCompareFuncToDX11[m_Description.m_SampleCompareFunc];
+  ezGALSamplerStateCreationDescription desc = this->GetDescription();
+  pDevice->AdjustSamplerStateDescription(desc);
 
-  if (m_Description.m_MagFilter == ezGALTextureFilterMode::Anisotropic || m_Description.m_MinFilter == ezGALTextureFilterMode::Anisotropic ||
-      m_Description.m_MipFilter == ezGALTextureFilterMode::Anisotropic)
+  D3D11_SAMPLER_DESC DXDesc;
+  DXDesc.AddressU = GALTextureAddressModeToDX11[desc.m_AddressU];
+  DXDesc.AddressV = GALTextureAddressModeToDX11[desc.m_AddressV];
+  DXDesc.AddressW = GALTextureAddressModeToDX11[desc.m_AddressW];
+  DXDesc.BorderColor[0] = desc.m_BorderColor.r;
+  DXDesc.BorderColor[1] = desc.m_BorderColor.g;
+  DXDesc.BorderColor[2] = desc.m_BorderColor.b;
+  DXDesc.BorderColor[3] = desc.m_BorderColor.a;
+  DXDesc.ComparisonFunc = GALCompareFuncToDX11[desc.m_SampleCompareFunc];
+
+  if (desc.m_MagFilter == ezGALTextureFilterMode::Anisotropic || desc.m_MinFilter == ezGALTextureFilterMode::Anisotropic ||
+      desc.m_MipFilter == ezGALTextureFilterMode::Anisotropic)
   {
-    if (m_Description.m_SampleCompareFunc == ezGALCompareFunc::Never)
+    if (desc.m_SampleCompareFunc == ezGALCompareFunc::Never)
       DXDesc.Filter = D3D11_FILTER_ANISOTROPIC;
     else
       DXDesc.Filter = D3D11_FILTER_COMPARISON_ANISOTROPIC;
@@ -293,25 +296,25 @@ ezResult ezGALSamplerStateDX11::InitPlatform(ezGALDevice* pDevice)
   {
     ezUInt32 uiTableIndex = 0;
 
-    if (m_Description.m_MipFilter == ezGALTextureFilterMode::Linear)
+    if (desc.m_MipFilter == ezGALTextureFilterMode::Linear)
       uiTableIndex |= 1;
 
-    if (m_Description.m_MagFilter == ezGALTextureFilterMode::Linear)
+    if (desc.m_MagFilter == ezGALTextureFilterMode::Linear)
       uiTableIndex |= 2;
 
-    if (m_Description.m_MinFilter == ezGALTextureFilterMode::Linear)
+    if (desc.m_MinFilter == ezGALTextureFilterMode::Linear)
       uiTableIndex |= 4;
 
-    if (m_Description.m_SampleCompareFunc != ezGALCompareFunc::Never)
+    if (desc.m_SampleCompareFunc != ezGALCompareFunc::Never)
       uiTableIndex |= 8;
 
     DXDesc.Filter = GALFilterTableIndexToDX11[uiTableIndex];
   }
 
-  DXDesc.MaxAnisotropy = m_Description.m_uiMaxAnisotropy;
-  DXDesc.MaxLOD = m_Description.m_fMaxMip;
-  DXDesc.MinLOD = m_Description.m_fMinMip;
-  DXDesc.MipLODBias = m_Description.m_fMipLodBias;
+  DXDesc.MaxAnisotropy = desc.m_uiMaxAnisotropy;
+  DXDesc.MaxLOD = desc.m_fMaxMip;
+  DXDesc.MinLOD = desc.m_fMinMip;
+  DXDesc.MipLODBias = desc.m_fMipLodBias;
 
   if (FAILED(static_cast<ezGALDeviceDX11*>(pDevice)->GetDXDevice()->CreateSamplerState(&DXDesc, &m_pDXSamplerState)))
   {

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -185,11 +185,11 @@ struct ezGALSamplerStateCreationDescription : public ezHashableStruct<ezGALSampl
 
   ezUInt8 m_uiMaxAnisotropy = 4;
 
-  /// Index into the device's quality mode table (0–7). When set, the sampler's filter and anisotropy are overridden
+  /// Quality slot that controls filter and anisotropy for this sampler. When set, these are overridden
   /// by the current quality setting for that slot, and the sampler is automatically recreated when quality changes.
-  /// Set to 0xFF (default) to use fixed filter settings from m_MinFilter/m_MagFilter/m_MipFilter/m_uiMaxAnisotropy.
+  /// Set to ezGALTextureQualitySlot::None (default) to use fixed filter settings from m_MinFilter/m_MagFilter/m_MipFilter/m_uiMaxAnisotropy.
   /// \see ezRenderContext::SetDefaultTextureQuality, ezTextureFilterSetting
-  ezUInt8 m_uiUseTextureQualityMode = 0xFF;
+  ezEnum<ezGALTextureQualitySlot> m_useTextureQualitySlot = ezGALTextureQualitySlot::None;
 };
 
 struct EZ_RENDERERFOUNDATION_DLL ezGALVertexBinding

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -183,7 +183,13 @@ struct ezGALSamplerStateCreationDescription : public ezHashableStruct<ezGALSampl
   float m_fMinMip = -1.0f;
   float m_fMaxMip = 42000.0f;
 
-  ezUInt32 m_uiMaxAnisotropy = 4;
+  ezUInt8 m_uiMaxAnisotropy = 4;
+
+  /// Index into the device's quality mode table (0–7). When set, the sampler's filter and anisotropy are overridden
+  /// by the current quality setting for that slot, and the sampler is automatically recreated when quality changes.
+  /// Set to 0xFF (default) to use fixed filter settings from m_MinFilter/m_MagFilter/m_MipFilter/m_uiMaxAnisotropy.
+  /// \see ezRenderContext::SetDefaultTextureQuality, ezTextureFilterSetting
+  ezUInt8 m_uiUseTextureQualityMode = 0xFF;
 };
 
 struct EZ_RENDERERFOUNDATION_DLL ezGALVertexBinding

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -406,7 +406,7 @@ protected:
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) = 0;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) = 0;
   /// \brief Destroys and reinitializes a sampler state in-place, applying AdjustSamplerStateDescription to pick up current quality settings.
-  virtual void RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState) {};
+  virtual void RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState) = 0;
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) = 0;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) = 0;

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -244,6 +244,23 @@ public:
   /// Internal: Returns the allocator used by the device.
   ezAllocator* GetAllocator();
 
+  /// \brief Sets the texture quality assigned to the given quality mode slot (0–7).
+  ///
+  /// Quality mode slots are referenced by samplers that opt in via m_uiUseTextureQualityMode.
+  /// Call UpdateTextureQuality() after changing slots to apply the change to existing samplers.
+  void SetTextureQualityMode(ezUInt32 uiMode, ezGALTextureQuality::Enum quality);
+
+  /// \brief Overrides the filter settings in \a inout_desc using the quality assigned to its quality mode slot.
+  ///
+  /// No-op if inout_desc.m_uiUseTextureQualityMode is 0xFF.
+  void AdjustSamplerStateDescription(ezGALSamplerStateCreationDescription& inout_desc);
+
+  /// \brief Recreates all quality-adjustable sampler states to reflect the current quality mode settings.
+  ///
+  /// Called automatically by ezRenderContext when the texture quality changes.
+  void UpdateTextureQuality();
+
+
 private:
   static ezGALDevice* s_pDefaultDevice;
 
@@ -388,6 +405,8 @@ protected:
 
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) = 0;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) = 0;
+  /// \brief Destroys and reinitializes a sampler state in-place, applying AdjustSamplerStateDescription to pick up current quality settings.
+  virtual void RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState) {};
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) = 0;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) = 0;
@@ -482,6 +501,8 @@ private:
   ezUInt32 m_uiGraphicsPipelines = 0;
   ezUInt32 m_uiComputePipelines = 0;
   ezGALCommandEncoderStats m_EncoderStats;
+
+  ezEnum<ezGALTextureQuality> m_QualityModes[8];
 };
 
 #include <RendererFoundation/Device/Implementation/Device_inl.h>

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -244,15 +244,15 @@ public:
   /// Internal: Returns the allocator used by the device.
   ezAllocator* GetAllocator();
 
-  /// \brief Sets the texture quality assigned to the given quality mode slot (0–7).
+  /// \brief Sets the texture quality assigned to the given quality slot.
   ///
-  /// Quality mode slots are referenced by samplers that opt in via m_uiUseTextureQualityMode.
+  /// Quality mode slots are referenced by samplers that opt in via m_useTextureQualitySlot.
   /// Call UpdateTextureQuality() after changing slots to apply the change to existing samplers.
-  void SetTextureQualityMode(ezUInt32 uiMode, ezGALTextureQuality::Enum quality);
+  void SetTextureQualityMode(ezGALTextureQualitySlot::Enum slot, ezGALTextureQuality::Enum quality);
 
   /// \brief Overrides the filter settings in \a inout_desc using the quality assigned to its quality mode slot.
   ///
-  /// No-op if inout_desc.m_uiUseTextureQualityMode is 0xFF.
+  /// No-op if inout_desc.m_useTextureQualitySlot is ezGALTextureQualitySlot::None.
   void AdjustSamplerStateDescription(ezGALSamplerStateCreationDescription& inout_desc);
 
   /// \brief Recreates all quality-adjustable sampler states to reflect the current quality mode settings.
@@ -502,7 +502,7 @@ private:
   ezUInt32 m_uiComputePipelines = 0;
   ezGALCommandEncoderStats m_EncoderStats;
 
-  ezEnum<ezGALTextureQuality> m_QualityModes[8];
+  ezEnum<ezGALTextureQuality> m_QualityModes[5];
 };
 
 #include <RendererFoundation/Device/Implementation/Device_inl.h>

--- a/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
+++ b/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
@@ -71,7 +71,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALDeviceCapabilities
   bool m_bSupportsConservativeRasterization = false;
   bool m_bSupportsWireframe = false;
   bool m_bSupportsVSRenderTargetArrayIndex = false;
-  bool m_bSupportsTexelBuffer = false; ///< Whether ezGALBufferUsageFlags::TexelBuffer is supported. Hardcoded per platform as it must match SUPPORTS_TEXEL_BUFFER shader define.
+  bool m_bSupportsTexelBuffer = false;     ///< Whether ezGALBufferUsageFlags::TexelBuffer is supported. Hardcoded per platform as it must match SUPPORTS_TEXEL_BUFFER shader define.
   bool m_bSupportsMultipleSRVTypes = true; ///< Whether more than one of ezGALBufferUsageFlags::StructuredBuffer, ezGALBufferUsageFlags::TexelBuffer and ezGALBufferUsageFlags::ByteAddressBuffer is supported on a buffer.
   bool m_bSupportsMultiSampledArrays = false;
   ezUInt16 m_uiMaxPushConstantsSize = 0;

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -341,6 +341,7 @@ void ezGALDevice::DestroyHashedResource(Handle& inout_hResource, Table& table, e
 
 void ezGALDevice::SetTextureQualityMode(ezGALTextureQualitySlot::Enum slot, ezGALTextureQuality::Enum quality)
 {
+  EZ_ASSERT_DEV(slot < 5, "Invalid ezGALTextureQualitySlot value used: {}", (int)slot);
   m_QualityModes[slot] = quality;
 }
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -339,6 +339,80 @@ void ezGALDevice::DestroyHashedResource(Handle& inout_hResource, Table& table, e
   inout_hResource.Invalidate();
 }
 
+void ezGALDevice::SetTextureQualityMode(ezUInt32 uiMode, ezGALTextureQuality::Enum quality)
+{
+  m_QualityModes[uiMode] = quality;
+}
+
+void ezGALDevice::AdjustSamplerStateDescription(ezGALSamplerStateCreationDescription& inout_desc)
+{
+  if (inout_desc.m_uiUseTextureQualityMode == 0xFF)
+    return;
+
+  switch (m_QualityModes[inout_desc.m_uiUseTextureQualityMode])
+  {
+    case ezGALTextureQuality::Nearest:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Point;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Point;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Point;
+      inout_desc.m_uiMaxAnisotropy = 1;
+      break;
+
+    case ezGALTextureQuality::Bilinear:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Linear;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Linear;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Point;
+      inout_desc.m_uiMaxAnisotropy = 1;
+      break;
+
+    case ezGALTextureQuality::Trilinear:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Linear;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Linear;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Linear;
+      inout_desc.m_uiMaxAnisotropy = 1;
+      break;
+
+    case ezGALTextureQuality::Anisotropic2x:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_uiMaxAnisotropy = 2;
+      break;
+
+    case ezGALTextureQuality::Anisotropic4x:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_uiMaxAnisotropy = 4;
+      break;
+
+    case ezGALTextureQuality::Anisotropic8x:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_uiMaxAnisotropy = 8;
+      break;
+
+    case ezGALTextureQuality::Anisotropic16x:
+      inout_desc.m_MinFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MagFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_MipFilter = ezGALTextureFilterMode::Anisotropic;
+      inout_desc.m_uiMaxAnisotropy = 16;
+      break;
+  }
+}
+
+void ezGALDevice::UpdateTextureQuality()
+{
+  for (auto it = m_SamplerStates.GetIterator(); it.IsValid(); ++it)
+  {
+    if (it.Value()->GetDescription().m_uiUseTextureQualityMode != 0xFF)
+    {
+      RecreateSamplerStatePlatform(it.Value());
+    }
+  }
+}
+
 ezGALBlendStateHandle ezGALDevice::CreateBlendState(const ezGALBlendStateCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -339,17 +339,17 @@ void ezGALDevice::DestroyHashedResource(Handle& inout_hResource, Table& table, e
   inout_hResource.Invalidate();
 }
 
-void ezGALDevice::SetTextureQualityMode(ezUInt32 uiMode, ezGALTextureQuality::Enum quality)
+void ezGALDevice::SetTextureQualityMode(ezGALTextureQualitySlot::Enum slot, ezGALTextureQuality::Enum quality)
 {
-  m_QualityModes[uiMode] = quality;
+  m_QualityModes[slot] = quality;
 }
 
 void ezGALDevice::AdjustSamplerStateDescription(ezGALSamplerStateCreationDescription& inout_desc)
 {
-  if (inout_desc.m_uiUseTextureQualityMode == 0xFF)
+  if (inout_desc.m_useTextureQualitySlot == ezGALTextureQualitySlot::None)
     return;
 
-  switch (m_QualityModes[inout_desc.m_uiUseTextureQualityMode])
+  switch (m_QualityModes[inout_desc.m_useTextureQualitySlot])
   {
     case ezGALTextureQuality::Nearest:
       inout_desc.m_MinFilter = ezGALTextureFilterMode::Point;
@@ -406,7 +406,7 @@ void ezGALDevice::UpdateTextureQuality()
 {
   for (auto it = m_SamplerStates.GetIterator(); it.IsValid(); ++it)
   {
-    if (it.Value()->GetDescription().m_uiUseTextureQualityMode != 0xFF)
+    if (it.Value()->GetDescription().m_useTextureQualitySlot != ezGALTextureQualitySlot::None)
     {
       RecreateSamplerStatePlatform(it.Value());
     }

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -367,6 +367,29 @@ struct ezGALTextureFilterMode
   };
 };
 
+/// \brief Defines global texture filtering quality levels.
+///
+/// Used to scale all quality-adjustable samplers simultaneously. The actual quality applied to each sampler
+/// depends on which quality mode slot it uses and what quality level is mapped to that slot.
+/// \see ezGALDevice::SetTextureQualityMode, ezRenderContext::SetDefaultTextureQuality
+struct ezGALTextureQuality
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    Nearest,
+    Bilinear,
+    Trilinear,
+    Anisotropic2x,
+    Anisotropic4x,
+    Anisotropic8x,
+    Anisotropic16x,
+
+    Default = Nearest,
+  };
+};
+
 struct ezGALUpdateMode
 {
   enum Enum

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -390,6 +390,29 @@ struct ezGALTextureQuality
   };
 };
 
+/// Identifies one of the five abstract quality tiers used by the texture quality system.
+///
+/// Samplers that opt in via ezGALSamplerStateCreationDescription::m_useTextureQualitySlot reference one of these slots.
+/// Each slot is assigned an ezGALTextureQuality value through ezGALDevice::SetTextureQualityMode, and the device maps
+/// the requested tier to a concrete filter based on the current global quality setting.
+struct ezGALTextureQualitySlot
+{
+  using StorageType = ezUInt8;
+
+  enum Enum : StorageType
+  {
+    LowestQuality,  ///< Lowest quality tier, typically used for distant or unimportant textures.
+    LowQuality,     ///< Below-default quality tier.
+    DefaultQuality, ///< Standard quality tier used for most textures.
+    HighQuality,    ///< Above-default quality tier.
+    HighestQuality, ///< Highest quality tier, typically reserved for hero assets or UI.
+
+    None = 0xFF,    ///< Sentinel value: sampler uses its own fixed filter settings instead of a quality slot.
+
+    Default = DefaultQuality
+  };
+};
+
 struct ezGALUpdateMode
 {
   enum Enum

--- a/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
@@ -143,5 +143,3 @@ void ezGALRenderingSetup::Reset()
 {
   *this = ezGALRenderingSetup();
 }
-
-

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -329,6 +329,7 @@ protected:
 
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) override;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
+  virtual void RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) override;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) override;

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -489,7 +489,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   }
   {
     m_properties = m_physicalDevice.getProperties2();
-    ezLog::Warning("Selected physical device \"{}\" for device creation.", m_properties.properties.deviceName);
+    ezLog::Dev("Selected physical device \"{}\" for device creation.", m_properties.properties.deviceName);
 
     // This is a workaround for broken lavapipe drivers which cannot handle label scopes that span across multiple command buffers.
     ezStringBuilder sDeviceName = ezStringUtf8(m_properties.properties.deviceName).GetView();

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1089,6 +1089,13 @@ void ezGALDeviceVulkan::DestroySamplerStatePlatform(ezGALSamplerState* pSamplerS
   EZ_DELETE(&m_Allocator, pVulkanSamplerState);
 }
 
+void ezGALDeviceVulkan::RecreateSamplerStatePlatform(ezGALSamplerState* pSamplerState)
+{
+  ezGALSamplerStateVulkan* pVulkanSamplerState = static_cast<ezGALSamplerStateVulkan*>(pSamplerState);
+  pVulkanSamplerState->DeInitPlatform(this).AssertSuccess();
+  pVulkanSamplerState->InitPlatform(this).AssertSuccess();
+}
+
 ezGALBindGroupLayout* ezGALDeviceVulkan::CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description)
 {
   ezGALBindGroupLayoutVulkan* pVulkanBindGroupLayout = EZ_NEW(&m_Allocator, ezGALBindGroupLayoutVulkan, Description);

--- a/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
@@ -193,13 +193,16 @@ ezGALSamplerStateVulkan::~ezGALSamplerStateVulkan() {}
 
 ezResult ezGALSamplerStateVulkan::InitPlatform(ezGALDevice* pDevice)
 {
+  ezGALSamplerStateCreationDescription desc = this->GetDescription();
+  pDevice->AdjustSamplerStateDescription(desc);
+
   auto pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
 
   vk::SamplerCreateInfo samplerCreateInfo = {};
-  samplerCreateInfo.addressModeU = GALTextureAddressModeToVulkan[m_Description.m_AddressU];
-  samplerCreateInfo.addressModeV = GALTextureAddressModeToVulkan[m_Description.m_AddressV];
-  samplerCreateInfo.addressModeW = GALTextureAddressModeToVulkan[m_Description.m_AddressW];
-  if (m_Description.m_MagFilter == ezGALTextureFilterMode::Anisotropic || m_Description.m_MinFilter == ezGALTextureFilterMode::Anisotropic || m_Description.m_MipFilter == ezGALTextureFilterMode::Anisotropic)
+  samplerCreateInfo.addressModeU = GALTextureAddressModeToVulkan[desc.m_AddressU];
+  samplerCreateInfo.addressModeV = GALTextureAddressModeToVulkan[desc.m_AddressV];
+  samplerCreateInfo.addressModeW = GALTextureAddressModeToVulkan[desc.m_AddressW];
+  if (desc.m_MagFilter == ezGALTextureFilterMode::Anisotropic || desc.m_MinFilter == ezGALTextureFilterMode::Anisotropic || desc.m_MipFilter == ezGALTextureFilterMode::Anisotropic)
   {
     samplerCreateInfo.anisotropyEnable = VK_TRUE;
   }
@@ -207,7 +210,7 @@ ezResult ezGALSamplerStateVulkan::InitPlatform(ezGALDevice* pDevice)
   vk::SamplerCustomBorderColorCreateInfoEXT customBorderColor;
   if (samplerCreateInfo.addressModeU == vk::SamplerAddressMode::eClampToBorder || samplerCreateInfo.addressModeV == vk::SamplerAddressMode::eClampToBorder || samplerCreateInfo.addressModeW == vk::SamplerAddressMode::eClampToBorder)
   {
-    const ezColor col = m_Description.m_BorderColor;
+    const ezColor col = desc.m_BorderColor;
     if (col == ezColor(0, 0, 0, 0))
     {
       samplerCreateInfo.borderColor = vk::BorderColor::eFloatTransparentBlack;
@@ -229,8 +232,8 @@ ezResult ezGALSamplerStateVulkan::InitPlatform(ezGALDevice* pDevice)
     else
     {
       // Fallback to close enough.
-      const bool bTransparent = m_Description.m_BorderColor.a == 0.0f;
-      const bool bBlack = m_Description.m_BorderColor.r == 0.0f;
+      const bool bTransparent = desc.m_BorderColor.a == 0.0f;
+      const bool bBlack = desc.m_BorderColor.r == 0.0f;
       if (bBlack)
       {
         samplerCreateInfo.borderColor = bTransparent ? vk::BorderColor::eFloatTransparentBlack : vk::BorderColor::eFloatOpaqueBlack;
@@ -241,15 +244,15 @@ ezResult ezGALSamplerStateVulkan::InitPlatform(ezGALDevice* pDevice)
       }
     }
   }
-  samplerCreateInfo.compareEnable = m_Description.m_SampleCompareFunc == ezGALCompareFunc::Never ? VK_FALSE : VK_TRUE;
-  samplerCreateInfo.compareOp = GALCompareFuncToVulkan[m_Description.m_SampleCompareFunc];
-  samplerCreateInfo.magFilter = GALFilterToVulkanFilter[m_Description.m_MagFilter];
-  samplerCreateInfo.minFilter = GALFilterToVulkanFilter[m_Description.m_MinFilter];
-  samplerCreateInfo.maxAnisotropy = static_cast<float>(m_Description.m_uiMaxAnisotropy);
-  samplerCreateInfo.maxLod = m_Description.m_fMaxMip;
-  samplerCreateInfo.minLod = m_Description.m_fMinMip;
-  samplerCreateInfo.mipLodBias = m_Description.m_fMipLodBias;
-  samplerCreateInfo.mipmapMode = GALFilterToVulkanMipmapMode[m_Description.m_MipFilter];
+  samplerCreateInfo.compareEnable = desc.m_SampleCompareFunc == ezGALCompareFunc::Never ? VK_FALSE : VK_TRUE;
+  samplerCreateInfo.compareOp = GALCompareFuncToVulkan[desc.m_SampleCompareFunc];
+  samplerCreateInfo.magFilter = GALFilterToVulkanFilter[desc.m_MagFilter];
+  samplerCreateInfo.minFilter = GALFilterToVulkanFilter[desc.m_MinFilter];
+  samplerCreateInfo.maxAnisotropy = static_cast<float>(desc.m_uiMaxAnisotropy);
+  samplerCreateInfo.maxLod = desc.m_fMaxMip;
+  samplerCreateInfo.minLod = desc.m_fMinMip;
+  samplerCreateInfo.mipLodBias = desc.m_fMipLodBias;
+  samplerCreateInfo.mipmapMode = GALFilterToVulkanMipmapMode[desc.m_MipFilter];
 
   m_resourceImageInfo.imageLayout = vk::ImageLayout::eUndefined;
   VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createSampler(&samplerCreateInfo, nullptr, &m_resourceImageInfo.sampler));

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -105,7 +105,7 @@ ezCommandLineOptionEnum opt_AddressU("_TexConv", "-addressU", "Which texture add
 ezCommandLineOptionEnum opt_AddressV("_TexConv", "-addressV", "Which texture address mode to use along V. Only supported by ez-specific output formats.", "Repeat = 0 | Clamp = 1 | ClampBorder = 2 | Mirror = 3", 0);
 ezCommandLineOptionEnum opt_AddressW("_TexConv", "-addressW", "Which texture address mode to use along W. Only supported by ez-specific output formats.", "Repeat = 0 | Clamp = 1 | ClampBorder = 2 | Mirror = 3", 0);
 
-ezCommandLineOptionEnum opt_Filter("_TexConv", "-filter", "Which texture filter mode to use at runtime. Only supported by ez-specific output formats.", "Default = 9 | Lowest = 7 | Low = 8 | High = 10 | Highest = 11 | Nearest = 0 | Linear = 1 | Trilinear = 2 | Aniso2x = 3 | Aniso4x = 4 | Aniso8x = 5 | Aniso16x = 6", 9);
+ezCommandLineOptionEnum opt_Filter("_TexConv", "-filter", "Which texture filter mode to use at runtime. Only supported by ez-specific output formats.", "Default = 9 | Lowest = 7 | Low = 8 | High = 10 | Highest = 11 | Nearest = 0 | Bilinear = 1 | Trilinear = 2 | Aniso2x = 3 | Aniso4x = 4 | Aniso8x = 5 | Aniso16x = 6", 9);
 
 ezCommandLineOptionEnum opt_BumpMapFilter("_TexConv", "-bumpMapFilter", "Filter used to approximate the x/y bump map gradients.", "Finite = 0 | Sobel = 1 | Scharr = 2", 0);
 

--- a/Code/UnitTests/RendererTest/Basics/Textures.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Textures.cpp
@@ -12,7 +12,7 @@ ezTestAppRun ezRendererTestBasics::SubtestTextures2D()
   BeginCommands("Textures2D");
   TransitionTexture(GetBackbuffer(), ezGALResourceState::RenderTarget);
 
-  ezRenderContext::GetDefaultInstance()->SetDefaultTextureFilter(ezTextureFilterSetting::FixedTrilinear);
+  ezRenderContext::GetDefaultInstance()->SetDefaultTextureQuality(ezGALTextureQuality::Trilinear);
 
   const ezInt32 iNumFrames = 14;
 
@@ -138,7 +138,7 @@ ezTestAppRun ezRendererTestBasics::SubtestTextures3D()
   BeginFrame();
   BeginCommands("Textures3D");
   TransitionTexture(GetBackbuffer(), ezGALResourceState::RenderTarget);
-  ezRenderContext::GetDefaultInstance()->SetDefaultTextureFilter(ezTextureFilterSetting::FixedTrilinear);
+  ezRenderContext::GetDefaultInstance()->SetDefaultTextureQuality(ezGALTextureQuality::Trilinear);
 
   const ezInt32 iNumFrames = 1;
 
@@ -171,7 +171,7 @@ ezTestAppRun ezRendererTestBasics::SubtestTexturesCube()
   BeginCommands("TexturesCube");
   TransitionTexture(GetBackbuffer(), ezGALResourceState::RenderTarget);
 
-  ezRenderContext::GetDefaultInstance()->SetDefaultTextureFilter(ezTextureFilterSetting::FixedTrilinear);
+  ezRenderContext::GetDefaultInstance()->SetDefaultTextureQuality(ezGALTextureQuality::Trilinear);
 
   const ezInt32 iNumFrames = 12;
 


### PR DESCRIPTION
Texture samplers now know which default mode they represent, and if their settings change, they get recreated right away.

This allows to change the texture filtering mode at any time and see the visual / performance difference.