### PR TITLE
Improved IPC connection state handling

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.cpp
@@ -48,6 +48,7 @@ ezResult ezEngineProcessCommunicationChannel::ConnectToHostProcess()
 {
   EZ_ASSERT_DEV(m_pChannel == nullptr, "ProcessCommunication object already in use");
 
+  ezResult res = EZ_SUCCESS;
   if (!ezEditorEngineProcessApp::GetSingleton()->IsRemoteMode())
   {
     if (ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC").IsEmpty())
@@ -67,11 +68,17 @@ ezResult ezEngineProcessCommunicationChannel::ConnectToHostProcess()
 
     ezLog::Debug("Host Process ID: {0}", m_iHostPID);
 
-    CreateAndConnectChannel(ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client));
+    res = CreateAndConnectChannel(ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client));
   }
   else
   {
-    CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel("localhost:1050", ezIpcChannel::Mode::Server));
+    res = CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel("localhost:1050", ezIpcChannel::Mode::Server));
   }
-  return EZ_SUCCESS;
+  if (res.Failed())
+  {
+    ezLog::Error("IpcChannel: CreateAndConnectChannel failed");
+    return EZ_FAILURE;
+  }
+
+  return WaitForConnection(ezTime::MakeFromSeconds(30));
 }

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -90,14 +90,14 @@ void ezProcessCommunicationChannel::OnIpcChannelEvent(const ezIpcChannelEvent& m
   m_IpcChannelEvents.Broadcast(msg);
 }
 
-void ezProcessCommunicationChannel::CreateAndConnectChannel(ezInternal::NewInstance<ezIpcChannel>&& channel)
+ezResult ezProcessCommunicationChannel::CreateAndConnectChannel(ezInternal::NewInstance<ezIpcChannel>&& channel)
 {
   EZ_ASSERT_DEBUG(m_pChannel == nullptr, "Channel already created");
   m_pChannel = channel;
   m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
   m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::OnIpcProtocolEvent, this));
   m_pChannel->m_Events.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::OnIpcChannelEvent, this));
-  m_pChannel->Connect();
+  return m_pChannel->Connect();
 }
 
 void ezProcessCommunicationChannel::DestroyChannel()
@@ -175,9 +175,14 @@ ezResult ezProcessCommunicationChannel::WaitForMessage(const ezRTTI* pMessageTyp
 
 ezResult ezProcessCommunicationChannel::WaitForConnection(ezTime timeout)
 {
-  if (m_pChannel->IsConnected())
+  if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connected)
   {
     return EZ_SUCCESS;
+  }
+
+  if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Disconnected)
+  {
+    return EZ_FAILURE;
   }
 
   ezThreadSignal waitForConnectionSignal;
@@ -186,8 +191,8 @@ ezResult ezProcessCommunicationChannel::WaitForConnection(ezTime timeout)
     {
     switch (event.m_Type)
     {
-      case ezIpcChannelEvent::Connected:
       case ezIpcChannelEvent::Disconnected:
+      case ezIpcChannelEvent::Connected:
         waitForConnectionSignal.RaiseSignal();
         break;
       default:
@@ -196,9 +201,14 @@ ezResult ezProcessCommunicationChannel::WaitForConnection(ezTime timeout)
 
   EZ_SCOPE_EXIT(m_pChannel->m_Events.RemoveEventHandler(eventSubscriptionId));
 
-  if (m_pChannel->IsConnected())
+  if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connected)
   {
     return EZ_SUCCESS;
+  }
+
+  if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Disconnected)
+  {
+    return EZ_FAILURE;
   }
 
   if (timeout == ezTime())

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
@@ -44,7 +44,7 @@ public:
 protected:
   void OnIpcProtocolEvent(const ezIpcProcessMessageProtocol::Event& msg);
   void OnIpcChannelEvent(const ezIpcChannelEvent& msg);
-  void CreateAndConnectChannel(ezInternal::NewInstance<ezIpcChannel>&& channel);
+  ezResult CreateAndConnectChannel(ezInternal::NewInstance<ezIpcChannel>&& channel);
   void DestroyChannel();
   ezUniquePtr<ezIpcProcessMessageProtocol> m_pProtocol;
   ezUniquePtr<ezIpcChannel> m_pChannel;

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -82,12 +82,13 @@ class ezEditorProcessorProcess
 public:
   enum class State
   {
-    LookingForWork,
-    WaitingForConnection,
-    Ready,
-    Processing,
-    ReportResult,
-    Crashed
+    StartClient,          ///< Starting client process.
+    WaitingForConnection, /// < Waiting for IPC connection to client process.
+    LookingForWork,       ///< Connected. Waiting for work to become available.
+    ReadyForProcessing,   ///< A work item has been found. Ready to start processing.
+    Processing,           ///< A work item is being processed.
+    ReportResult,         ///< Report result of the precessing phase.
+    Crashed               ///< Process has crashed. Dead end until `RequestRestart` is called.
   };
 
 public:
@@ -122,7 +123,7 @@ private:
   void OnProcessCrashed(ezStringView message);
 
 private:
-  State m_State = State::LookingForWork;
+  State m_State = State::StartClient;
   ezEditorProcessCommunicationChannel* m_pIPC;
   bool m_bProcessShouldBeRunning = false;
   bool m_bIsIdle = false;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -3,6 +3,7 @@
 #include <EditorFramework/Assets/AssetProcessor.h>
 #include <EditorFramework/Assets/AssetProcessorMessages.h>
 #include <EditorFramework/Preferences/EditorPreferences.h>
+#include <Foundation/Communication/IpcChannel.h>
 #include <Foundation/Configuration/SubSystem.h>
 #include <GameEngine/GameApplication/GameApplication.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
@@ -298,7 +299,7 @@ void ezAssetProcessor::Run()
 
 
 ////////////////////////////////////////////////////////////////////////
-// ezProcessTask
+// ezEditorProcessorProcess
 ////////////////////////////////////////////////////////////////////////
 
 ezEditorProcessorProcess::ezEditorProcessorProcess()
@@ -354,12 +355,14 @@ ezResult ezEditorProcessorProcess::StartProcess()
   {
     return EZ_FAILURE;
   }
+  m_bProcessShouldBeRunning = true;
   m_CurrentProcessID = m_pIPC->GetProcessId();
   return EZ_SUCCESS;
 }
 
 void ezEditorProcessorProcess::ShutdownProcess()
 {
+  m_bProcessShouldBeRunning = false;
   m_pIPC->CloseConnection();
 }
 
@@ -383,10 +386,8 @@ void ezEditorProcessorProcess::EventHandlerIPC(const ezProcessCommunicationChann
 
 void ezEditorProcessorProcess::ChannelEventHandler(const ezIpcChannelEvent& e)
 {
-  if (m_pNewWorkSignal)
-  {
-    m_pNewWorkSignal->RaiseSignal();
-  }
+  // We explicitly do not handle the event as it is called in a separate thread. All handling of state changes happens in ezEditorProcessorProcess::Tick.
+  m_pNewWorkSignal->RaiseSignal();
 }
 
 bool ezEditorProcessorProcess::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState)
