### PR TITLE
Re-added missing data conversion in RmlUI data binding

### DIFF
--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/BlackboardDataBinding.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/BlackboardDataBinding.cpp
@@ -47,7 +47,13 @@ namespace ezRmlUiInternal
   {
     auto pInfo = static_cast<EntryInfo*>(pPtr);
 
-    pInfo->m_pBlackboard->SetEntryValue(pInfo->m_sName, ezRmlUiConversionUtils::ToVariant(variant));
+    ezVariant::Type::Enum targetType = ezVariant::Type::Invalid;
+    if (auto pEntry = pInfo->m_pBlackboard->GetEntry(pInfo->m_sName))
+    {
+      targetType = pEntry->m_Value.GetType();
+    }
+
+    pInfo->m_pBlackboard->SetEntryValue(pInfo->m_sName, ezRmlUiConversionUtils::ToVariant(variant, targetType));
 
     return true;
   }


### PR DESCRIPTION
Fixes #1956 

We can't influence the data type returned by RmlUI for data bindings so we try to convert the values to the same type as existing blackboard values. This conversion existed before but was lost during adding support for arrays in the RmlUI 6.2 update.