@@ -499,6 +500,7 @@ bool ezEditorProcessorProcess::GetNextAssetToProcess(ezUuid& out_guid, ezDataDir
 void ezEditorProcessorProcess::OnProcessCrashed(ezStringView message)
 {
   ShutdownProcess();
+  m_State = (m_State == State::Processing || m_State == State::ReadyForProcessing) ? State::ReportResult : State::Crashed;
   m_Status = ezStatus(message);
   ezLogEntryDelegate logger([this](ezLogEntry& ref_entry)
     { m_LogEntries.PushBack(std::move(ref_entry)); });
@@ -512,7 +514,7 @@ void ezEditorProcessorProcess::RequestRestart()
   if (m_State == State::Crashed)
   {
     ezLog::Info(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Restarting crashed processor {}", m_uiProcessorID);
-    m_State = State::LookingForWork;
+    m_State = State::StartClient;
   }
 }
 
@@ -625,10 +627,54 @@ void ezEditorProcessorProcess::HandleHashMissmatch()
 bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
 {
   EZ_PROFILE_SCOPE("ezEditorProcessorProcess::Tick");
+  if (m_State != State::StartClient && m_State != State::Crashed)
+  {
+    if (!m_pIPC->IsClientAlive())
+    {
+      // Will transition to Crashed or ReportResult
+      OnProcessCrashed("Asset processor crashed while waiting for connection");
+    }
+  }
+
+  if (m_State >= State::LookingForWork && m_State <= State::Processing)
+  {
+    if (!m_pIPC->IsConnected())
+    {
+      // Will transition to Crashed or ReportResult
+      OnProcessCrashed("Asset processor IPC channel is not connected");
+    }
+  }
+
   while (true)
   {
     switch (m_State)
     {
+      case State::StartClient:
+      {
+        if (StartProcess().Failed())
+        {
+          OnProcessCrashed("Asset processor did not launch");
+          m_State = State::Crashed;
+          return false; // don't call later
+        }
+        else
+        {
+          m_State = State::WaitingForConnection;
+          return bStartNewWork;
+        }
+      }
+      break;
+
+      case State::WaitingForConnection:
+      {
+        if (m_pIPC->IsConnected())
+        {
+          m_State = State::LookingForWork;
+          break;
+        }
+        return bStartNewWork;
+      }
+      break;
       case State::LookingForWork:
       {
         if (!bStartNewWork)
@@ -656,6 +702,7 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
         m_StartedProcessing = {};
         m_StartedTransform = {};
         m_FinishedProcessing = {};
+
         {
           auto pCurator = ezAssetCurator::GetSingleton();
 
@@ -702,41 +749,11 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
           }
         }
 
-        if (!m_pIPC->IsClientAlive() || !m_pIPC->IsConnected())
-        {
-          if (StartProcess().Failed())
-          {
-            m_State = State::ReportResult;
-            OnProcessCrashed("Asset processor did not launch");
-          }
-          else
-          {
-            m_State = State::WaitingForConnection;
-            return true; // call again later
-          }
-        }
-        else
-        {
-          m_State = State::Ready;
-        }
+        m_State = State::ReadyForProcessing;
       }
       break;
-      case State::WaitingForConnection:
-      {
-        if (!m_pIPC->IsClientAlive())
-        {
-          m_State = State::ReportResult;
-          OnProcessCrashed("Asset processor crashed while waiting for connection");
-          break;
-        }
 
-        if (m_pIPC->IsConnected())
-        {
-          m_State = State::Ready;
-        }
-      }
-      break;
-      case State::Ready:
+      case State::ReadyForProcessing:
       {
         ezLog::Info(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Processing '{0}'", m_AssetPath.GetDataDirRelativePath());
 
@@ -770,8 +787,8 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
         }
         else
         {
-          m_State = State::ReportResult;
           OnProcessCrashed("Asset processor crashed, failed to send message");
+          break;
         }
       }
       break;
@@ -779,13 +796,7 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
       {
         EZ_PROFILE_SCOPE("ezEditorProcessorProcess::Processing");
         m_pIPC->ProcessMessages();
-        if (!m_pIPC->IsClientAlive())
-        {
-          OnProcessCrashed("Asset Processor crashed during processing");
-          m_State = State::ReportResult;
-        }
-        if (m_State == State::Processing)
-          return true; // call again later
+        return true; // call again later
       }
       break;
       case State::ReportResult:

--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
@@ -24,14 +24,22 @@ ezResult ezEditorProcessCommunicationChannel::StartClientProcess(const char* szP
   sMemName.SetFormat("{0}", ezArgU(uiUniqueHash, 16, true, 16, true));
   ++uiUniqueHash;
 
+  ezResult res = EZ_SUCCESS;
   if (bRemote)
   {
-    CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel("172.16.80.3:1050", ezIpcChannel::Mode::Client));
+    res = CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel("172.16.80.3:1050", ezIpcChannel::Mode::Client));
   }
   else
   {
-    CreateAndConnectChannel(ezIpcChannel::CreatePipeChannel(sMemName, ezIpcChannel::Mode::Server));
+    res = CreateAndConnectChannel(ezIpcChannel::CreatePipeChannel(sMemName, ezIpcChannel::Mode::Server));
   }
+  if (res.Failed())
+  {
+    ezLog::Error("IpcChannel: CreateAndConnectChannel failed");
+    CloseConnection();
+    return EZ_FAILURE;
+  }
+
   for (ezUInt32 i = 0; i < 100; i++)
   {
     if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connecting)
@@ -117,11 +125,16 @@ ezResult ezEditorProcessRemoteCommunicationChannel::ConnectToServer(const char* 
   EZ_LOG_BLOCK("ezEditorProcessRemoteCommunicationChannel::ConnectToServer");
   EZ_ASSERT_DEV(m_pChannel == nullptr, "ProcessCommunication object already in use");
   m_pFirstAllowedMessageType = nullptr;
-  CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel(szAddress, ezIpcChannel::Mode::Client));
+  if (CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel(szAddress, ezIpcChannel::Mode::Client)).Failed())
+  {
+    ezLog::Error("IpcChannel: CreateAndConnectChannel failed");
+    CloseConnection();
+    return EZ_FAILURE;
+  }
 
   for (ezUInt32 i = 0; i < 200; i++)
   {
-    if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connected)
+    if (m_pChannel->GetConnectionState() != ezIpcChannel::ConnectionState::Connecting)
       break;
 
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(10));
@@ -149,8 +162,8 @@ void ezEditorProcessRemoteCommunicationChannel::CloseConnection()
 
 void ezEditorProcessRemoteCommunicationChannel::TryConnect()
 {
-  if (m_pChannel && !m_pChannel->IsConnected())
+  if (m_pChannel && m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Disconnected)
   {
-    m_pChannel->Connect();
+    m_pChannel->Connect().IgnoreResult();
   }
 }

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -323,6 +323,7 @@ public:
       else
       {
         ezLog::Error("Failed to connect with host process");
+        this->SetReturnCode(200);
       }
     }
   }

--- a/Code/Engine/Foundation/Communication/Implementation/IpcChannel.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcChannel.cpp
@@ -21,8 +21,8 @@ ezIpcChannel::ezIpcChannel(ezStringView sAddress, Mode::Enum mode)
   , m_pOwner(ezMessageLoop::GetSingleton())
 {
   EZ_TRACE_EVENT("IpcChannel_Created", ezTraceLevel::Info,
-          EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
-          EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
+    EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+    EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
 }
 
 ezIpcChannel::~ezIpcChannel()
@@ -65,8 +65,8 @@ ezInternal::NewInstance<ezIpcChannel> ezIpcChannel::CreateNetworkChannel(ezStrin
 ezResult ezIpcChannel::Connect()
 {
   EZ_TRACE_EVENT("IpcChannel_Connect", ezTraceLevel::Info,
-            EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
-            EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
+    EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+    EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
 
   ezEnum<ConnectionState> newState = ConnectionState::Connecting;
   ezEnum<ConnectionState> previousState = m_ConnectionState.CompareAndSwap(ConnectionState::Disconnected, newState);
@@ -88,8 +88,8 @@ ezResult ezIpcChannel::Connect()
 void ezIpcChannel::Disconnect()
 {
   EZ_TRACE_EVENT("IpcChannel_Disconnect", ezTraceLevel::Info,
-          EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
-          EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
+    EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+    EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
 
   EZ_LOCK(m_pOwner->m_TasksMutex);
   m_pOwner->m_DisconnectQueue.PushBack(this);
@@ -225,9 +225,9 @@ void ezIpcChannel::FlushPendingOperations()
 void ezIpcChannel::LogAndBroadcastConnectionState(ezEnum<ConnectionState> previousState, ezEnum<ConnectionState> currentState)
 {
   EZ_TRACE_EVENT("IpcChannel_StateChanged", ezTraceLevel::Info,
-        EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
-        EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()),
-        EZ_TRACE_VALUE("OldState", previousState.GetValue()),
-        EZ_TRACE_VALUE("NewState", currentState.GetValue()));
+    EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+    EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()),
+    EZ_TRACE_VALUE("OldState", previousState.GetValue()),
+    EZ_TRACE_VALUE("NewState", currentState.GetValue()));
   m_Events.Broadcast(ezIpcChannelEvent((ezIpcChannelEvent::Type)currentState.GetValue(), this));
 }

--- a/Code/Engine/Foundation/Communication/Implementation/IpcChannel.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcChannel.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/Communication/IpcChannel.h>
 #include <Foundation/Communication/RemoteMessage.h>
 #include <Foundation/Logging/Log.h>
+#include <Foundation/Tracing/TraceProvider.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_IPC)
 #  include <PipeChannel_Platform.h>
@@ -19,6 +20,9 @@ ezIpcChannel::ezIpcChannel(ezStringView sAddress, Mode::Enum mode)
   , m_Mode(mode)
   , m_pOwner(ezMessageLoop::GetSingleton())
 {
+  EZ_TRACE_EVENT("IpcChannel_Created", ezTraceLevel::Info,
+          EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+          EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
 }
 
 ezIpcChannel::~ezIpcChannel()
@@ -58,16 +62,35 @@ ezInternal::NewInstance<ezIpcChannel> ezIpcChannel::CreateNetworkChannel(ezStrin
 #endif
 }
 
-void ezIpcChannel::Connect()
+ezResult ezIpcChannel::Connect()
 {
+  EZ_TRACE_EVENT("IpcChannel_Connect", ezTraceLevel::Info,
+            EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+            EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
+
+  ezEnum<ConnectionState> newState = ConnectionState::Connecting;
+  ezEnum<ConnectionState> previousState = m_ConnectionState.CompareAndSwap(ConnectionState::Disconnected, newState);
+
+  if (previousState != ConnectionState::Disconnected)
+  {
+    return EZ_FAILURE;
+  }
+
+  LogAndBroadcastConnectionState(previousState, newState);
+
   EZ_LOCK(m_pOwner->m_TasksMutex);
   m_pOwner->m_ConnectQueue.PushBack(this);
   m_pOwner->WakeUp();
+  return EZ_SUCCESS;
 }
 
 
 void ezIpcChannel::Disconnect()
 {
+  EZ_TRACE_EVENT("IpcChannel_Disconnect", ezTraceLevel::Info,
+          EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+          EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()));
+
   EZ_LOCK(m_pOwner->m_TasksMutex);
   m_pOwner->m_DisconnectQueue.PushBack(this);
   m_pOwner->WakeUp();
@@ -125,11 +148,10 @@ ezResult ezIpcChannel::WaitForMessages(ezTime timeout)
 
 void ezIpcChannel::SetConnectionState(ezEnum<ezIpcChannel::ConnectionState> state)
 {
-  const ezEnum<ezIpcChannel::ConnectionState> oldValue = m_ConnectionState.Set(state);
-
-  if (state != oldValue)
+  ezEnum<ConnectionState> previousState = m_ConnectionState.Set(state);
+  if (state != previousState)
   {
-    m_Events.Broadcast(ezIpcChannelEvent((ezIpcChannelEvent::Type)state.GetValue(), this));
+    LogAndBroadcastConnectionState(previousState, state);
   }
 }
 
@@ -198,4 +220,14 @@ void ezIpcChannel::ReceiveData(ezArrayPtr<const ezUInt8> data)
 void ezIpcChannel::FlushPendingOperations()
 {
   m_pOwner->WaitForMessages(-1, this);
+}
+
+void ezIpcChannel::LogAndBroadcastConnectionState(ezEnum<ConnectionState> previousState, ezEnum<ConnectionState> currentState)
+{
+  EZ_TRACE_EVENT("IpcChannel_StateChanged", ezTraceLevel::Info,
+        EZ_TRACE_VALUE("Address", m_sAddress.GetData()),
+        EZ_TRACE_VALUE("Mode", (int)m_Mode.GetValue()),
+        EZ_TRACE_VALUE("OldState", previousState.GetValue()),
+        EZ_TRACE_VALUE("NewState", currentState.GetValue()));
+  m_Events.Broadcast(ezIpcChannelEvent((ezIpcChannelEvent::Type)currentState.GetValue(), this));
 }

--- a/Code/Engine/Foundation/Communication/Implementation/IpcChannelEnet.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcChannelEnet.cpp
@@ -22,6 +22,7 @@ ezIpcChannelEnet::ezIpcChannelEnet(ezStringView sAddress, Mode::Enum mode)
 
 ezIpcChannelEnet::~ezIpcChannelEnet()
 {
+  m_pNetwork->m_RemoteEvents.RemoveEventHandler(ezMakeDelegate(&ezIpcChannelEnet::EnetEventHandler, this));
   m_pNetwork->ShutdownConnection();
 
   m_pOwner->RemoveChannel(this);
@@ -29,32 +30,31 @@ ezIpcChannelEnet::~ezIpcChannelEnet()
 
 void ezIpcChannelEnet::InternalConnect()
 {
+  if (GetConnectionState() != ConnectionState::Connecting)
+    return;
+
   if (m_Mode == Mode::Server)
   {
-    m_pNetwork->StartServer('RMOT', m_sAddress, false).IgnoreResult();
-    SetConnectionState(ConnectionState::Connecting);
+    if (m_pNetwork->StartServer('RMOT', m_sAddress, false).Failed())
+    {
+      SetConnectionState(ConnectionState::Disconnected);
+      return;
+    }
   }
   else
   {
-    SetConnectionState(ConnectionState::Connecting);
-    if ((m_sLastAddress != m_sAddress) || (ezTime::Now() - m_LastConnectAttempt > ezTime::MakeFromSeconds(10)))
+    if (m_pNetwork->ConnectToServer('RMOT', m_sAddress, false).Failed())
     {
-      m_sLastAddress = m_sAddress;
-      m_LastConnectAttempt = ezTime::Now();
-      m_pNetwork->ConnectToServer('RMOT', m_sAddress, false).AssertSuccess();
+      SetConnectionState(ConnectionState::Disconnected);
+      return;
     }
-
-    m_pNetwork->WaitForConnectionToServer(ezTime::MakeFromMilliseconds(10.0)).IgnoreResult();
+    m_LastConnectAttempt = ezTime::Now();
   }
-
-  SetConnectionState(m_pNetwork->IsConnectedToOther() ? ConnectionState::Connected : ConnectionState::Disconnected);
 }
 
 void ezIpcChannelEnet::InternalDisconnect()
 {
   m_pNetwork->ShutdownConnection();
-  m_pNetwork->m_RemoteEvents.RemoveEventHandler(ezMakeDelegate(&ezIpcChannelEnet::EnetEventHandler, this));
-
   SetConnectionState(ConnectionState::Disconnected);
 }
 
@@ -85,8 +85,27 @@ void ezIpcChannelEnet::Tick()
 {
   m_pNetwork->UpdateRemoteInterface();
 
-  SetConnectionState(m_pNetwork->IsConnectedToOther() ? ConnectionState::Connected : ConnectionState::Disconnected);
+  if (GetConnectionState() == ConnectionState::Connecting)
+  {
+    if (m_pNetwork->IsConnectedToOther())
+    {
+      m_LastConnectAttempt = ezTime::MakeZero();
+      SetConnectionState(ConnectionState::Connected);
+    }
+    else if (m_Mode == Mode::Client && !m_LastConnectAttempt.IsZero() && ezTime::Now() - m_LastConnectAttempt > ezTime::MakeFromSeconds(2))
+    {
+      m_LastConnectAttempt = ezTime::MakeZero();
+      SetConnectionState(ConnectionState::Disconnected);
+    }
+  }
 
+  if (!m_pNetwork->IsConnectedToOther())
+  {
+    if (GetConnectionState() == ConnectionState::Connected)
+    {
+      SetConnectionState(ConnectionState::Disconnected);
+    }
+  }
   m_pNetwork->ExecuteAllMessageHandlers();
 }
 
@@ -97,15 +116,25 @@ void ezIpcChannelEnet::NetworkMessageHandler(ezRemoteMessage& msg)
 
 void ezIpcChannelEnet::EnetEventHandler(const ezRemoteEvent& e)
 {
+  if (e.m_Type == ezRemoteEvent::ConnectedToClient)
+  {
+    SetConnectionState(ConnectionState::Connected);
+  }
+
   if (e.m_Type == ezRemoteEvent::DisconnectedFromServer)
   {
-    ezLog::Info("Disconnected from remote engine process.");
     Disconnect();
+  }
+
+  if (e.m_Type == ezRemoteEvent::DisconnectedFromClient)
+  {
+    SetConnectionState(ConnectionState::Disconnected);
   }
 
   if (e.m_Type == ezRemoteEvent::ConnectedToServer)
   {
-    ezLog::Info("Connected to remote engine process.");
+    m_LastConnectAttempt = ezTime::MakeZero();
+    SetConnectionState(ConnectionState::Connected);
   }
 }
 

--- a/Code/Engine/Foundation/Communication/Implementation/IpcChannelEnet.h
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcChannelEnet.h
@@ -25,8 +25,7 @@ protected:
   void EnetEventHandler(const ezRemoteEvent& e);
 
   ezString m_sAddress;
-  ezString m_sLastAddress;
-  ezTime m_LastConnectAttempt;
+  ezTime m_LastConnectAttempt = ezTime::MakeZero();
   ezUniquePtr<ezRemoteInterface> m_pNetwork;
 };
 

--- a/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
@@ -37,7 +37,7 @@ ezIpcProcessMessageProtocol::~ezIpcProcessMessageProtocol()
 bool ezIpcProcessMessageProtocol::Send(ezProcessMessage* pMsg)
 {
   ezStringBuilder sTypeName = pMsg->GetDynamicRTTI()->GetTypeName();
-  ezUInt64 uiMessageId = (ezUInt64)m_uiSendMessageId.Increment();
+  ezUInt64 uiMessageId = (ezUInt64)m_iSendMessageId.Increment();
   [[maybe_unused]] ezUInt64 uiRequestId = m_uiSendChannelId + uiMessageId;
   pMsg->m_uiMessageId = uiMessageId;
 

--- a/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
@@ -6,9 +6,21 @@
 // #include <Foundation/Communication/RemoteMessage.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Serialization/ReflectionSerializer.h>
+#include <Foundation/Tracing/TraceProvider.h>
 
 ezIpcProcessMessageProtocol::ezIpcProcessMessageProtocol(ezIpcChannel* pChannel)
 {
+  ezStringView sAddress = pChannel->GetAddress();
+
+  m_uiReceiveChannelId = ezHashingUtils::xxHash64String(sAddress);
+  m_uiSendChannelId = ezHashingUtils::xxHash64String(sAddress, 1337);
+
+  if (pChannel->GetMode() == ezIpcChannel::Mode::Client)
+  {
+    // To make sure telemetry events can be correlated, the client swaps the stable channel IDs.
+    std::swap(m_uiReceiveChannelId, m_uiSendChannelId);
+  }
+
   m_pChannel = pChannel;
   m_pChannel->SetReceiveCallback(ezMakeDelegate(&ezIpcProcessMessageProtocol::ReceiveMessageData, this));
 }
@@ -24,9 +36,20 @@ ezIpcProcessMessageProtocol::~ezIpcProcessMessageProtocol()
 
 bool ezIpcProcessMessageProtocol::Send(ezProcessMessage* pMsg)
 {
+  ezStringBuilder sTypeName = pMsg->GetDynamicRTTI()->GetTypeName();
+  ezUInt64 uiMessageId = (ezUInt64)m_uiSendMessageId.Increment();
+  ezUInt64 uiRequestId = m_uiSendChannelId + uiMessageId;
+  pMsg->m_uiMessageId = uiMessageId;
+
   ezContiguousMemoryStreamStorage storage;
   ezMemoryStreamWriter writer(&storage);
   ezReflectionSerializer::WriteObjectToBinary(writer, pMsg->GetDynamicRTTI(), pMsg);
+
+  EZ_TRACE_ASYNC_BEGIN("IpcProtocol_Send", uiRequestId, ezTraceLevel::Info,
+    EZ_TRACE_VALUE("Address", m_pChannel->GetAddress().GetStartPointer()), // Safe as underlying storage is ezString
+    EZ_TRACE_VALUE("MessageId", uiMessageId),
+    EZ_TRACE_VALUE("Type", sTypeName.GetData()));
+
   return m_pChannel->Send(ezArrayPtr<const ezUInt8>(storage.GetData(), storage.GetStorageSize32()));
 }
 
@@ -36,6 +59,14 @@ bool ezIpcProcessMessageProtocol::ProcessMessages()
 
   while (ezUniquePtr<ezProcessMessage> msg = PopMessage())
   {
+    ezUInt64 uiRequestId = m_uiReceiveChannelId + msg->m_uiMessageId;
+    ezStringBuilder sTypeName = msg->GetDynamicRTTI()->GetTypeName();
+    EZ_TRACE_ASYNC_END("IpcProtocol_Send", uiRequestId);
+
+    EZ_TRACE_EVENT("IpcProtocol_Receive", ezTraceLevel::Info,
+      EZ_TRACE_VALUE("Address", m_pChannel->GetAddress().GetStartPointer()), // Safe as underlying storage is ezString
+      EZ_TRACE_VALUE("MessageId", msg->m_uiMessageId),
+      EZ_TRACE_VALUE("Type", sTypeName.GetData()));
     messagesPresent = true;
     Event e;
     e.m_pMessage = msg.Borrow();

--- a/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
@@ -38,7 +38,7 @@ bool ezIpcProcessMessageProtocol::Send(ezProcessMessage* pMsg)
 {
   ezStringBuilder sTypeName = pMsg->GetDynamicRTTI()->GetTypeName();
   ezUInt64 uiMessageId = (ezUInt64)m_uiSendMessageId.Increment();
-  ezUInt64 uiRequestId = m_uiSendChannelId + uiMessageId;
+  [[maybe_unused]] ezUInt64 uiRequestId = m_uiSendChannelId + uiMessageId;
   pMsg->m_uiMessageId = uiMessageId;
 
   ezContiguousMemoryStreamStorage storage;
@@ -59,7 +59,7 @@ bool ezIpcProcessMessageProtocol::ProcessMessages()
 
   while (ezUniquePtr<ezProcessMessage> msg = PopMessage())
   {
-    ezUInt64 uiRequestId = m_uiReceiveChannelId + msg->m_uiMessageId;
+    [[maybe_unused]] ezUInt64 uiRequestId = m_uiReceiveChannelId + msg->m_uiMessageId;
     ezStringBuilder sTypeName = msg->GetDynamicRTTI()->GetTypeName();
     EZ_TRACE_ASYNC_END("IpcProtocol_Send", uiRequestId);
 

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
@@ -92,6 +92,8 @@ void ezRemoteInterface::ShutdownConnection()
     m_RemoteMode = ezRemoteMode::None;
     m_uiApplicationID = 0;
     m_uiConnectionToken = 0;
+    m_uiConnectedToServerWithID = 0;
+    m_iConnectionsToClients = 0;
   }
 }
 

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterfaceEnet.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterfaceEnet.cpp
@@ -135,6 +135,7 @@ void ezRemoteInterfaceEnetImpl::InternalShutdownConnection()
 
   // enet_deinitialize();
   m_pEnetConnectionToServer = nullptr;
+  m_EnetPeerToClientID.Clear();
 }
 
 ezTime ezRemoteInterfaceEnetImpl::InternalGetPingToServer()

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteMessage.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteMessage.cpp
@@ -4,6 +4,13 @@
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcessMessage, 1, ezRTTIDefaultAllocator<ezProcessMessage>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("MessageId", m_uiMessageId),
+  }
+  EZ_END_PROPERTIES;
+}
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/Engine/Foundation/Communication/IpcChannel.h
+++ b/Code/Engine/Foundation/Communication/IpcChannel.h
@@ -75,7 +75,7 @@ public:
 
   static ezInternal::NewInstance<ezIpcChannel> CreateNetworkChannel(ezStringView sAddress, Mode::Enum mode);
 
-  ezEnum<Mode> GetMode() const { return m_Mode;}
+  ezEnum<Mode> GetMode() const { return m_Mode; }
   ezStringView GetAddress() const { return m_sAddress; }
 
   /// \brief Connects async. Returns whether the state was changed from Disconnected to Connecting.

--- a/Code/Engine/Foundation/Communication/IpcChannel.h
+++ b/Code/Engine/Foundation/Communication/IpcChannel.h
@@ -75,9 +75,11 @@ public:
 
   static ezInternal::NewInstance<ezIpcChannel> CreateNetworkChannel(ezStringView sAddress, Mode::Enum mode);
 
+  ezEnum<Mode> GetMode() const { return m_Mode;}
+  ezStringView GetAddress() const { return m_sAddress; }
 
-  /// \brief Connects async. On success, m_Events will be broadcasted.
-  void Connect();
+  /// \brief Connects async. Returns whether the state was changed from Disconnected to Connecting.
+  ezResult Connect();
   /// \brief Disconnect async. On completion, m_Events will be broadcasted.
   void Disconnect();
   /// \brief Returns whether we have a connection.
@@ -114,6 +116,7 @@ protected:
   /// \brief Called by Send to determine whether the message loop need to be woken up.
   virtual bool NeedWakeup() const = 0;
 
+  /// \brief Sets the connection state and calls LogAndBroadcastConnectionState.
   void SetConnectionState(ezEnum<ConnectionState> state);
   /// \brief Implementation needs to call this when new data has been received.
   ///  data can be invalidated after the function.
@@ -121,6 +124,8 @@ protected:
   void FlushPendingOperations();
 
 private:
+  void LogAndBroadcastConnectionState(ezEnum<ConnectionState> previousState, ezEnum<ConnectionState> currentState);
+
 protected:
   enum Constants : ezUInt32
   {

--- a/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
+++ b/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
@@ -45,7 +45,7 @@ private:
 
 private:
   ezIpcChannel* m_pChannel = nullptr;
-  ezUInt64 m_uiSendChannelId = 0; // UniqueID derived from channel address to correlate telemetry across processes.
+  ezUInt64 m_uiSendChannelId = 0;    // UniqueID derived from channel address to correlate telemetry across processes.
   ezUInt64 m_uiReceiveChannelId = 0; // UniqueID derived from channel address to correlate telemetry across processes.
   ezAtomicInteger64 m_uiSendMessageId = 0;
 

--- a/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
+++ b/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
@@ -45,6 +45,9 @@ private:
 
 private:
   ezIpcChannel* m_pChannel = nullptr;
+  ezUInt64 m_uiSendChannelId = 0; // UniqueID derived from channel address to correlate telemetry across processes.
+  ezUInt64 m_uiReceiveChannelId = 0; // UniqueID derived from channel address to correlate telemetry across processes.
+  ezAtomicInteger64 m_uiSendMessageId = 0;
 
   ezMutex m_IncomingQueueMutex;
   ezDeque<ezUniquePtr<ezProcessMessage>> m_IncomingQueue;

--- a/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
+++ b/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
@@ -47,7 +47,7 @@ private:
   ezIpcChannel* m_pChannel = nullptr;
   ezUInt64 m_uiSendChannelId = 0;    // UniqueID derived from channel address to correlate telemetry across processes.
   ezUInt64 m_uiReceiveChannelId = 0; // UniqueID derived from channel address to correlate telemetry across processes.
-  ezAtomicInteger64 m_uiSendMessageId = 0;
+  ezAtomicInteger64 m_iSendMessageId = 0;
 
   ezMutex m_IncomingQueueMutex;
   ezDeque<ezUniquePtr<ezProcessMessage>> m_IncomingQueue;

--- a/Code/Engine/Foundation/Communication/RemoteMessage.h
+++ b/Code/Engine/Foundation/Communication/RemoteMessage.h
@@ -66,4 +66,5 @@ class EZ_FOUNDATION_DLL ezProcessMessage : public ezReflectedClass
 
 public:
   ezProcessMessage() = default;
+  ezUInt64 m_uiMessageId = 0;
 };

--- a/Code/Engine/Foundation/Platform/Linux/PipeChannel_Linux.cpp
+++ b/Code/Engine/Foundation/Platform/Linux/PipeChannel_Linux.cpp
@@ -61,7 +61,7 @@ ezPipeChannel_linux::~ezPipeChannel_linux()
 
 void ezPipeChannel_linux::InternalConnect()
 {
-  if (GetConnectionState() != ConnectionState::Disconnected)
+  if (GetConnectionState() != ConnectionState::Connecting)
     return;
 
   int& targetSocket = (m_Mode == Mode::Server) ? m_serverSocketFd : m_clientSocketFd;
@@ -74,6 +74,7 @@ void ezPipeChannel_linux::InternalConnect()
     if (targetSocket == -1)
     {
       ezLog::Error("[IPC]Failed to create unix domain socket. error {}", errno);
+      SetConnectionState(ConnectionState::Disconnected);
       return;
     }
 
@@ -88,6 +89,7 @@ void ezPipeChannel_linux::InternalConnect()
       ezLog::Error("[IPC]Given ipc channel address is to long. Resulting path '{}' path length limit {}", strlen(thisSocketPath), EZ_ARRAY_SIZE(addr.sun_path) - 1);
       close(targetSocket);
       targetSocket = -1;
+      SetConnectionState(ConnectionState::Disconnected);
       return;
     }
 
@@ -97,6 +99,7 @@ void ezPipeChannel_linux::InternalConnect()
       ezLog::Error("[IPC]Failed to bind unix domain socket to '{}' error {}", thisSocketPath, errno);
       close(targetSocket);
       targetSocket = -1;
+      SetConnectionState(ConnectionState::Disconnected);
       return;
     }
   }
@@ -105,19 +108,24 @@ void ezPipeChannel_linux::InternalConnect()
   {
     if (m_serverSocketFd < 0)
     {
+      SetConnectionState(ConnectionState::Disconnected);
       return;
     }
-    listen(m_serverSocketFd, 1);
-    SetConnectionState(ConnectionState::Connecting);
+    if (listen(m_serverSocketFd, 1) != 0)
+    {
+      ezLog::Error("[IPC]Failed to listen on unix domain socket. Error {}", errno);
+      SetConnectionState(ConnectionState::Disconnected);
+      return;
+    }
     static_cast<ezMessageLoop_linux*>(m_pOwner)->RegisterWait(this, ezMessageLoop_linux::WaitType::Accept, m_serverSocketFd);
   }
   else
   {
     if (m_clientSocketFd < 0)
     {
+      SetConnectionState(ConnectionState::Disconnected);
       return;
     }
-    SetConnectionState(ConnectionState::Connecting);
     struct sockaddr_un serverAddress = {};
     serverAddress.sun_family = AF_UNIX;
     strcpy(serverAddress.sun_path, m_serverSocketPath.GetData());
@@ -230,6 +238,15 @@ bool ezPipeChannel_linux::NeedWakeup() const
 
 void ezPipeChannel_linux::ProcessConnectSuccessfull()
 {
+  int errorCode = 0;
+  socklen_t errorCodeSize = sizeof(errorCode);
+  if (getsockopt(m_clientSocketFd, SOL_SOCKET, SO_ERROR, &errorCode, &errorCodeSize) != 0 || errorCode != 0)
+  {
+    ezLog::Error("[IPC]Failed to connect unix domain socket. Error {}", errorCode != 0 ? errorCode : errno);
+    InternalDisconnect();
+    return;
+  }
+
   SetConnectionState(ConnectionState::Connected);
 
   // We are connected. Register for incoming messages events.

--- a/Code/Engine/Foundation/Platform/Linux/ProcessGroup_Linux.cpp
+++ b/Code/Engine/Foundation/Platform/Linux/ProcessGroup_Linux.cpp
@@ -1,5 +1,66 @@
 #include <Foundation/FoundationPCH.h>
 
-#if EZ_ENABLED(EZ_PLATFORM_LINUX)
-#  include <Foundation/Platform/NoImpl/ProcessGroup_NoImpl.h>
+#if EZ_ENABLED(EZ_PLATFORM_LINUX) && EZ_ENABLED(EZ_SUPPORTS_PROCESSES)
+
+#  include <Foundation/System/ProcessGroup.h>
+
+namespace ezInternal
+{
+  bool SetProcessLaunchParentDeathSignal(bool bEnable);
+}
+
+struct ezProcessGroupImpl
+{
+  EZ_DECLARE_POD_TYPE();
+};
+
+ezProcessGroup::ezProcessGroup(ezStringView sGroupName)
+{
+  EZ_IGNORE_UNUSED(sGroupName);
+}
+
+ezProcessGroup::~ezProcessGroup()
+{
+  TerminateAll().IgnoreResult();
+}
+
+ezResult ezProcessGroup::Launch(const ezProcessOptions& opt)
+{
+  ezProcess& process = m_Processes.ExpandAndGetRef();
+
+  const bool bPreviousValue = ezInternal::SetProcessLaunchParentDeathSignal(true);
+  ezResult result = process.Launch(opt);
+  ezInternal::SetProcessLaunchParentDeathSignal(bPreviousValue);
+
+  return result;
+}
+
+ezResult ezProcessGroup::WaitToFinish(ezTime timeout /*= ezTime::MakeZero()*/)
+{
+  for (auto& process : m_Processes)
+  {
+    if (process.GetState() != ezProcessState::Finished && process.WaitToFinish(timeout).Failed())
+    {
+      return EZ_FAILURE;
+    }
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezProcessGroup::TerminateAll(ezInt32 iForcedExitCode /*= -2*/)
+{
+  EZ_IGNORE_UNUSED(iForcedExitCode);
+
+  auto result = EZ_SUCCESS;
+  for (auto& process : m_Processes)
+  {
+    if (process.GetState() == ezProcessState::Running && process.Terminate().Failed())
+    {
+      result = EZ_FAILURE;
+    }
+  }
+
+  return result;
+}
 #endif

--- a/Code/Engine/Foundation/Platform/Posix/Process_Posix.inl
+++ b/Code/Engine/Foundation/Platform/Posix/Process_Posix.inl
@@ -9,6 +9,9 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
+#if EZ_ENABLED(EZ_USE_LINUX_POSIX_EXTENSIONS)
+#  include <sys/prctl.h>
+#endif
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -136,13 +139,59 @@ namespace
     enum class Type : ezUInt32
     {
       FailedToChangeWorkingDirectory = 0,
-      FailedToExecv = 1
+      FailedToExecv = 1,
+      FailedToSetParentDeathSignal = 2
     };
 
     Type type;
     int errorCode;
   };
+
+  static ezInt32 GetExitCodeFromWaitStatus(int childStatus)
+  {
+    if (WIFEXITED(childStatus))
+    {
+      return WEXITSTATUS(childStatus);
+    }
+
+    if (WIFSIGNALED(childStatus))
+    {
+      return WTERMSIG(childStatus);
+    }
+
+    return -1;
+  }
+
+  static pid_t WaitPidInterruptedRetry(pid_t childPid, int* pChildStatus, int iOptions)
+  {
+    pid_t waitedPid = -1;
+    do
+    {
+      waitedPid = waitpid(childPid, pChildStatus, iOptions);
+    } while (waitedPid < 0 && errno == EINTR);
+
+    return waitedPid;
+  }
 } // namespace
+
+#if EZ_ENABLED(EZ_USE_LINUX_POSIX_EXTENSIONS)
+namespace ezInternal
+{
+  static thread_local bool s_bSetProcessParentDeathSignal = false;
+
+  bool SetProcessLaunchParentDeathSignal(bool bEnable)
+  {
+    const bool bPrevious = s_bSetProcessParentDeathSignal;
+    s_bSetProcessParentDeathSignal = bEnable;
+    return bPrevious;
+  }
+
+  static bool GetProcessLaunchParentDeathSignal()
+  {
+    return s_bSetProcessParentDeathSignal;
+  }
+} // namespace ezInternal
+#endif
 
 
 struct ezProcessImpl
@@ -400,6 +449,20 @@ struct ezProcessImpl
       return EZ_FAILURE;
     }
 
+#if EZ_ENABLED(EZ_USE_LINUX_POSIX_EXTENSIONS)
+    const bool bSetParentDeathSignal = ezInternal::GetProcessLaunchParentDeathSignal();
+    const pid_t parentPid = getpid();
+#endif
+
+    ezHybridArray<char*, 9> args;
+
+    args.PushBack(const_cast<char*>(executablePath.GetData()));
+    for (const ezString& arg : opt.m_Arguments)
+    {
+      args.PushBack(const_cast<char*>(arg.GetData()));
+    }
+    args.PushBack(nullptr);
+
     pid_t childPid = fork();
     if (childPid < 0)
     {
@@ -408,6 +471,25 @@ struct ezProcessImpl
 
     if (childPid == 0) // We are the child
     {
+      // DANGER! We are the child process and are now working on a shadow copy of the parent process including the state of all locks etc. This means that if we hit any locks, e.g. by allocating memory we will deadlock if at the point of fork the lock was held by a different thread. So between this line and the call to `execv` we must not make any allocations or access any high level code.
+#if EZ_ENABLED(EZ_USE_LINUX_POSIX_EXTENSIONS)
+      if (bSetParentDeathSignal)
+      {
+        if (prctl(PR_SET_PDEATHSIG, SIGKILL) != 0)
+        {
+          auto err = ProcessStartupError{ProcessStartupError::Type::FailedToSetParentDeathSignal, errno};
+          EZ_IGNORE_UNUSED(write(startupErrorPipe[1].Borrow(), &err, sizeof(err)));
+          startupErrorPipe[1].Close();
+          _exit(-1);
+        }
+
+        if (getppid() != parentPid)
+        {
+          _exit(-1);
+        }
+      }
+#endif
+
       if (suspended)
       {
         if (raise(SIGSTOP) < 0)
@@ -459,15 +541,6 @@ struct ezProcessImpl
 
       startupErrorPipe[0].Close(); // we don't need the read end of the startup error pipe in the child process
 
-      ezHybridArray<char*, 9> args;
-
-      args.PushBack(const_cast<char*>(executablePath.GetData()));
-      for (const ezString& arg : opt.m_Arguments)
-      {
-        args.PushBack(const_cast<char*>(arg.GetData()));
-      }
-      args.PushBack(nullptr);
-
       if (!opt.m_sWorkingDirectory.IsEmpty())
       {
         if (chdir(opt.m_sWorkingDirectory.GetData()) < 0)
@@ -510,6 +583,9 @@ struct ezProcessImpl
             break;
           case ProcessStartupError::Type::FailedToExecv:
             ezLog::Error("Failed to exec when starting process '{}' the error code is '{}'", opt.m_sProcess, err.errorCode);
+            break;
+          case ProcessStartupError::Type::FailedToSetParentDeathSignal:
+            ezLog::Error("Failed to configure parent death signal when starting process '{}' the error code is '{}'", opt.m_sProcess, err.errorCode);
             break;
         }
         return EZ_FAILURE;
@@ -578,25 +654,14 @@ ezResult ezProcess::Execute(const ezProcessOptions& opt, ezInt32* out_iExitCode 
   }
 
   int childStatus = -1;
-  pid_t waitedPid = waitpid(childPid, &childStatus, 0);
+  pid_t waitedPid = WaitPidInterruptedRetry(childPid, &childStatus, 0);
   if (waitedPid < 0)
   {
     return EZ_FAILURE;
   }
   if (out_iExitCode != nullptr)
   {
-    if (WIFEXITED(childStatus))
-    {
-      *out_iExitCode = WEXITSTATUS(childStatus);
-    }
-    else if (WIFSIGNALED(childStatus))
-    {
-      *out_iExitCode = WTERMSIG(childStatus);
-    }
-    else
-    {
-      *out_iExitCode = -1;
-    }
+    *out_iExitCode = GetExitCodeFromWaitStatus(childStatus);
   }
   return EZ_SUCCESS;
 }
@@ -667,10 +732,10 @@ ezResult ezProcess::WaitToFinish(ezTime timeout /*= ezTime::MakeZero()*/)
   if (timeout.IsZero())
   {
     int childStatus = 0;
-    int waitResult = waitpid(m_pImpl->m_childPid, &childStatus, 0);
+    int waitResult = WaitPidInterruptedRetry(m_pImpl->m_childPid, &childStatus, 0);
     if (waitResult > 0)
     {
-      m_iExitCode = WEXITSTATUS(childStatus);
+      m_iExitCode = GetExitCodeFromWaitStatus(childStatus);
       m_pImpl->m_exitCodeAvailable = true;
 
       m_pImpl->StopStreamWatcher();
@@ -722,6 +787,16 @@ ezResult ezProcess::Terminate()
       return EZ_FAILURE;
     }
   }
+
+  int childStatus = 0;
+  if (WaitPidInterruptedRetry(m_pImpl->m_childPid, &childStatus, 0) < 0)
+  {
+    if (errno != ECHILD) // ECHILD = Process is not a child of the calling process or was already waited for
+    {
+      return EZ_FAILURE;
+    }
+  }
+
   m_pImpl->m_exitCodeAvailable = true;
   m_iExitCode = -1;
 
@@ -741,10 +816,10 @@ ezProcessState ezProcess::GetState() const
   }
 
   int childStatus = -1;
-  int waitResult = waitpid(m_pImpl->m_childPid, &childStatus, WNOHANG);
+  int waitResult = WaitPidInterruptedRetry(m_pImpl->m_childPid, &childStatus, WNOHANG);
   if (waitResult > 0)
   {
-    m_iExitCode = WEXITSTATUS(childStatus);
+    m_iExitCode = GetExitCodeFromWaitStatus(childStatus);
     m_pImpl->m_exitCodeAvailable = true;
 
     m_pImpl->StopStreamWatcher();

--- a/Code/Engine/Foundation/Platform/Win/PipeChannel_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/PipeChannel_Win.cpp
@@ -160,7 +160,7 @@ void ezPipeChannel_win::InternalDisconnect()
 
   if (bNeedsDisconnectedEvent)
   {
-    SetConnectionState(ConnectionState::Disconnected).IgnoreResult();
+    SetConnectionState(ConnectionState::Disconnected);
     // Raise in case another thread is waiting for new messages (as we would sleep forever otherwise).
     m_IncomingMessages.RaiseSignal();
   }
@@ -200,7 +200,7 @@ bool ezPipeChannel_win::ProcessConnection()
       m_InputState.IsPending = true;
       break;
     case ERROR_PIPE_CONNECTED:
-      SetConnectionState(ConnectionState::Connected).IgnoreResult();
+      SetConnectionState(ConnectionState::Connected);
       break;
     case ERROR_NO_DATA:
       return false;

--- a/Code/Engine/Foundation/Platform/Win/PipeChannel_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/PipeChannel_Win.cpp
@@ -80,7 +80,7 @@ bool ezPipeChannel_win::CreatePipe(ezStringView sAddress)
 
 void ezPipeChannel_win::InternalConnect()
 {
-  if (GetConnectionState() != ConnectionState::Disconnected)
+  if (GetConnectionState() != ConnectionState::Connecting)
     return;
 
 #  if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
@@ -89,15 +89,24 @@ void ezPipeChannel_win::InternalConnect()
 #  endif
 
   if (!CreatePipe(m_sAddress))
+  {
+    SetConnectionState(ConnectionState::Disconnected);
     return;
+  }
 
   if (m_hPipeHandle == INVALID_HANDLE_VALUE)
+  {
+    SetConnectionState(ConnectionState::Disconnected);
     return;
+  }
 
-  SetConnectionState(ConnectionState::Connecting);
   if (m_Mode == Mode::Server)
   {
-    ProcessConnection();
+    if (!ProcessConnection())
+    {
+      InternalDisconnect();
+      return;
+    }
   }
   else
   {
@@ -143,16 +152,15 @@ void ezPipeChannel_win::InternalDisconnect()
     FlushPendingOperations();
   }
 
-  bool bWasConnected = false;
+  const bool bNeedsDisconnectedEvent = GetConnectionState() != ConnectionState::Disconnected;
   {
     EZ_LOCK(m_OutputQueueMutex);
     m_OutputQueue.Clear();
-    bWasConnected = IsConnected();
   }
 
-  if (bWasConnected)
+  if (bNeedsDisconnectedEvent)
   {
-    SetConnectionState(ConnectionState::Disconnected);
+    SetConnectionState(ConnectionState::Disconnected).IgnoreResult();
     // Raise in case another thread is waiting for new messages (as we would sleep forever otherwise).
     m_IncomingMessages.RaiseSignal();
   }
@@ -192,7 +200,7 @@ bool ezPipeChannel_win::ProcessConnection()
       m_InputState.IsPending = true;
       break;
     case ERROR_PIPE_CONNECTED:
-      SetConnectionState(ConnectionState::Connected);
+      SetConnectionState(ConnectionState::Connected).IgnoreResult();
       break;
     case ERROR_NO_DATA:
       return false;
@@ -326,7 +334,10 @@ void ezPipeChannel_win::OnIOCompleted(IOContext* pContext, DWORD uiBytesTransfer
     if (!IsConnected())
     {
       if (!ProcessConnection())
+      {
+        InternalDisconnect();
         return;
+      }
 
       bool bHasOutput = false;
       {

--- a/Code/UnitTests/FoundationTest/Communication/IpcChannelTest.cpp
+++ b/Code/UnitTests/FoundationTest/Communication/IpcChannelTest.cpp
@@ -103,29 +103,31 @@ void TestIPCChannel(ezIpcChannel* pServer, ChannelTester* pServerTester, ezIpcCh
       EZ_TEST_BOOL(!res2.has_value());
     }
     {
-      pServer->Connect();
+      EZ_TEST_RESULT(pServer->Connect());
       auto res = pServerTester->WaitForEvents(ezTime::MakeFromMilliseconds(100));
       EZ_TEST_BOOL(res.has_value() && res->m_Type == ezIpcChannelEvent::Connecting);
       EZ_TEST_BOOL(pServer->GetConnectionState() == ezIpcChannel::ConnectionState::Connecting);
     }
     {
-      pClient->Connect();
+      EZ_TEST_RESULT(pClient->Connect());
       auto res = pClientTester->WaitForEvents(ezTime::MakeFromMilliseconds(100));
       EZ_TEST_BOOL(res.has_value() && res->m_Type == ezIpcChannelEvent::Connecting);
     }
-    auto res = pServerTester->WaitForEvents(ezTime::MakeFromSeconds(100));
+    auto res = pServerTester->WaitForEvents(ezTime::MakeFromSeconds(3));
     EZ_TEST_BOOL(res.has_value() && res->m_Type == ezIpcChannelEvent::Connected);
-    auto res2 = pClientTester->WaitForEvents(ezTime::MakeFromSeconds(100));
+    auto res2 = pClientTester->WaitForEvents(ezTime::MakeFromSeconds(3));
     EZ_TEST_BOOL(res2.has_value() && res2->m_Type == ezIpcChannelEvent::Connected);
 
-    EZ_TEST_BOOL(pServer->GetConnectionState() == ezIpcChannel::ConnectionState::Connected);
-    EZ_TEST_BOOL(pClient->GetConnectionState() == ezIpcChannel::ConnectionState::Connected);
+    if (!EZ_TEST_BOOL(pServer->GetConnectionState() == ezIpcChannel::ConnectionState::Connected))
+      return;
+    if (!EZ_TEST_BOOL(pClient->GetConnectionState() == ezIpcChannel::ConnectionState::Connected))
+      return;
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Connect When Already Connected")
   {
-    pServer->Connect();
-    pClient->Connect();
+    EZ_TEST_BOOL(pServer->Connect().Failed());
+    EZ_TEST_BOOL(pClient->Connect().Failed());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ClientSend")
@@ -173,13 +175,13 @@ void TestIPCChannel(ezIpcChannel* pServer, ChannelTester* pServerTester, ezIpcCh
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Reconnect")
   {
     {
-      pServer->Connect();
+      EZ_TEST_RESULT(pServer->Connect());
       auto res = pServerTester->WaitForEvents(ezTime::MakeFromMilliseconds(100));
       EZ_TEST_BOOL(res.has_value() && res->m_Type == ezIpcChannelEvent::Connecting);
       EZ_TEST_BOOL(pServer->GetConnectionState() == ezIpcChannel::ConnectionState::Connecting);
     }
     {
-      pClient->Connect();
+      EZ_TEST_RESULT(pClient->Connect());
       auto res = pClientTester->WaitForEvents(ezTime::MakeFromMilliseconds(100));
       EZ_TEST_BOOL(res.has_value() && res->m_Type == ezIpcChannelEvent::Connecting);
     }
@@ -189,8 +191,10 @@ void TestIPCChannel(ezIpcChannel* pServer, ChannelTester* pServerTester, ezIpcCh
     auto res2 = pClientTester->WaitForEvents(ezTime::MakeFromSeconds(1));
     EZ_TEST_BOOL(res2.has_value() && res2->m_Type == ezIpcChannelEvent::Connected);
 
-    EZ_TEST_BOOL(pServer->GetConnectionState() == ezIpcChannel::ConnectionState::Connected);
-    EZ_TEST_BOOL(pClient->GetConnectionState() == ezIpcChannel::ConnectionState::Connected);
+    if (!EZ_TEST_BOOL(pServer->GetConnectionState() == ezIpcChannel::ConnectionState::Connected))
+      return;
+    if (!EZ_TEST_BOOL(pClient->GetConnectionState() == ezIpcChannel::ConnectionState::Connected))
+      return;
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ClientSend after reconnect")
@@ -223,7 +227,6 @@ void TestIPCChannel(ezIpcChannel* pServer, ChannelTester* pServerTester, ezIpcCh
   }
 }
 
-/* TODO: Enet does not connect in process.
 EZ_CREATE_SIMPLE_TEST(Communication, IpcChannel_Network)
 {
   ezUniquePtr<ezIpcChannel> pServer = ezIpcChannel::CreateNetworkChannel("127.0.0.1:1050"_ezsv, ezIpcChannel::Mode::Server);
@@ -240,7 +243,7 @@ EZ_CREATE_SIMPLE_TEST(Communication, IpcChannel_Network)
   pServerTester.Clear();
   pServer.Clear();
 }
-*/
+
 
 EZ_CREATE_SIMPLE_TEST(Communication, IpcChannel_Pipe)
 {

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -268,7 +268,7 @@ ezResult ezRendererTestAdvancedFeatures::InitializeSubTest(ezInt32 iIdentifier)
     m_pChannel = ezIpcChannel::CreatePipeChannel(sIPC, ezIpcChannel::Mode::Server);
     m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
     m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezRendererTestAdvancedFeatures::OffscreenProcessMessageFunc, this));
-    m_pChannel->Connect();
+    EZ_SUCCEED_OR_RETURN(m_pChannel->Connect());
     while (m_pChannel->GetConnectionState() != ezIpcChannel::ConnectionState::Connecting)
     {
       ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(16));
@@ -284,7 +284,7 @@ ezResult ezRendererTestAdvancedFeatures::InitializeSubTest(ezInt32 iIdentifier)
       m_SharedTextureQueue.PushBack({i, 0});
     }
 
-    while (!m_pChannel->IsConnected())
+    while (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connecting)
     {
       ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(16));
       if (m_pOffscreenProcess->GetState() == ezProcessState::Finished)
@@ -293,6 +293,12 @@ ezResult ezRendererTestAdvancedFeatures::InitializeSubTest(ezInt32 iIdentifier)
         ezLog::Error("Process exited prematurely with code: {}", uiExitCode);
         return EZ_FAILURE;
       }
+    }
+
+    if (m_pChannel->GetConnectionState() != ezIpcChannel::ConnectionState::Connected)
+    {
+      ezLog::Error("Failed to connect to offscreen process");
+      return EZ_FAILURE;
     }
 
     ezOffscreenTest_OpenMsg msg;

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -191,11 +191,19 @@ void ezOffscreenRendererTest::AfterCoreSystemsStartup()
   m_pChannel = ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client);
   m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
   m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezOffscreenRendererTest::MessageFunc, this));
-  m_pChannel->Connect();
+  EZ_TEST_RESULT(m_pChannel->Connect());
 
-  while (!m_pChannel->IsConnected())
+  while (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connecting)
   {
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(16));
+  }
+
+  if (m_pChannel->GetConnectionState() != ezIpcChannel::ConnectionState::Connected)
+  {
+    ezLog::Error("Failed to connect to host process");
+    SetReturnCode(-4);
+    QuitApplication();
+    return;
   }
 
   ezStartup::StartupHighLevelSystems();


### PR DESCRIPTION
## IPC Connections

* Made `ezIpcChannel::Connect()` report whether a connection attempt was actually started and move channels into `Connecting` state before the platform-specific connect work is queued. The state machine will then either transition to `Connected` or `Disconnected` after a timeout on a client and the server will stay in `Connecting` until a client connects.
* Added protocol message ids so the added IPC send/receive telemetry in `ezIpcProcessMessageProtocol` can be correlated across processes.
* Fixed Enet-based IPC channel and re-enabled testing.
* Reworked asset processor startup. Processor clients now start from a dedicated `StartClient` state which transitions to `WaitingForConnection` if the process could be started and eventually switches to `LookingForWork` if the IPC channel is connected.

## Linux

* Added Linux process group support using parent-death signals so launched child processes are terminated when the parent exits.
* Fixed deadlock when starting process as the old code did try to enter a lock in the allocator after calling `fork`.
* Make POSIX process waiting more robust against interrupted waitpid calls and signaled exits. Mainly surfaced in `<defunct>` processes staying around.