### PR TITLE
Render Graph Inspector

### DIFF
--- a/Code/Engine/RendererCore/RenderGraph/Declarations.h
+++ b/Code/Engine/RendererCore/RenderGraph/Declarations.h
@@ -78,5 +78,3 @@ struct ezRenderGraphPhase
     Default = Render
   };
 };
-
-

--- a/Code/Engine/RendererCore/RenderGraph/Declarations.h
+++ b/Code/Engine/RendererCore/RenderGraph/Declarations.h
@@ -9,10 +9,13 @@ class ezRenderGraph;
 class ezRenderGraphPassBuilder;
 class ezRenderGraphContext;
 class ezRenderGraphManager;
+struct ezRenderGraphInspectionInfo;
+struct ezRenderGraphDebugTarget;
 class ezRenderGraphResourcePool;
 class ezRenderGraphResourceAllocator;
 class ezPooledRenderTexture;
 class ezPooledRenderBuffer;
+struct ezRenderGraphInspectionSummary;
 
 /// Opaque handle to a texture within a render graph.
 class ezRenderGraphTextureHandle
@@ -75,3 +78,5 @@ struct ezRenderGraphPhase
     Default = Render
   };
 };
+
+

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraph.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraph.cpp
@@ -1,10 +1,13 @@
 #include <RendererCore/RendererCorePCH.h>
 
 #include <RendererCore/RenderGraph/RenderGraph.h>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
 
 #include <RendererCore/GPUResourcePool/GPUResourcePool.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderGraph/RenderGraphContext.h>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
 #include <RendererCore/RenderGraph/RenderGraphManager.h>
 #include <RendererCore/RenderGraph/RenderGraphResourceAllocator.h>
 #include <RendererCore/RenderGraph/RenderGraphResourcePool.h>
@@ -275,7 +278,108 @@ ezResult ezRenderGraph::Compile()
   return EZ_SUCCESS;
 }
 
-void ezRenderGraph::Execute(ezRenderGraphContext& ref_ctx)
+ezResult ezRenderGraph::GetInspectionInfo(ezRenderGraphInspectionInfo& out_info) const
+{
+  if (m_RenderGraphState < RenderGraphState::Compiled)
+    return EZ_FAILURE;
+
+  // All passes in declaration order, with alive flag.
+  const ezUInt32 uiNumPasses = m_Passes.GetCount();
+  out_info.m_Passes.SetCount(uiNumPasses);
+  for (ezUInt32 i = 0; i < uiNumPasses; ++i)
+  {
+    auto& pi = out_info.m_Passes[i];
+    pi.m_sName = m_PassNames[i];
+    pi.m_QueueType = m_Passes[i].m_QueueType;
+    pi.m_bHasSideEffects = m_Passes[i].m_bHasSideEffects;
+    pi.m_bAlive = m_Alive[i];
+  }
+
+  // Textures
+  const ezUInt32 uiNumTextures = m_TextureCreationDescriptions.GetCount();
+  out_info.m_Textures.SetCount(uiNumTextures);
+  for (ezUInt32 i = 0; i < uiNumTextures; ++i)
+  {
+    auto& ti = out_info.m_Textures[i];
+    ti.m_Desc = m_TextureCreationDescriptions[i];
+
+    ezRenderGraphTextureHandle hTex;
+    hTex.m_InternalId.m_InstanceIndex = i;
+    hTex.m_InternalId.m_Generation = 0;
+    ti.m_bImported = m_HandleToImportTexture.Contains(hTex);
+    ti.m_uiFirstUsePassIndex = m_TextureFirstUse[i];
+    ti.m_uiLastUsePassIndex = m_TextureLastUse[i];
+    ti.m_uiResolvedIndex = m_TextureToResolvedTexture[i];
+  }
+
+  // Buffers
+  const ezUInt32 uiNumBuffers = m_BufferCreationDescriptions.GetCount();
+  out_info.m_Buffers.SetCount(uiNumBuffers);
+  for (ezUInt32 i = 0; i < uiNumBuffers; ++i)
+  {
+    auto& bi = out_info.m_Buffers[i];
+    bi.m_Desc = m_BufferCreationDescriptions[i];
+
+    ezRenderGraphBufferHandle hBuf;
+    hBuf.m_InternalId.m_InstanceIndex = i;
+    hBuf.m_InternalId.m_Generation = 0;
+    bi.m_bImported = m_HandleToImportBuffer.Contains(hBuf);
+    bi.m_uiFirstUsePassIndex = m_BufferFirstUse[i];
+    bi.m_uiLastUsePassIndex = m_BufferLastUse[i];
+    bi.m_uiResolvedIndex = m_BufferToResolvedBuffer[i];
+  }
+
+  // Accesses - flatten all pass resource accesses (all passes, not just alive)
+  out_info.m_Accesses.Clear();
+  out_info.m_Accesses.Reserve(m_ReadBuffers.GetCount() + m_WriteBuffers.GetCount() + m_ReadTextures.GetCount() + m_WriteTextures.GetCount());
+  for (ezUInt32 passIdx = 0; passIdx < uiNumPasses; ++passIdx)
+  {
+    const Pass& pass = m_Passes[passIdx];
+    ezUInt16 uiAccessIndexInPass = 0;
+    for (const TextureInfo& info : pass.GetReadTextures(this))
+    {
+      auto& a = out_info.m_Accesses.ExpandAndGetRef();
+      a.m_uiPassIndex = static_cast<ezUInt16>(passIdx);
+      a.m_uiResourceIndex = info.m_hTexture.m_InternalId.m_InstanceIndex;
+      a.m_uiAccessIndex = uiAccessIndexInPass++;
+      a.m_bIsTexture = true;
+      a.m_Access = info.m_access;
+      a.m_TextureRange = info.m_range;
+    }
+    for (const TextureInfo& info : pass.GetWriteTextures(this))
+    {
+      auto& a = out_info.m_Accesses.ExpandAndGetRef();
+      a.m_uiPassIndex = static_cast<ezUInt16>(passIdx);
+      a.m_uiResourceIndex = info.m_hTexture.m_InternalId.m_InstanceIndex;
+      a.m_uiAccessIndex = uiAccessIndexInPass++;
+      a.m_bIsTexture = true;
+      a.m_Access = info.m_access;
+      a.m_TextureRange = info.m_range;
+    }
+    for (const BufferInfo& info : pass.GetReadBuffers(this))
+    {
+      auto& a = out_info.m_Accesses.ExpandAndGetRef();
+      a.m_uiPassIndex = static_cast<ezUInt16>(passIdx);
+      a.m_uiResourceIndex = info.m_hBuffer.m_InternalId.m_InstanceIndex;
+      a.m_uiAccessIndex = uiAccessIndexInPass++;
+      a.m_bIsTexture = false;
+      a.m_Access = info.m_access;
+    }
+    for (const BufferInfo& info : pass.GetWriteBuffers(this))
+    {
+      auto& a = out_info.m_Accesses.ExpandAndGetRef();
+      a.m_uiPassIndex = static_cast<ezUInt16>(passIdx);
+      a.m_uiResourceIndex = info.m_hBuffer.m_InternalId.m_InstanceIndex;
+      a.m_uiAccessIndex = uiAccessIndexInPass++;
+      a.m_bIsTexture = false;
+      a.m_Access = info.m_access;
+    }
+  }
+
+  return EZ_SUCCESS;
+}
+
+void ezRenderGraph::Execute(ezRenderGraphContext& ref_ctx, ezArrayPtr<ezRenderGraphPassObserver*> observers)
 {
   EZ_ASSERT_DEV(m_RenderGraphState == RenderGraphState::BarriersCreated, "Graph must be compiled before execution");
 
@@ -386,6 +490,21 @@ void ezRenderGraph::Execute(ezRenderGraphContext& ref_ctx)
       default:
         EZ_REPORT_FAILURE("Invalid queue type");
         break;
+    }
+
+    // Execute observer copies after this pass.
+    for (auto* pObserver : observers)
+    {
+      if (!pObserver->m_bValid || pObserver->m_uiSortedPassIndex != (ezUInt32)i)
+        continue;
+
+      if (!pObserver->m_PreCopyBarriers.IsEmpty())
+        ref_ctx.m_pCommandEncoder->TextureBarrier(pObserver->m_PreCopyBarriers);
+
+      ref_ctx.m_pCommandEncoder->CopyTexture(pObserver->GetCopyTexture(), pObserver->m_hResolvedSourceTexture);
+
+      if (!pObserver->m_PostCopyBarriers.IsEmpty())
+        ref_ctx.m_pCommandEncoder->TextureBarrier(pObserver->m_PostCopyBarriers);
     }
   }
 
@@ -1124,7 +1243,7 @@ void ezRenderGraph::BuildRenderingSetups()
   }
 }
 
-void ezRenderGraph::ComputeBarriers(ezGALResourceStateTracker& ref_tracker)
+void ezRenderGraph::ComputeBarriers(ezGALResourceStateTracker& ref_tracker, ezArrayPtr<ezRenderGraphPassObserver*> observers)
 {
   EZ_PROFILE_SCOPE("ComputeBarriers");
   EZ_ASSERT_DEBUG(m_RenderGraphState == RenderGraphState::Compiled, "ComputeBarriers must be called after Compile succeeded");
@@ -1205,6 +1324,59 @@ void ezRenderGraph::ComputeBarriers(ezGALResourceStateTracker& ref_tracker)
         });
     }
     compiled.m_uiBufferBarrierCount = m_CompiledBufferBarriers.GetCount() - compiled.m_uiBufferBarrierIndex;
+
+    // Set up observers that target this pass.
+    for (auto* pObserver : observers)
+    {
+      if (pObserver->GetRequest().m_sPassName != m_PassNames[passIdx])
+        continue;
+
+      const ezRenderGraphTextureHandle hSourceTex = FindTextureAccessInPass(passIdx, pObserver->GetRequest().m_uiAccessIndex);
+      if (hSourceTex.IsInvalidated())
+        continue;
+
+      const ezUInt16 uiResolvedIdx = m_TextureToResolvedTexture[hSourceTex.m_InternalId.m_InstanceIndex];
+      if (uiResolvedIdx == s_Unused)
+        continue;
+
+      const ezGALTextureHandle hResolvedSource = m_ResolvedTextures[uiResolvedIdx];
+      const ezGALTextureCreationDescription& srcDesc = m_TextureCreationDescriptions[hSourceTex.m_InternalId.m_InstanceIndex];
+
+      pObserver->EnsureCopyTexture(srcDesc);
+      if (pObserver->GetCopyTexture().IsInvalidated())
+        continue;
+
+      pObserver->m_hResolvedSourceTexture = hResolvedSource;
+      pObserver->m_uiSortedPassIndex = sortedIdx;
+      pObserver->m_bValid = true;
+
+      // Source → CopySource barrier (tracked by the state tracker so the
+      // next pass's barriers will restore the correct state).
+      ref_tracker.ChangeState(hResolvedSource, {}, ezGALResourceState::CopySource, ezGALShaderStageFlags::Auto, [&](const ezGALTextureBarrier& barrier)
+        { pObserver->m_PreCopyBarriers.PushBack(barrier); });
+
+      const ezGALResourceState::Enum destReadState = ezGALResourceFormat::IsDepthFormat(srcDesc.m_Format)
+                                                       ? ezGALResourceState::DepthStencilRead
+                                                       : ezGALResourceState::ShaderResource;
+
+      // Destination → CopyDestination barrier (not tracked — external resource).
+      {
+        ezGALTextureBarrier destBarrier;
+        destBarrier.m_hTexture = pObserver->GetCopyTexture();
+        destBarrier.m_StateBefore = destReadState;
+        destBarrier.m_StateAfter = ezGALResourceState::CopyDestination;
+        pObserver->m_PreCopyBarriers.PushBack(destBarrier);
+      }
+
+      // Destination → read barrier after copy.
+      {
+        ezGALTextureBarrier destBarrier;
+        destBarrier.m_hTexture = pObserver->GetCopyTexture();
+        destBarrier.m_StateBefore = ezGALResourceState::CopyDestination;
+        destBarrier.m_StateAfter = destReadState;
+        pObserver->m_PostCopyBarriers.PushBack(destBarrier);
+      }
+    }
   }
   m_RenderGraphState = RenderGraphState::BarriersCreated;
 }

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphInspectionInfo.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphInspectionInfo.cpp
@@ -330,12 +330,12 @@ void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionInfo& ref_v
   }
 }
 
-void ezRenderGraphInspectionInfo::Swap(ezRenderGraphInspectionInfo& data)
+void ezRenderGraphInspectionInfo::Swap(ezRenderGraphInspectionInfo& ref_data)
 {
-  m_Passes.Swap(data.m_Passes);
-  m_Textures.Swap(data.m_Textures);
-  m_Buffers.Swap(data.m_Buffers);
-  m_Accesses.Swap(data.m_Accesses);
+  m_Passes.Swap(ref_data.m_Passes);
+  m_Textures.Swap(ref_data.m_Textures);
+  m_Buffers.Swap(ref_data.m_Buffers);
+  m_Accesses.Swap(ref_data.m_Accesses);
 }
 
 void ezRenderGraphInspectionInfo::Clear()

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphInspectionInfo.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphInspectionInfo.cpp
@@ -329,3 +329,19 @@ void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionInfo& ref_v
     ReadTextureRange(inout_stream, access.m_TextureRange);
   }
 }
+
+void ezRenderGraphInspectionInfo::Swap(ezRenderGraphInspectionInfo& data)
+{
+  m_Passes.Swap(data.m_Passes);
+  m_Textures.Swap(data.m_Textures);
+  m_Buffers.Swap(data.m_Buffers);
+  m_Accesses.Swap(data.m_Accesses);
+}
+
+void ezRenderGraphInspectionInfo::Clear()
+{
+  m_Passes.Clear();
+  m_Textures.Clear();
+  m_Buffers.Clear();
+  m_Accesses.Clear();
+}

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -5,9 +5,11 @@
 #include <Foundation/Configuration/Startup.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderGraph/RenderGraph.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
 #include <RendererCore/RenderGraph/RenderGraphResourcePool.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Device/SwapChain.h>
 #include <RendererFoundation/Utils/ResourceStateTracker.h>
 
 // clang-format off
@@ -37,7 +39,10 @@ ezDynamicArray<ezSharedPtr<ezRenderGraph>> ezRenderGraphManager::s_EnqueuedRende
 ezDynamicArray<ezRenderGraph*> ezRenderGraphManager::s_AllRenderGraphs[3];
 ezUniquePtr<ezRenderGraphResourcePool> ezRenderGraphManager::s_pPool;
 ezUniquePtr<ezGALResourceStateTracker> ezRenderGraphManager::s_pStateTracker;
+ezDynamicArray<ezSharedPtr<ezRenderGraphPassObserver>> ezRenderGraphManager::s_Observers;
+ezSharedPtr<ezRenderGraph> ezRenderGraphManager::s_pObserverGraph;
 ezDynamicArray<ezRenderGraph*> ezRenderGraphManager::s_ExecutingGraphs;
+ezDynamicArray<ezRenderGraphPassObserver*> ezRenderGraphManager::s_ExecutingObservers;
 ezUInt32 ezRenderGraphManager::s_uiCurrentGraphIndex = 0;
 ezUInt32 ezRenderGraphManager::s_uiCurrentPassIndex = 0;
 
@@ -52,6 +57,8 @@ void ezRenderGraphManager::OnEngineStartup()
 
 void ezRenderGraphManager::OnEngineShutdown()
 {
+  s_pObserverGraph = nullptr;
+
   DeinitPool(ezGALDevice::GetDefaultDevice());
   ezGALDevice::s_Events.RemoveEventHandler(ezMakeDelegate(&ezRenderGraphManager::GALDeviceEventHandler));
   ezGALCommandEncoder::s_TextureBarrierValidationFailed.RemoveEventHandler(ezMakeDelegate(&ezRenderGraphManager::PrintTextureResourceHistory));
@@ -62,6 +69,17 @@ void ezRenderGraphManager::OnEngineShutdown()
   EZ_ASSERT_DEV(s_AllRenderGraphs[ezRenderGraphPhase::PreRender].IsEmpty(), "Not all PreRender-phase render graphs were destroyed before shutdown.");
   EZ_ASSERT_DEV(s_AllRenderGraphs[ezRenderGraphPhase::Render].IsEmpty(), "Not all render-phase render graphs were destroyed before shutdown.");
   EZ_ASSERT_DEV(s_AllRenderGraphs[ezRenderGraphPhase::PostRender].IsEmpty(), "Not all post-render-phase render graphs were destroyed before shutdown.");
+
+  for (ezUInt32 i = s_Observers.GetCount(); i > 0; --i)
+  {
+    if (s_Observers[i - 1]->GetRefCount() == 1)
+    {
+      s_Observers.RemoveAtAndSwap(i - 1);
+      continue;
+    }
+  }
+
+  EZ_ASSERT_DEV(s_Observers.IsEmpty(), "Not render graph observers were destroyed before shutdown.");
 }
 
 void ezRenderGraphManager::GALDeviceEventHandler(const ezGALDeviceEvent& e)
@@ -149,15 +167,58 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
           s_ExecutingGraphs.PushBack(pRenderGraph.Borrow());
       }
     }
+    s_ExecutingObservers.Clear();
+    for (ezUInt32 i = s_Observers.GetCount(); i > 0; --i)
+    {
+      if (s_Observers[i - 1]->GetRefCount() == 1)
+      {
+        s_Observers.RemoveAtAndSwap(i - 1);
+        continue;
+      }
+      // Apply any pending requests while we hold the mutex.
+      // After this point, m_Request is only accessed on the render thread.
+      s_Observers[i - 1]->ApplyPendingRequest();
+      s_ExecutingObservers.PushBack(s_Observers[i - 1].Borrow());
+    }
+
+    // Create observer render graph
+    if (!s_ExecutingObservers.IsEmpty())
+    {
+      if (s_pObserverGraph == nullptr)
+      {
+        s_pObserverGraph = CreateRenderGraph("__OBSERVER__", ezRenderGraphPhase::PostRender);
+      }
+
+      for (auto* pObserver : s_ExecutingObservers)
+      {
+        pObserver->RecordPreview(*s_pObserverGraph.Borrow());
+      }
+
+      if (s_pObserverGraph->Compile().Succeeded())
+        s_ExecutingGraphs.PushBack(s_pObserverGraph.Borrow());
+    }
   }
 
   {
     EZ_PROFILE_SCOPE("ComputeBarriers");
     for (auto pRenderGraph : s_ExecutingGraphs)
     {
-      pRenderGraph->ComputeBarriers(*s_pStateTracker.Borrow());
+      // Collect observers for this graph.
+      ezHybridArray<ezRenderGraphPassObserver*, 4> graphObservers;
+      for (auto* pObserver : s_ExecutingObservers)
+      {
+        if (pObserver->m_pGraph == pRenderGraph)
+        {
+          pObserver->Reset();
+          graphObservers.PushBack(pObserver);
+        }
+      }
+
+      pRenderGraph->ComputeBarriers(*s_pStateTracker.Borrow(), graphObservers);
     }
   }
+
+
 
   ezHybridArray<ezGALTextureBarrier, 8> textureBarriers;
   s_pStateTracker->RevertTextureState([&](const ezGALTextureBarrier& barrier)
@@ -171,7 +232,15 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
   ezRenderGraphContext ctx(pEncoder, pDevice, ezRenderContext::GetDefaultInstance());
   for (s_uiCurrentGraphIndex = 0; s_uiCurrentGraphIndex < s_ExecutingGraphs.GetCount(); ++s_uiCurrentGraphIndex)
   {
-    s_ExecutingGraphs[s_uiCurrentGraphIndex]->Execute(ctx);
+    // Collect valid observers for this graph.
+    ezHybridArray<ezRenderGraphPassObserver*, 4> graphObservers;
+    for (auto* pObserver : s_ExecutingObservers)
+    {
+      if (pObserver->m_bValid && pObserver->m_pGraph == s_ExecutingGraphs[s_uiCurrentGraphIndex])
+        graphObservers.PushBack(pObserver);
+    }
+
+    s_ExecutingGraphs[s_uiCurrentGraphIndex]->Execute(ctx, graphObservers);
   }
   pEncoder->TextureBarrier(textureBarriers);
   pEncoder->BufferBarrier(bufferBarriers);
@@ -195,6 +264,110 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
 
   for (auto& bucket : s_EnqueuedRenderGraphs)
     bucket.Clear();
+}
+
+void ezRenderGraphManager::GetExecutionSummary(ezRenderGraphInspectionSummary& out_summary)
+{
+  out_summary.m_RenderGraphs.Clear();
+  out_summary.m_AvailableSwapChains.Clear();
+
+  if (ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice())
+  {
+    ezDynamicArray<ezGALSwapChainHandle> swapChains;
+    pDevice->GetAllSwapChains(swapChains);
+    out_summary.m_AvailableSwapChains.Reserve(swapChains.GetCount());
+    for (ezGALSwapChainHandle hSwapChain : swapChains)
+    {
+      ezRenderGraphSwapChainSummary& swapChainSummary = out_summary.m_AvailableSwapChains.ExpandAndGetRef();
+      swapChainSummary.m_uiSwapChainId = GetSwapChainId(hSwapChain);
+
+      if (const ezGALSwapChain* pSwapChain = pDevice->GetSwapChain(hSwapChain))
+      {
+        const ezSizeU32 size = pSwapChain->GetCurrentSize();
+        swapChainSummary.m_uiWidth = size.width;
+        swapChainSummary.m_uiHeight = size.height;
+      }
+    }
+  }
+
+  for (ezUInt32 i = 0; i < 3; ++i)
+  {
+    for (ezRenderGraph* pGraph : s_AllRenderGraphs[i])
+    {
+      if (pGraph == s_pObserverGraph.Borrow())
+        continue;
+      ezRenderGraphExecutionSummary& summary = out_summary.m_RenderGraphs.ExpandAndGetRef();
+      summary.m_uiRenderGraphId = GetRenderGraphId(pGraph);
+      summary.m_sGraphName = pGraph->GetGraphName();
+      summary.m_sUserName = pGraph->GetUserName();
+      summary.m_Phase = pGraph->m_Phase;
+
+      summary.m_uiExecutionOrder = -1;
+      for (ezUInt32 j = 0; j < s_EnqueuedRenderGraphs[i].GetCount(); ++j)
+      {
+        if (s_EnqueuedRenderGraphs[i][j].Borrow() == pGraph)
+        {
+          summary.m_uiExecutionOrder = j;
+          break;
+        }
+      }
+    }
+  }
+}
+
+ezResult ezRenderGraphManager::GetRenderGraphInspectionInfo(ezUInt64 uiRenderGraphId, ezRenderGraphInspectionInfo& out_InspectionInfo)
+{
+  if (ezRenderGraph* pGraph = GetRenderGraphById(uiRenderGraphId))
+  {
+    return pGraph->GetInspectionInfo(out_InspectionInfo);
+  }
+  return EZ_FAILURE;
+}
+
+ezUInt64 ezRenderGraphManager::GetRenderGraphId(ezRenderGraph* pGraph)
+{
+  return reinterpret_cast<ezUInt64>(pGraph);
+}
+
+ezRenderGraph* ezRenderGraphManager::GetRenderGraphById(ezUInt64 uiRenderGraphId)
+{
+  ezRenderGraph* pGraph = reinterpret_cast<ezRenderGraph*>(uiRenderGraphId);
+  for (ezUInt32 i = 0; i < 3; ++i)
+  {
+    for (ezRenderGraph* pGraph2 : s_AllRenderGraphs[i])
+    {
+      if (pGraph == pGraph2)
+      {
+        return pGraph2;
+      }
+    }
+  }
+  return nullptr;
+}
+
+ezUInt32 ezRenderGraphManager::GetSwapChainId(ezGALSwapChainHandle hSwapChain)
+{
+  return hSwapChain.GetInternalID().m_Data;
+}
+
+ezGALSwapChainHandle ezRenderGraphManager::GetSwapChainById(ezUInt32 uiSwapChainId)
+{
+  ezGALSwapChainHandle hSwapChain{ezGALSwapChainHandle::IdType(uiSwapChainId)};
+  if (ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice())
+  {
+    if (pDevice->GetSwapChain(hSwapChain) != nullptr)
+    {
+      return hSwapChain;
+    }
+  }
+  return ezGALSwapChainHandle();
+}
+
+ezSharedPtr<ezRenderGraphPassObserver> ezRenderGraphManager::CreateObserver()
+{
+  ezSharedPtr<ezRenderGraphPassObserver> observer = EZ_DEFAULT_NEW(ezRenderGraphPassObserver, ezGALDevice::GetDefaultDevice());
+  s_Observers.PushBack(observer);
+  return observer;
 }
 
 void ezRenderGraphManager::OnGraphDestroyed(ezRenderGraph* pGraph)
@@ -226,7 +399,7 @@ namespace
 void ezRenderGraphManager::PrintTextureResourceHistory(const ezTextureValidationError& error)
 {
   ezLog::Error("Bind group '{}' binding '{}': texture sub-resource [mip={}, slice={}] state mismatch. Tracked: {} [{}], Expected: {} [{}]",
-    error.m_uiBindGroup, error.m_sBinding.GetData(), error.m_failedSubResource.m_uiMipLevel, error.m_failedSubResource.m_uiArraySlice, ezArgEnum(error.m_actualState), ezArgEnum(error.m_actualStages), ezArgEnum(error.m_expectedState), ezArgEnum(error.m_expectedStages));
+  error.m_uiBindGroup, error.m_sBinding.GetData(), error.m_failedSubResource.m_uiMipLevel, error.m_failedSubResource.m_uiArraySlice, ezArgEnum(error.m_actualState), ezArgEnum(error.m_actualStages), ezArgEnum(error.m_expectedState), ezArgEnum(error.m_expectedStages));
 
 
   if (s_ExecutingGraphs.IsEmpty())

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/Configuration/Startup.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderGraph/RenderGraph.h>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
 #include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
 #include <RendererCore/RenderGraph/RenderGraphResourcePool.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -316,11 +316,11 @@ void ezRenderGraphManager::GetExecutionSummary(ezRenderGraphInspectionSummary& o
   }
 }
 
-ezResult ezRenderGraphManager::GetRenderGraphInspectionInfo(ezUInt64 uiRenderGraphId, ezRenderGraphInspectionInfo& out_InspectionInfo)
+ezResult ezRenderGraphManager::GetRenderGraphInspectionInfo(ezUInt64 uiRenderGraphId, ezRenderGraphInspectionInfo& out_inspectionInfo)
 {
   if (ezRenderGraph* pGraph = GetRenderGraphById(uiRenderGraphId))
   {
-    return pGraph->GetInspectionInfo(out_InspectionInfo);
+    return pGraph->GetInspectionInfo(out_inspectionInfo);
   }
   return EZ_FAILURE;
 }

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -399,7 +399,7 @@ namespace
 void ezRenderGraphManager::PrintTextureResourceHistory(const ezTextureValidationError& error)
 {
   ezLog::Error("Bind group '{}' binding '{}': texture sub-resource [mip={}, slice={}] state mismatch. Tracked: {} [{}], Expected: {} [{}]",
-  error.m_uiBindGroup, error.m_sBinding.GetData(), error.m_failedSubResource.m_uiMipLevel, error.m_failedSubResource.m_uiArraySlice, ezArgEnum(error.m_actualState), ezArgEnum(error.m_actualStages), ezArgEnum(error.m_expectedState), ezArgEnum(error.m_expectedStages));
+    error.m_uiBindGroup, error.m_sBinding.GetData(), error.m_failedSubResource.m_uiMipLevel, error.m_failedSubResource.m_uiArraySlice, ezArgEnum(error.m_actualState), ezArgEnum(error.m_actualStages), ezArgEnum(error.m_expectedState), ezArgEnum(error.m_expectedStages));
 
 
   if (s_ExecutingGraphs.IsEmpty())

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphPassObserver.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphPassObserver.cpp
@@ -1,0 +1,582 @@
+#include <RendererCore/RendererCorePCH.h>
+
+#include <Core/ResourceManager/Implementation/ResourceLock.h>
+#include <Core/ResourceManager/ResourceManager.h>
+#include <RendererCore/RenderContext/RenderContext.h>
+#include <RendererCore/RenderGraph/RenderGraph.h>
+#include <RendererCore/RenderGraph/RenderGraphManager.h>
+#include <RendererCore/RenderGraph/RenderGraphPassBuilder.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
+#include <RendererCore/Shader/ShaderResource.h>
+#include <RendererCore/Textures/Texture2DResource.h>
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Device/SwapChain.h>
+#include <RendererFoundation/Resources/Buffer.h>
+#include <RendererFoundation/Resources/Texture.h>
+
+#include <RendererCore/../../../Data/Base/Shaders/RenderGraph/RenderGraphHistogramConstants.h>
+#include <RendererCore/../../../Data/Base/Shaders/RenderGraph/RenderGraphMinMaxConstants.h>
+#include <RendererCore/../../../Data/Base/Shaders/RenderGraph/RenderGraphPreviewConstants.h>
+#include <RendererCore/../../../Data/Base/Shaders/RenderGraph/RenderGraphReadbackPixelConstants.h>
+
+static ezAtomicInteger32 s_uiObserverTextureCounter;
+
+namespace
+{
+  constexpr ezUInt32 s_uiHistogramBinCount = 256;
+  constexpr ezUInt32 s_uiHistogramChannelCount = 4;
+  constexpr ezUInt32 s_uiMinMaxValueCount = 2;
+
+  float GetAdjustedHistogramMax(float fMin, float fMax)
+  {
+    const float fRange = ezMath::Max(fMax - fMin, 0.0000001f);
+    return fMax + fRange * 0.000001f;
+  }
+
+  float OrderedUintToFloat(ezUInt32 uiOrderedValue)
+  {
+    // Inverse of FloatToOrderedUint in RenderGraphBuildMinMax.ezShader.
+    // The shader stores min/max floats in an integer domain that preserves float ordering for atomic operations.
+    const ezUInt32 uiRawValue = (uiOrderedValue & 0x80000000u) != 0u ? (uiOrderedValue ^ 0x80000000u) : ~uiOrderedValue;
+    return *reinterpret_cast<const float*>(&uiRawValue);
+  }
+} // namespace
+
+ezRenderGraphPassObserver::ezRenderGraphPassObserver(ezGALDevice* pDevice)
+  : m_pDevice(pDevice)
+{
+  m_Response.m_Histogram.SetCount(s_uiHistogramBinCount * s_uiHistogramChannelCount);
+  ezMemoryUtils::ZeroFill(m_Response.m_Histogram.GetData(), m_Response.m_Histogram.GetCount());
+}
+
+ezRenderGraphPassObserver::~ezRenderGraphPassObserver()
+{
+  DestroyInspectionResources();
+  m_hCopyTextureResource.Invalidate();
+  m_hCopyTexture.Invalidate();
+}
+
+ezRenderGraphObserverResponse ezRenderGraphPassObserver::GetResponse() const
+{
+  EZ_LOCK(m_Mutex);
+  return m_Response;
+}
+
+void ezRenderGraphPassObserver::SetRequest(const ezRenderGraphObserverRequest& request)
+{
+  EZ_LOCK(m_Mutex);
+  m_PendingRequest = request;
+  m_bPendingRequestDirty = true;
+}
+
+void ezRenderGraphPassObserver::ApplyPendingRequest()
+{
+  EZ_LOCK(m_Mutex);
+  if (m_bPendingRequestDirty)
+  {
+    m_Request = m_PendingRequest;
+    m_pGraph = ezRenderGraphManager::GetRenderGraphById(m_Request.m_uiRenderGraphId);
+    m_hSwapChain = ezRenderGraphManager::GetSwapChainById(m_Request.m_uiSwapChainId);
+    m_bPendingRequestDirty = false;
+  }
+}
+
+void ezRenderGraphPassObserver::EnsureInspectionResources()
+{
+  if (m_hPixelReadbackBuffer.IsInvalidated())
+  {
+    ezGALBufferCreationDescription desc;
+    desc.m_uiStructSize = sizeof(ezVec4);
+    desc.m_uiTotalSize = desc.m_uiStructSize;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
+    desc.m_ResourceAccess.m_bImmutable = false;
+    m_hPixelReadbackBuffer = m_pDevice->CreateBuffer(desc);
+  }
+
+  if (m_hHistogramBuffer.IsInvalidated())
+  {
+    ezGALBufferCreationDescription desc;
+    desc.m_uiStructSize = sizeof(ezUInt32);
+    desc.m_uiTotalSize = s_uiHistogramBinCount * s_uiHistogramChannelCount * desc.m_uiStructSize;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
+    desc.m_ResourceAccess.m_bImmutable = false;
+    m_hHistogramBuffer = m_pDevice->CreateBuffer(desc);
+  }
+
+  if (m_hMinMaxBuffer.IsInvalidated())
+  {
+    ezGALBufferCreationDescription desc;
+    desc.m_uiStructSize = sizeof(ezUInt32);
+    desc.m_uiTotalSize = s_uiMinMaxValueCount * desc.m_uiStructSize;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
+    desc.m_ResourceAccess.m_bImmutable = false;
+    m_hMinMaxBuffer = m_pDevice->CreateBuffer(desc);
+  }
+
+  if (!m_hReadbackPixelShader.IsValid())
+  {
+    m_hReadbackPixelShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/RenderGraph/RenderGraphReadbackPixel.ezShader");
+  }
+
+  if (!m_hClearHistogramShader.IsValid())
+  {
+    m_hClearHistogramShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/RenderGraph/RenderGraphClearHistogram.ezShader");
+  }
+
+  if (!m_hBuildHistogramShader.IsValid())
+  {
+    m_hBuildHistogramShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/RenderGraph/RenderGraphBuildHistogram.ezShader");
+  }
+
+  if (!m_hClearMinMaxShader.IsValid())
+  {
+    m_hClearMinMaxShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/RenderGraph/RenderGraphClearMinMax.ezShader");
+  }
+
+  if (!m_hBuildMinMaxShader.IsValid())
+  {
+    m_hBuildMinMaxShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/RenderGraph/RenderGraphBuildMinMax.ezShader");
+  }
+
+  if (!m_hPreviewShader.IsValid())
+  {
+    m_hPreviewShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/RenderGraph/RenderGraphPreview.ezShader");
+  }
+}
+
+void ezRenderGraphPassObserver::DestroyInspectionResources()
+{
+  m_PixelReadback.Reset();
+  m_HistogramReadback.Reset();
+  m_MinMaxReadback.Reset();
+  m_pDevice->DestroyBuffer(m_hPixelReadbackBuffer);
+  m_pDevice->DestroyBuffer(m_hHistogramBuffer);
+  m_pDevice->DestroyBuffer(m_hMinMaxBuffer);
+  m_hReadbackPixelShader.Invalidate();
+  m_hClearHistogramShader.Invalidate();
+  m_hBuildHistogramShader.Invalidate();
+  m_hClearMinMaxShader.Invalidate();
+  m_hBuildMinMaxShader.Invalidate();
+  m_hPreviewShader.Invalidate();
+}
+
+void ezRenderGraphPassObserver::PollReadbacks()
+{
+  if (m_bPixelReadbackInFlight)
+  {
+    const ezEnum<ezGALAsyncResult> result = m_PixelReadback.GetReadbackResult(ezTime::MakeZero());
+    if (result == ezGALAsyncResult::Ready)
+    {
+      ezArrayPtr<const ezUInt8> memory;
+      if (ezReadbackBufferLock lock = m_PixelReadback.LockBuffer(memory))
+      {
+        ProcessPixelReadback(memory);
+      }
+      m_bPixelReadbackInFlight = false;
+    }
+    else if (result == ezGALAsyncResult::Expired)
+    {
+      m_bPixelReadbackInFlight = false;
+    }
+  }
+
+  if (m_bHistogramReadbackInFlight)
+  {
+    const ezEnum<ezGALAsyncResult> result = m_HistogramReadback.GetReadbackResult(ezTime::MakeZero());
+    if (result == ezGALAsyncResult::Ready)
+    {
+      ezArrayPtr<const ezUInt8> memory;
+      if (ezReadbackBufferLock lock = m_HistogramReadback.LockBuffer(memory))
+      {
+        ProcessHistogramReadback(memory);
+      }
+      m_bHistogramReadbackInFlight = false;
+    }
+    else if (result == ezGALAsyncResult::Expired)
+    {
+      m_bHistogramReadbackInFlight = false;
+    }
+  }
+
+  if (m_bMinMaxReadbackInFlight)
+  {
+    const ezEnum<ezGALAsyncResult> result = m_MinMaxReadback.GetReadbackResult(ezTime::MakeZero());
+    if (result == ezGALAsyncResult::Ready)
+    {
+      ezArrayPtr<const ezUInt8> memory;
+      if (ezReadbackBufferLock lock = m_MinMaxReadback.LockBuffer(memory))
+      {
+        ProcessMinMaxReadback(memory);
+      }
+      m_bMinMaxReadbackInFlight = false;
+    }
+    else if (result == ezGALAsyncResult::Expired)
+    {
+      m_bMinMaxReadbackInFlight = false;
+    }
+  }
+}
+
+void ezRenderGraphPassObserver::ProcessPixelReadback(ezArrayPtr<const ezUInt8> memory)
+{
+  EZ_ASSERT_DEBUG(memory.GetCount() >= sizeof(ezVec4), "Readback size missmatch");
+
+  ezVec4 pixelValue;
+  ezMemoryUtils::RawByteCopy(&pixelValue, memory.GetPtr(), sizeof(ezVec4));
+
+  EZ_LOCK(m_Mutex);
+  m_Response.m_PixelValue = pixelValue;
+}
+
+void ezRenderGraphPassObserver::ProcessHistogramReadback(ezArrayPtr<const ezUInt8> memory)
+{
+  constexpr ezUInt32 uiRequiredSize = s_uiHistogramBinCount * s_uiHistogramChannelCount * sizeof(ezUInt32);
+  EZ_ASSERT_DEBUG(memory.GetCount() >= uiRequiredSize, "Readback size missmatch");
+
+  const ezUInt32* pHistogram = reinterpret_cast<const ezUInt32*>(memory.GetPtr());
+  bool bIgnoreChannel[s_uiHistogramChannelCount] = {};
+  ezUInt32 uiMaxCount = 0;
+
+  for (ezUInt32 uiChannel = 0; uiChannel < s_uiHistogramChannelCount; ++uiChannel)
+  {
+    if ((m_Request.m_uiChannelMask & EZ_BIT(uiChannel)) == 0)
+    {
+      bIgnoreChannel[uiChannel] = true;
+      continue;
+    }
+
+    ezUInt32 uiNonZeroBuckets = 0;
+    ezUInt32 uiChannelMaxCount = 0;
+
+    for (ezUInt32 uiBucket = 0; uiBucket < s_uiHistogramBinCount; ++uiBucket)
+    {
+      const ezUInt32 uiCount = pHistogram[uiChannel * s_uiHistogramBinCount + uiBucket];
+      if (uiCount > 0)
+      {
+        ++uiNonZeroBuckets;
+        uiChannelMaxCount = ezMath::Max(uiChannelMaxCount, uiCount);
+      }
+    }
+
+    bIgnoreChannel[uiChannel] = uiNonZeroBuckets <= 1;
+    if (!bIgnoreChannel[uiChannel])
+    {
+      uiMaxCount = ezMath::Max(uiMaxCount, uiChannelMaxCount);
+    }
+  }
+
+  EZ_LOCK(m_Mutex);
+  m_Response.m_bHistogramValid = true;
+
+  if (uiMaxCount == 0)
+  {
+    ezMemoryUtils::ZeroFill(m_Response.m_Histogram.GetData(), m_Response.m_Histogram.GetCount());
+    return;
+  }
+
+  for (ezUInt32 uiChannel = 0; uiChannel < s_uiHistogramChannelCount; ++uiChannel)
+  {
+    const ezUInt32 uiChannelOffset = uiChannel * s_uiHistogramBinCount;
+    if (bIgnoreChannel[uiChannel])
+    {
+      ezMemoryUtils::ZeroFill(m_Response.m_Histogram.GetData() + uiChannelOffset, s_uiHistogramBinCount);
+      continue;
+    }
+
+    for (ezUInt32 uiBucket = 0; uiBucket < s_uiHistogramBinCount; ++uiBucket)
+    {
+      const ezUInt64 uiNormalizedValue = (static_cast<ezUInt64>(pHistogram[uiChannelOffset + uiBucket]) * 255ull) / uiMaxCount;
+      m_Response.m_Histogram[uiChannelOffset + uiBucket] = static_cast<ezUInt8>(ezMath::Min<ezUInt64>(255, uiNormalizedValue));
+    }
+  }
+}
+
+void ezRenderGraphPassObserver::ProcessMinMaxReadback(ezArrayPtr<const ezUInt8> memory)
+{
+  constexpr ezUInt32 uiRequiredSize = s_uiMinMaxValueCount * sizeof(ezUInt32);
+  EZ_ASSERT_DEBUG(memory.GetCount() >= uiRequiredSize, "Readback size missmatch");
+
+  const ezUInt32* pMinMax = reinterpret_cast<const ezUInt32*>(memory.GetPtr());
+  float fMin = 0.0f;
+  float fMax = 1.0f;
+
+  if (pMinMax[0] != ezMath::MaxValue<ezUInt32>() || pMinMax[1] != 0)
+  {
+    fMin = OrderedUintToFloat(pMinMax[0]);
+    fMax = OrderedUintToFloat(pMinMax[1]);
+  }
+
+  EZ_LOCK(m_Mutex);
+  m_Response.m_fImageMin = fMin;
+  m_Response.m_fImageMax = fMax;
+}
+
+void ezRenderGraphPassObserver::Reset()
+{
+  m_bValid = false;
+  m_uiSortedPassIndex = 0xFFFFFFFF;
+  m_hResolvedSourceTexture.Invalidate();
+  m_PreCopyBarriers.Clear();
+  m_PostCopyBarriers.Clear();
+}
+
+void ezRenderGraphPassObserver::EnsureCopyTexture(const ezGALTextureCreationDescription& srcDesc)
+{
+  ezGALTextureCreationDescription newDesc = srcDesc;
+  newDesc.m_TextureFlags = ezGALTextureUsageFlags::ShaderResource;
+  newDesc.m_ResourceAccess.m_bImmutable = false;
+  newDesc.m_pExisitingNativeObject = nullptr;
+
+  if (!m_hCopyTexture.IsInvalidated())
+  {
+    const ezGALTexture* pExisting = m_pDevice->GetTexture(m_hCopyTexture);
+    if (pExisting != nullptr && newDesc.CalculateHash() == pExisting->GetDescription().CalculateHash())
+    {
+      return; // Already matches.
+    }
+
+    // Release old resource. The resource manager will clean up the GAL texture.
+    m_hCopyTextureResource.Invalidate();
+    m_hCopyTexture.Invalidate();
+  }
+
+  ezStringBuilder resourceName;
+  resourceName.SetFormat("RGObserverCopy_{}", s_uiObserverTextureCounter.Increment());
+
+  ezTexture2DResourceDescriptor texDesc;
+  texDesc.m_DescGAL = newDesc;
+  texDesc.m_SamplerDesc.m_MinFilter = ezGALTextureFilterMode::Point;
+  texDesc.m_SamplerDesc.m_MagFilter = ezGALTextureFilterMode::Point;
+  texDesc.m_SamplerDesc.m_MipFilter = ezGALTextureFilterMode::Point;
+
+  m_hCopyTextureResource = ezResourceManager::CreateResource<ezTexture2DResource>(resourceName, std::move(texDesc), "Render Graph Observer Copy");
+
+  ezResourceLock<ezTexture2DResource> pResource(m_hCopyTextureResource, ezResourceAcquireMode::BlockTillLoaded);
+  m_hCopyTexture = pResource->GetGALTexture();
+}
+
+void ezRenderGraphPassObserver::RecordPreview(ezRenderGraph& ref_graph)
+{
+  if (m_pGraph == nullptr || m_Request.m_sPassName.IsEmpty())
+    return;
+
+  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
+  ezGALTextureHandle hCopyTexture = GetCopyTexture();
+  if (hCopyTexture.IsInvalidated())
+    return;
+  const ezGALTexture* pCopyTexture = pDevice->GetTexture(hCopyTexture);
+  if (pCopyTexture == nullptr)
+    return;
+
+  PollReadbacks();
+  EnsureInspectionResources();
+
+  const ezGALTextureCreationDescription& copyTextureDesc = pCopyTexture->GetDescription();
+  const ezUInt32 uiMipLevel = ezMath::Min<ezUInt32>(m_Request.m_uiMipLevel, copyTextureDesc.m_uiMipLevelCount - 1);
+  const ezUInt32 uiArraySlice = ezMath::Min<ezUInt32>(m_Request.m_uiArraySlice, copyTextureDesc.GetNumberOfSlices() - 1);
+  const ezVec3U32 mipSize = copyTextureDesc.GetMipMapSize(uiMipLevel);
+  const bool bIsMSAA = copyTextureDesc.m_SampleCount != ezGALMSAASampleCount::None;
+  const ezUInt32 uiSampleCount = (ezUInt32)copyTextureDesc.m_SampleCount;
+  const ezInt32 iSampleIndex = m_Request.m_iSampleIndex < 0 ? -1 : ezMath::Min<ezInt32>(m_Request.m_iSampleIndex, uiSampleCount - 1u);
+
+  ezGALTextureRange sourceRange;
+  sourceRange.m_uiBaseMipLevel = uiMipLevel;
+  sourceRange.m_uiMipLevels = 1;
+  sourceRange.m_uiBaseArraySlice = uiArraySlice;
+  sourceRange.m_uiArraySlices = 1;
+
+  ezRenderGraphTextureHandle hSource = ref_graph.ImportTexture(hCopyTexture);
+  ezRenderGraphBufferHandle hPixelBuffer = ref_graph.ImportBuffer(m_hPixelReadbackBuffer);
+  ezRenderGraphBufferHandle hHistogramBuffer = ref_graph.ImportBuffer(m_hHistogramBuffer);
+  ezRenderGraphBufferHandle hMinMaxBuffer = ref_graph.ImportBuffer(m_hMinMaxBuffer);
+
+  if (!m_bPixelReadbackInFlight && m_Request.m_vPixelPosition.x >= 0 && m_Request.m_vPixelPosition.y >= 0)
+  {
+    ezRenderGraphReadbackPixelConstants constants;
+    constants.PixelPosition = m_Request.m_vPixelPosition;
+    constants.SampleIndex = iSampleIndex;
+    constants.SampleCount = uiSampleCount;
+    constants.TextureSize = ezVec2U32(mipSize.x, mipSize.y);
+
+    {
+      auto pass = ref_graph.AddComputePass("RenderGraphObserver Read Pixel");
+      pass.ReadTexture(hSource, sourceRange);
+      pass.WriteBuffer(hPixelBuffer);
+      pass.SetExecuteCallback([this, hSource, hPixelBuffer, sourceRange, constants, bIsMSAA](const ezRenderGraphContext& ctx)
+        {
+        ezRenderContext* pContext = ctx.GetRenderContext();
+        pContext->SetShaderPermutationVariable("MSAA", bIsMSAA ? ezTempHashedString("TRUE") : ezTempHashedString("FALSE"));
+        pContext->BindShader(m_hReadbackPixelShader);
+        pContext->SetPushConstants("ezRenderGraphReadbackPixelConstants", constants);
+        ezBindGroupBuilder& bindGroup = pContext->GetBindGroup(EZ_GAL_BIND_GROUP_DRAW_CALL);
+        bindGroup.BindTexture("SourceTexture", ctx.ResolveTexture(hSource), sourceRange, {}, ezGALTextureType::Texture2D);
+        bindGroup.BindBuffer("PixelOutput", ctx.ResolveBuffer(hPixelBuffer));
+        pContext->Dispatch(1, 1, 1).AssertSuccess(); });
+    }
+    {
+      auto readbackPass = ref_graph.AddTransferPass("RenderGraphObserver Pixel Readback");
+      readbackPass.ReadBuffer(hPixelBuffer, ezGALResourceState::CopySource);
+      readbackPass.HasSideEffects();
+      readbackPass.SetExecuteCallback([this, hPixelBuffer](const ezRenderGraphContext& ctx)
+        { m_PixelReadback.ReadbackBuffer(*ctx.GetCommandEncoder(), ctx.ResolveBuffer(hPixelBuffer)); });
+    }
+
+    m_bPixelReadbackInFlight = true;
+  }
+
+  if (!m_bMinMaxReadbackInFlight)
+  {
+    ezRenderGraphMinMaxConstants constants;
+    constants.TextureSize = ezVec2U32(mipSize.x, mipSize.y);
+    constants.SampleIndex = iSampleIndex;
+    constants.SampleCount = uiSampleCount;
+    constants.ChannelMask = m_Request.m_uiChannelMask;
+
+    {
+      auto pass = ref_graph.AddComputePass("RenderGraphObserver Clear MinMax");
+      pass.WriteBuffer(hMinMaxBuffer);
+      pass.HasSideEffects();
+      pass.SetExecuteCallback([this, hMinMaxBuffer](const ezRenderGraphContext& ctx)
+        {
+        ezRenderContext* pContext = ctx.GetRenderContext();
+        pContext->BindShader(m_hClearMinMaxShader);
+        ezBindGroupBuilder& bindGroup = pContext->GetBindGroup(EZ_GAL_BIND_GROUP_DRAW_CALL);
+        bindGroup.BindBuffer("MinMaxOutput", ctx.ResolveBuffer(hMinMaxBuffer));
+        pContext->Dispatch(1, 1, 1).AssertSuccess(); });
+    }
+
+    {
+      auto pass = ref_graph.AddComputePass("RenderGraphObserver Build MinMax");
+      pass.ReadTexture(hSource, sourceRange);
+      pass.WriteBuffer(hMinMaxBuffer);
+      pass.SetExecuteCallback([this, hSource, hMinMaxBuffer, sourceRange, constants, bIsMSAA](const ezRenderGraphContext& ctx)
+        {
+        ezRenderContext* pContext = ctx.GetRenderContext();
+        pContext->SetShaderPermutationVariable("MSAA", bIsMSAA ? ezTempHashedString("TRUE") : ezTempHashedString("FALSE"));
+        pContext->BindShader(m_hBuildMinMaxShader);
+        pContext->SetPushConstants("ezRenderGraphMinMaxConstants", constants);
+        ezBindGroupBuilder& bindGroup = pContext->GetBindGroup(EZ_GAL_BIND_GROUP_DRAW_CALL);
+        bindGroup.BindTexture("SourceTexture", ctx.ResolveTexture(hSource), sourceRange, ezGALResourceFormat::Invalid, ezGALTextureType::Texture2D);
+        bindGroup.BindBuffer("MinMaxOutput", ctx.ResolveBuffer(hMinMaxBuffer));
+        pContext->Dispatch((constants.TextureSize.x + 7u) / 8u, (constants.TextureSize.y + 7u) / 8u, 1).AssertSuccess(); });
+    }
+
+    {
+      auto readbackPass = ref_graph.AddTransferPass("RenderGraphObserver MinMax Readback");
+      readbackPass.ReadBuffer(hMinMaxBuffer, ezGALResourceState::CopySource);
+      readbackPass.HasSideEffects();
+      readbackPass.SetExecuteCallback([this, hMinMaxBuffer](const ezRenderGraphContext& ctx)
+        { m_MinMaxReadback.ReadbackBuffer(*ctx.GetCommandEncoder(), ctx.ResolveBuffer(hMinMaxBuffer)); });
+    }
+    m_bMinMaxReadbackInFlight = true;
+  }
+
+  if (!m_bHistogramReadbackInFlight)
+  {
+    ezRenderGraphHistogramConstants constants;
+    constants.TextureSize = ezVec2U32(mipSize.x, mipSize.y);
+    constants.SampleIndex = iSampleIndex;
+    constants.SampleCount = uiSampleCount;
+    constants.ChannelMask = m_Request.m_uiChannelMask;
+    constants.RangeMin = m_Request.m_fRangeMin;
+    constants.RangeMax = GetAdjustedHistogramMax(m_Request.m_fRangeMin, m_Request.m_fRangeMax);
+
+    {
+      auto pass = ref_graph.AddComputePass("RenderGraphObserver Clear Histogram");
+      pass.WriteBuffer(hHistogramBuffer);
+      pass.HasSideEffects();
+      pass.SetExecuteCallback([this, hHistogramBuffer](const ezRenderGraphContext& ctx)
+        {
+        ezRenderContext* pContext = ctx.GetRenderContext();
+        pContext->BindShader(m_hClearHistogramShader);
+        ezBindGroupBuilder& bindGroup = pContext->GetBindGroup(EZ_GAL_BIND_GROUP_DRAW_CALL);
+        bindGroup.BindBuffer("HistogramOutput", ctx.ResolveBuffer(hHistogramBuffer));
+        pContext->Dispatch(1, 1, 1).AssertSuccess(); });
+    }
+
+    {
+      auto pass = ref_graph.AddComputePass("RenderGraphObserver Build Histogram");
+      pass.ReadTexture(hSource, sourceRange);
+      pass.WriteBuffer(hHistogramBuffer);
+      pass.SetExecuteCallback([this, hSource, hHistogramBuffer, sourceRange, constants, bIsMSAA](const ezRenderGraphContext& ctx)
+        {
+        ezRenderContext* pContext = ctx.GetRenderContext();
+        pContext->SetShaderPermutationVariable("MSAA", bIsMSAA ? ezTempHashedString("TRUE") : ezTempHashedString("FALSE"));
+        pContext->BindShader(m_hBuildHistogramShader);
+        pContext->SetPushConstants("ezRenderGraphHistogramConstants", constants);
+        ezBindGroupBuilder& bindGroup = pContext->GetBindGroup(EZ_GAL_BIND_GROUP_DRAW_CALL);
+        bindGroup.BindTexture("SourceTexture", ctx.ResolveTexture(hSource), sourceRange, ezGALResourceFormat::Invalid, ezGALTextureType::Texture2D);
+        bindGroup.BindBuffer("HistogramOutput", ctx.ResolveBuffer(hHistogramBuffer));
+        pContext->Dispatch((constants.TextureSize.x + 7u) / 8u, (constants.TextureSize.y + 7u) / 8u, 1).AssertSuccess(); });
+    }
+
+    {
+      auto readbackPass = ref_graph.AddTransferPass("RenderGraphObserver Histogram Readback");
+      readbackPass.ReadBuffer(hHistogramBuffer, ezGALResourceState::CopySource);
+      readbackPass.HasSideEffects();
+      readbackPass.SetExecuteCallback([this, hHistogramBuffer](const ezRenderGraphContext& ctx)
+        { m_HistogramReadback.ReadbackBuffer(*ctx.GetCommandEncoder(), ctx.ResolveBuffer(hHistogramBuffer)); });
+    }
+    m_bHistogramReadbackInFlight = true;
+  }
+
+  const ezGALSwapChain* pSwapChain = pDevice->GetSwapChain(m_hSwapChain);
+  if (!pSwapChain)
+    return;
+
+  ezGALTextureHandle hBackbuffer = pSwapChain->GetBackBufferTexture();
+  const ezGALTexture* pBackbuffer = pDevice->GetTexture(hBackbuffer);
+  if (!pBackbuffer)
+    return;
+
+  const ezGALTextureCreationDescription& desc = pBackbuffer->GetDescription();
+  ezRenderGraphTextureHandle hTarget = ref_graph.ImportTexture(hBackbuffer);
+
+  const float fZoom = ezMath::Clamp(m_Request.m_fZoom, 0.1f, 64.0f);
+  const float fTexAspect = (float)mipSize.x / (float)ezMath::Max(mipSize.y, 1u);
+  const float fViewAspect = (float)desc.m_uiWidth / (float)ezMath::Max(desc.m_uiHeight, 1u);
+
+  float fHalfExtentU = 0.5f;
+  float fHalfExtentV = 0.5f;
+  if (fTexAspect > fViewAspect)
+  {
+    fHalfExtentU = 0.5f / fZoom;
+    fHalfExtentV = 0.5f / fZoom * (fTexAspect / fViewAspect);
+  }
+  else
+  {
+    fHalfExtentU = 0.5f / fZoom * (fViewAspect / fTexAspect);
+    fHalfExtentV = 0.5f / fZoom;
+  }
+
+  const ezVec2 uv0(m_Request.m_vPanCenter.x - fHalfExtentU, m_Request.m_vPanCenter.y - fHalfExtentV);
+  const ezVec2 uv1(m_Request.m_vPanCenter.x + fHalfExtentU, m_Request.m_vPanCenter.y + fHalfExtentV);
+
+  ezRenderGraphPreviewConstants previewConstants;
+  previewConstants.UVTransform = ezVec4(uv1.x - uv0.x, uv1.y - uv0.y, uv0.x, uv0.y);
+  previewConstants.ValueRange = ezVec2(m_Request.m_fRangeMin, m_Request.m_fRangeMax);
+  previewConstants.ChannelMask = m_Request.m_uiChannelMask;
+  previewConstants.SampleIndex = iSampleIndex;
+  previewConstants.PixelPosition = m_Request.m_vPixelPosition;
+  previewConstants.HighlightPixel = m_Request.m_bHighlightPixel ? 1 : 0;
+
+  {
+    auto pass = ref_graph.AddGraphicsPass("RenderGraphObserver Preview");
+    pass.AddColorTarget(hTarget);
+    pass.ReadTexture(hSource, sourceRange, ezGALResourceState::ShaderResource, ezGALShaderStageFlags::PixelShader);
+    pass.SetExecuteCallback([this, hSource, sourceRange, previewConstants, bIsMSAA](const ezRenderGraphContext& ctx)
+      {
+        ezRenderContext* pContext = ctx.GetRenderContext();
+        pContext->SetShaderPermutationVariable("MSAA", bIsMSAA ? ezTempHashedString("TRUE") : ezTempHashedString("FALSE"));
+
+        pContext->BindShader(m_hPreviewShader);
+        pContext->SetPushConstants("ezRenderGraphPreviewConstants", previewConstants);
+        pContext->BindNullMeshBuffer(ezGALPrimitiveTopology::Triangles, 1);
+
+        ezBindGroupBuilder& bindGroup = pContext->GetBindGroup(EZ_GAL_BIND_GROUP_DRAW_CALL);
+        bindGroup.BindTexture("SourceTexture", ctx.ResolveTexture(hSource), sourceRange, ezGALResourceFormat::Invalid, ezGALTextureType::Texture2D);
+
+        pContext->DrawMeshBuffer().AssertSuccess(); //
+      });
+  }
+}

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphSerialization.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphSerialization.cpp
@@ -88,7 +88,7 @@ namespace
     ref_value.m_BufferFlags.SetValue(bufferFlags);
     ref_value.m_Format = static_cast<ezGALResourceFormat::Enum>(uiFormat);
   }
-}
+} // namespace
 
 void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphObserverRequest& value)
 {

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphSerialization.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphSerialization.cpp
@@ -1,0 +1,331 @@
+#include <RendererCore/RendererCorePCH.h>
+
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
+
+#include <Foundation/IO/Stream.h>
+
+namespace
+{
+  void WriteTextureRange(ezStreamWriter& inout_stream, const ezGALTextureRange& value)
+  {
+    inout_stream << value.m_uiBaseMipLevel;
+    inout_stream << value.m_uiMipLevels;
+    inout_stream << value.m_uiBaseArraySlice;
+    inout_stream << value.m_uiArraySlices;
+  }
+
+  void ReadTextureRange(ezStreamReader& inout_stream, ezGALTextureRange& ref_value)
+  {
+    inout_stream >> ref_value.m_uiBaseMipLevel;
+    inout_stream >> ref_value.m_uiMipLevels;
+    inout_stream >> ref_value.m_uiBaseArraySlice;
+    inout_stream >> ref_value.m_uiArraySlices;
+  }
+
+  void WriteTextureDesc(ezStreamWriter& inout_stream, const ezGALTextureCreationDescription& value)
+  {
+    inout_stream << value.m_uiWidth;
+    inout_stream << value.m_uiHeight;
+    inout_stream << value.m_uiDepth;
+    inout_stream << value.m_uiArraySize;
+    inout_stream << value.m_uiMipLevelCount;
+    inout_stream << static_cast<ezUInt8>(value.m_Format.GetValue());
+    inout_stream << static_cast<ezUInt8>(value.m_SampleCount.GetValue());
+    inout_stream << static_cast<ezUInt8>(value.m_Type.GetValue());
+    inout_stream << value.m_TextureFlags.GetValue();
+    inout_stream << value.m_ResourceAccess.m_bImmutable;
+    inout_stream << reinterpret_cast<ezUInt64>(value.m_pExisitingNativeObject);
+  }
+
+  void ReadTextureDesc(ezStreamReader& inout_stream, ezGALTextureCreationDescription& ref_value)
+  {
+    ezUInt8 uiFormat = 0;
+    ezUInt8 uiSampleCount = 0;
+    ezUInt8 uiType = 0;
+    ezGALTextureUsageFlags::StorageType textureFlags = 0;
+    ezUInt64 uiNativeObject = 0;
+
+    inout_stream >> ref_value.m_uiWidth;
+    inout_stream >> ref_value.m_uiHeight;
+    inout_stream >> ref_value.m_uiDepth;
+    inout_stream >> ref_value.m_uiArraySize;
+    inout_stream >> ref_value.m_uiMipLevelCount;
+    inout_stream >> uiFormat;
+    inout_stream >> uiSampleCount;
+    inout_stream >> uiType;
+    inout_stream >> textureFlags;
+    inout_stream >> ref_value.m_ResourceAccess.m_bImmutable;
+    inout_stream >> uiNativeObject;
+
+    ref_value.m_Format = static_cast<ezGALResourceFormat::Enum>(uiFormat);
+    ref_value.m_SampleCount = static_cast<ezGALMSAASampleCount::Enum>(uiSampleCount);
+    ref_value.m_Type = static_cast<ezGALTextureType::Enum>(uiType);
+    ref_value.m_TextureFlags.SetValue(textureFlags);
+    ref_value.m_pExisitingNativeObject = reinterpret_cast<void*>(uiNativeObject);
+  }
+
+  void WriteBufferDesc(ezStreamWriter& inout_stream, const ezGALBufferCreationDescription& value)
+  {
+    inout_stream << value.m_uiTotalSize;
+    inout_stream << value.m_uiStructSize;
+    inout_stream << value.m_BufferFlags.GetValue();
+    inout_stream << value.m_ResourceAccess.m_bImmutable;
+    inout_stream << static_cast<ezUInt8>(value.m_Format.GetValue());
+  }
+
+  void ReadBufferDesc(ezStreamReader& inout_stream, ezGALBufferCreationDescription& ref_value)
+  {
+    ezGALBufferUsageFlags::StorageType bufferFlags = 0;
+    ezUInt8 uiFormat = 0;
+
+    inout_stream >> ref_value.m_uiTotalSize;
+    inout_stream >> ref_value.m_uiStructSize;
+    inout_stream >> bufferFlags;
+    inout_stream >> ref_value.m_ResourceAccess.m_bImmutable;
+    inout_stream >> uiFormat;
+
+    ref_value.m_BufferFlags.SetValue(bufferFlags);
+    ref_value.m_Format = static_cast<ezGALResourceFormat::Enum>(uiFormat);
+  }
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphObserverRequest& value)
+{
+  inout_stream << value.m_uiRenderGraphId;
+  inout_stream << value.m_sPassName;
+  inout_stream << value.m_uiAccessIndex;
+  inout_stream << value.m_uiSwapChainId;
+  inout_stream << value.m_uiArraySlice;
+  inout_stream << value.m_uiMipLevel;
+  inout_stream << value.m_uiChannelMask;
+  inout_stream << value.m_iSampleIndex;
+  inout_stream << value.m_fRangeMin;
+  inout_stream << value.m_fRangeMax;
+  inout_stream << value.m_fZoom;
+  inout_stream << value.m_vPanCenter;
+  inout_stream << value.m_vPixelPosition;
+  inout_stream << value.m_bHighlightPixel;
+}
+
+void operator>>(ezStreamReader& inout_stream, ezRenderGraphObserverRequest& ref_value)
+{
+  inout_stream >> ref_value.m_uiRenderGraphId;
+  inout_stream >> ref_value.m_sPassName;
+  inout_stream >> ref_value.m_uiAccessIndex;
+  inout_stream >> ref_value.m_uiSwapChainId;
+  inout_stream >> ref_value.m_uiArraySlice;
+  inout_stream >> ref_value.m_uiMipLevel;
+  inout_stream >> ref_value.m_uiChannelMask;
+  inout_stream >> ref_value.m_iSampleIndex;
+  inout_stream >> ref_value.m_fRangeMin;
+  inout_stream >> ref_value.m_fRangeMax;
+  inout_stream >> ref_value.m_fZoom;
+  inout_stream >> ref_value.m_vPanCenter;
+  inout_stream >> ref_value.m_vPixelPosition;
+  inout_stream >> ref_value.m_bHighlightPixel;
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphObserverResponse& value)
+{
+  inout_stream << value.m_fImageMin;
+  inout_stream << value.m_fImageMax;
+  inout_stream << static_cast<ezUInt32>(value.m_Histogram.GetCount());
+  for (ezUInt8 uiValue : value.m_Histogram)
+  {
+    inout_stream << uiValue;
+  }
+  inout_stream << value.m_bHistogramValid;
+  inout_stream << value.m_PixelValue;
+}
+
+void operator>>(ezStreamReader& inout_stream, ezRenderGraphObserverResponse& ref_value)
+{
+  ezUInt32 uiHistogramCount = 0;
+
+  inout_stream >> ref_value.m_fImageMin;
+  inout_stream >> ref_value.m_fImageMax;
+  inout_stream >> uiHistogramCount;
+
+  ref_value.m_Histogram.Clear();
+  ref_value.m_Histogram.SetCount(ezMath::Min<ezUInt32>(uiHistogramCount, 1024));
+  for (ezUInt32 i = 0; i < uiHistogramCount; ++i)
+  {
+    ezUInt8 uiValue = 0;
+    inout_stream >> uiValue;
+    if (i < ref_value.m_Histogram.GetCount())
+    {
+      ref_value.m_Histogram[i] = uiValue;
+    }
+  }
+
+  inout_stream >> ref_value.m_bHistogramValid;
+  inout_stream >> ref_value.m_PixelValue;
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphExecutionSummary& value)
+{
+  inout_stream << value.m_uiRenderGraphId;
+  inout_stream << value.m_sGraphName;
+  inout_stream << value.m_sUserName;
+  inout_stream << static_cast<ezUInt8>(value.m_Phase.GetValue());
+  inout_stream << value.m_uiExecutionOrder;
+}
+
+void operator>>(ezStreamReader& inout_stream, ezRenderGraphExecutionSummary& ref_value)
+{
+  ezUInt8 uiPhase = 0;
+
+  inout_stream >> ref_value.m_uiRenderGraphId;
+  inout_stream >> ref_value.m_sGraphName;
+  inout_stream >> ref_value.m_sUserName;
+  inout_stream >> uiPhase;
+  inout_stream >> ref_value.m_uiExecutionOrder;
+
+  ref_value.m_Phase = static_cast<ezRenderGraphPhase::Enum>(uiPhase);
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphSwapChainSummary& value)
+{
+  inout_stream << value.m_uiSwapChainId;
+  inout_stream << value.m_uiWidth;
+  inout_stream << value.m_uiHeight;
+}
+
+void operator>>(ezStreamReader& inout_stream, ezRenderGraphSwapChainSummary& ref_value)
+{
+  inout_stream >> ref_value.m_uiSwapChainId;
+  inout_stream >> ref_value.m_uiWidth;
+  inout_stream >> ref_value.m_uiHeight;
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphInspectionSummary& value)
+{
+  inout_stream << static_cast<ezUInt32>(value.m_RenderGraphs.GetCount());
+  for (const auto& graph : value.m_RenderGraphs)
+  {
+    inout_stream << graph;
+  }
+
+  inout_stream << static_cast<ezUInt32>(value.m_AvailableSwapChains.GetCount());
+  for (const auto& swapChain : value.m_AvailableSwapChains)
+  {
+    inout_stream << swapChain;
+  }
+}
+
+void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionSummary& ref_value)
+{
+  ezUInt32 uiGraphCount = 0;
+  ezUInt32 uiSwapChainCount = 0;
+
+  inout_stream >> uiGraphCount;
+  ref_value.m_RenderGraphs.SetCount(uiGraphCount);
+  for (auto& graph : ref_value.m_RenderGraphs)
+  {
+    inout_stream >> graph;
+  }
+
+  inout_stream >> uiSwapChainCount;
+  ref_value.m_AvailableSwapChains.SetCount(uiSwapChainCount);
+  for (auto& swapChain : ref_value.m_AvailableSwapChains)
+  {
+    inout_stream >> swapChain;
+  }
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphInspectionInfo& value)
+{
+  inout_stream << static_cast<ezUInt32>(value.m_Passes.GetCount());
+  for (const auto& pass : value.m_Passes)
+  {
+    inout_stream << pass.m_sName;
+    inout_stream << static_cast<ezUInt8>(pass.m_QueueType.GetValue());
+    inout_stream << pass.m_bHasSideEffects;
+    inout_stream << pass.m_bAlive;
+  }
+
+  inout_stream << static_cast<ezUInt32>(value.m_Textures.GetCount());
+  for (const auto& texture : value.m_Textures)
+  {
+    WriteTextureDesc(inout_stream, texture.m_Desc);
+    inout_stream << texture.m_bImported;
+    inout_stream << texture.m_uiFirstUsePassIndex;
+    inout_stream << texture.m_uiLastUsePassIndex;
+    inout_stream << texture.m_uiResolvedIndex;
+  }
+
+  inout_stream << static_cast<ezUInt32>(value.m_Buffers.GetCount());
+  for (const auto& buffer : value.m_Buffers)
+  {
+    WriteBufferDesc(inout_stream, buffer.m_Desc);
+    inout_stream << buffer.m_bImported;
+    inout_stream << buffer.m_uiFirstUsePassIndex;
+    inout_stream << buffer.m_uiLastUsePassIndex;
+    inout_stream << buffer.m_uiResolvedIndex;
+  }
+
+  inout_stream << static_cast<ezUInt32>(value.m_Accesses.GetCount());
+  for (const auto& access : value.m_Accesses)
+  {
+    inout_stream << access.m_uiPassIndex;
+    inout_stream << access.m_uiResourceIndex;
+    inout_stream << access.m_uiAccessIndex;
+    inout_stream << access.m_bIsTexture;
+    inout_stream << access.m_Access.GetValue();
+    WriteTextureRange(inout_stream, access.m_TextureRange);
+  }
+}
+
+void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionInfo& ref_value)
+{
+  ezUInt32 uiCount = 0;
+
+  inout_stream >> uiCount;
+  ref_value.m_Passes.SetCount(uiCount);
+  for (auto& pass : ref_value.m_Passes)
+  {
+    ezUInt8 uiQueueType = 0;
+    inout_stream >> pass.m_sName;
+    inout_stream >> uiQueueType;
+    inout_stream >> pass.m_bHasSideEffects;
+    inout_stream >> pass.m_bAlive;
+    pass.m_QueueType = static_cast<ezGALQueueType::Enum>(uiQueueType);
+  }
+
+  inout_stream >> uiCount;
+  ref_value.m_Textures.SetCount(uiCount);
+  for (auto& texture : ref_value.m_Textures)
+  {
+    ReadTextureDesc(inout_stream, texture.m_Desc);
+    inout_stream >> texture.m_bImported;
+    inout_stream >> texture.m_uiFirstUsePassIndex;
+    inout_stream >> texture.m_uiLastUsePassIndex;
+    inout_stream >> texture.m_uiResolvedIndex;
+  }
+
+  inout_stream >> uiCount;
+  ref_value.m_Buffers.SetCount(uiCount);
+  for (auto& buffer : ref_value.m_Buffers)
+  {
+    ReadBufferDesc(inout_stream, buffer.m_Desc);
+    inout_stream >> buffer.m_bImported;
+    inout_stream >> buffer.m_uiFirstUsePassIndex;
+    inout_stream >> buffer.m_uiLastUsePassIndex;
+    inout_stream >> buffer.m_uiResolvedIndex;
+  }
+
+  inout_stream >> uiCount;
+  ref_value.m_Accesses.SetCount(uiCount);
+  for (auto& access : ref_value.m_Accesses)
+  {
+    ezGALResourceState::StorageType accessFlags = 0;
+    inout_stream >> access.m_uiPassIndex;
+    inout_stream >> access.m_uiResourceIndex;
+    inout_stream >> access.m_uiAccessIndex;
+    inout_stream >> access.m_bIsTexture;
+    inout_stream >> accessFlags;
+    access.m_Access.SetValue(accessFlags);
+    ReadTextureRange(inout_stream, access.m_TextureRange);
+  }
+}

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraph.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraph.h
@@ -12,9 +12,11 @@
 
 class ezGALCommandEncoder;
 class ezGALDevice;
+class ezRenderGraphPassObserver;
 class ezRenderGraphResourcePool;
 class ezRenderGraphResourceAllocator;
 class ezGALResourceStateTracker;
+struct ezRenderGraphInspectionInfo;
 
 /// Render graph usable for a single frame. Contains passes that declare transient resource dependencies. After all passes are added, the graph is compiled to cull unused passes, allocate and alias transient resources, and compute barrier placement, then executed. Passes are always executed in declaration order.
 ///
@@ -30,8 +32,8 @@ public:
   const ezString& GetGraphName() const { return m_sGraphName; }
 
   /// Sets the user name that can be changed at any time.
-  void SetUserName(ezStringView sName) { m_sUserName = sName; }
-  const ezString& GetUserName() const { return m_sUserName; }
+  void SetUserName(ezStringView sName) {m_sUserName = sName; }
+  const ezString& GetUserName() const {return m_sUserName; }
 
   /// User data is accessible during execution callbacks via `ctx.GetUserData<T>()`.
   void SetUserData(ezReflectedClass* pUserData) { m_pUserData = pUserData; }
@@ -104,10 +106,10 @@ public:
   ezResult Compile();
 
   /// Compute texture and buffer barriers for each pass based on resource state tracking.
-  void ComputeBarriers(ezGALResourceStateTracker& ref_tracker);
+  void ComputeBarriers(ezGALResourceStateTracker& ref_tracker, ezArrayPtr<ezRenderGraphPassObserver*> observers = {});
 
   /// Execute all passes in compiled order.
-  void Execute(ezRenderGraphContext& ref_ctx);
+  void Execute(ezRenderGraphContext& ctx, ezArrayPtr<ezRenderGraphPassObserver*> observers = {});
 
 private:
   friend class ezRenderGraphManager;
@@ -117,6 +119,8 @@ private:
 
   void StartPassBuilder(ezEnum<ezGALQueueType> queueType, ezStringView sName);
   void EndPassBuilder();
+
+  ezResult GetInspectionInfo(ezRenderGraphInspectionInfo& out_info) const;
 
   /// Find a pass by name and return its original index. Returns s_Unused if not found.
   ezUInt16 FindPassByName(ezStringView sName) const;

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraph.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraph.h
@@ -109,7 +109,7 @@ public:
   void ComputeBarriers(ezGALResourceStateTracker& ref_tracker, ezArrayPtr<ezRenderGraphPassObserver*> observers = {});
 
   /// Execute all passes in compiled order.
-  void Execute(ezRenderGraphContext& ctx, ezArrayPtr<ezRenderGraphPassObserver*> observers = {});
+  void Execute(ezRenderGraphContext& ref_ctx, ezArrayPtr<ezRenderGraphPassObserver*> observers = {});
 
 private:
   friend class ezRenderGraphManager;

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraph.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraph.h
@@ -32,8 +32,8 @@ public:
   const ezString& GetGraphName() const { return m_sGraphName; }
 
   /// Sets the user name that can be changed at any time.
-  void SetUserName(ezStringView sName) {m_sUserName = sName; }
-  const ezString& GetUserName() const {return m_sUserName; }
+  void SetUserName(ezStringView sName) { m_sUserName = sName; }
+  const ezString& GetUserName() const { return m_sUserName; }
 
   /// User data is accessible during execution callbacks via `ctx.GetUserData<T>()`.
   void SetUserData(ezReflectedClass* pUserData) { m_pUserData = pUserData; }

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Strings/String.h>
+#include <RendererCore/RendererCoreDLL.h>
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/Descriptors/Enumerations.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererCore/RenderGraph/Declarations.h>
+
+class ezStreamReader;
+class ezStreamWriter;
+
+/// Identifies a render graph execution that was observed during the last frame.
+struct ezRenderGraphExecutionSummary
+{
+  ezUInt64 m_uiRenderGraphId = 0;
+  ezString m_sGraphName;
+  ezString m_sUserName;
+  ezEnum<ezRenderGraphPhase> m_Phase;
+  ezInt32 m_uiExecutionOrder = -1; ///< execution oder in the phase. -1 if not executed this frame.
+};
+
+/// Describes a swap-chain that can be used as a preview target by the render graph inspector.
+struct ezRenderGraphSwapChainSummary
+{
+  EZ_DECLARE_POD_TYPE();
+
+  ezUInt32 m_uiSwapChainId = 0;
+  ezUInt32 m_uiWidth = 0;
+  ezUInt32 m_uiHeight = 0;
+};
+
+/// Aggregates the render graphs and preview targets currently known to the inspector.
+struct ezRenderGraphInspectionSummary
+{
+  ezDynamicArray<ezRenderGraphExecutionSummary> m_RenderGraphs;
+  ezDynamicArray<ezRenderGraphSwapChainSummary> m_AvailableSwapChains;
+};
+
+EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphExecutionSummary& value);
+EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphExecutionSummary& ref_value);
+EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphSwapChainSummary& value);
+EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphSwapChainSummary& ref_value);
+EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphInspectionSummary& value);
+EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionSummary& ref_value);
+
+/// Read-only snapshot of a compiled render graph's structure, taken after compilation. Used for visualization and debugging without exposing internal graph state.
+struct ezRenderGraphInspectionInfo
+{
+  void Swap(ezRenderGraphInspectionInfo& data);
+  void Clear();
+
+  /// Describes one declared pass and whether it remains active after graph compilation.
+  struct PassInfo
+  {
+    ezString m_sName;
+    ezEnum<ezGALQueueType> m_QueueType;
+    bool m_bHasSideEffects = false;
+    bool m_bAlive = true; ///< false if the pass was culled during compilation.
+  };
+
+  /// Describes a texture resource used by the compiled render graph.
+  struct TextureResourceInfo
+  {
+    EZ_DECLARE_POD_TYPE();
+    ezGALTextureCreationDescription m_Desc;
+    bool m_bImported = false;
+    ezUInt16 m_uiFirstUsePassIndex = 0xFFFF;
+    ezUInt16 m_uiLastUsePassIndex = 0xFFFF;
+    ezUInt16 m_uiResolvedIndex = 0xFFFF;
+  };
+
+  /// Describes a buffer resource used by the compiled render graph.
+  struct BufferResourceInfo
+  {
+    EZ_DECLARE_POD_TYPE();
+    ezGALBufferCreationDescription m_Desc;
+    bool m_bImported = false;
+    ezUInt16 m_uiFirstUsePassIndex = 0xFFFF;
+    ezUInt16 m_uiLastUsePassIndex = 0xFFFF;
+    ezUInt16 m_uiResolvedIndex = 0xFFFF;
+  };
+
+  /// Describes a single resource access made by one pass in the compiled render graph.
+  struct AccessInfo
+  {
+    EZ_DECLARE_POD_TYPE();
+    ezUInt16 m_uiPassIndex = 0;     ///< Index into m_Passes (declaration order).
+    ezUInt16 m_uiResourceIndex = 0; ///< Index into m_Textures or m_Buffers.
+    ezUInt16 m_uiAccessIndex = 0;
+    bool m_bIsTexture = true;
+    ezBitflags<ezGALResourceState> m_Access;
+    ezGALTextureRange m_TextureRange; ///< Only meaningful for textures.
+  };
+
+  /// All passes in declaration order. Culled passes have m_bAlive == false.
+  ezDynamicArray<PassInfo> m_Passes;
+
+  ezDynamicArray<TextureResourceInfo> m_Textures;
+  ezDynamicArray<BufferResourceInfo> m_Buffers;
+
+  /// All resource accesses across all passes, flattened first by passId, then by access types.
+  ezDynamicArray<AccessInfo> m_Accesses;
+};
+
+EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphInspectionInfo& value);
+EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionInfo& ref_value);
+
+inline void ezRenderGraphInspectionInfo::Swap(ezRenderGraphInspectionInfo& data)
+{
+  m_Passes.Swap(data.m_Passes);
+  m_Textures.Swap(data.m_Textures);
+  m_Buffers.Swap(data.m_Buffers);
+  m_Accesses.Swap(data.m_Accesses);
+}
+
+inline void ezRenderGraphInspectionInfo::Clear()
+{
+  m_Passes.Clear();
+  m_Textures.Clear();
+  m_Buffers.Clear();
+  m_Accesses.Clear();
+}

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
@@ -2,11 +2,11 @@
 
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Strings/String.h>
+#include <RendererCore/RenderGraph/Declarations.h>
 #include <RendererCore/RendererCoreDLL.h>
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Descriptors/Enumerations.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
-#include <RendererCore/RenderGraph/Declarations.h>
 
 class ezStreamReader;
 class ezStreamWriter;

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
@@ -46,7 +46,7 @@ EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRender
 EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionSummary& ref_value);
 
 /// Read-only snapshot of a compiled render graph's structure, taken after compilation. Used for visualization and debugging without exposing internal graph state.
-struct ezRenderGraphInspectionInfo
+struct EZ_RENDERERCORE_DLL ezRenderGraphInspectionInfo
 {
   void Swap(ezRenderGraphInspectionInfo& data);
   void Clear();
@@ -107,18 +107,3 @@ struct ezRenderGraphInspectionInfo
 EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphInspectionInfo& value);
 EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionInfo& ref_value);
 
-inline void ezRenderGraphInspectionInfo::Swap(ezRenderGraphInspectionInfo& data)
-{
-  m_Passes.Swap(data.m_Passes);
-  m_Textures.Swap(data.m_Textures);
-  m_Buffers.Swap(data.m_Buffers);
-  m_Accesses.Swap(data.m_Accesses);
-}
-
-inline void ezRenderGraphInspectionInfo::Clear()
-{
-  m_Passes.Clear();
-  m_Textures.Clear();
-  m_Buffers.Clear();
-  m_Accesses.Clear();
-}

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
@@ -106,4 +106,3 @@ struct EZ_RENDERERCORE_DLL ezRenderGraphInspectionInfo
 
 EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphInspectionInfo& value);
 EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphInspectionInfo& ref_value);
-

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphInspectionInfo.h
@@ -48,7 +48,7 @@ EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphI
 /// Read-only snapshot of a compiled render graph's structure, taken after compilation. Used for visualization and debugging without exposing internal graph state.
 struct EZ_RENDERERCORE_DLL ezRenderGraphInspectionInfo
 {
-  void Swap(ezRenderGraphInspectionInfo& data);
+  void Swap(ezRenderGraphInspectionInfo& ref_data);
   void Clear();
 
   /// Describes one declared pass and whether it remains active after graph compilation.

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphManager.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphManager.h
@@ -54,7 +54,7 @@ public:
 
   /// Fills an inspection info of a specific render graph.
   /// Only safe to call from an ezRenderGraphRenderEvent::Type::AfterGraphExecution callback registered through s_RenderEvent.
-  static ezResult GetRenderGraphInspectionInfo(ezUInt64 uiRenderGraphId, ezRenderGraphInspectionInfo& out_InspectionInfo);
+  static ezResult GetRenderGraphInspectionInfo(ezUInt64 uiRenderGraphId, ezRenderGraphInspectionInfo& out_inspectionInfo);
 
   static ezSharedPtr<ezRenderGraphPassObserver> CreateObserver();
 

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphManager.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphManager.h
@@ -8,6 +8,7 @@
 struct ezGALDeviceEvent;
 class ezGALResourceStateTracker;
 class ezRenderGraph;
+class ezRenderGraphPassObserver;
 class ezRenderGraphResourcePool;
 struct ezTextureValidationError;
 struct ezBufferValidationError;
@@ -44,6 +45,21 @@ public:
   /// Access the shared resource pool. Only valid after device init.
   static ezRenderGraphResourcePool* GetResourcePool();
 
+  /// \name Pass Observers
+  ///@{
+
+  /// Fills a summary with the render graphs and available swapchains.
+  /// Only safe to call from an ezRenderGraphRenderEvent::Type::AfterGraphExecution callback registered through s_RenderEvent.
+  static void GetExecutionSummary(ezRenderGraphInspectionSummary& out_summary);
+
+  /// Fills an inspection info of a specific render graph.
+  /// Only safe to call from an ezRenderGraphRenderEvent::Type::AfterGraphExecution callback registered through s_RenderEvent.
+  static ezResult GetRenderGraphInspectionInfo(ezUInt64 uiRenderGraphId, ezRenderGraphInspectionInfo& out_InspectionInfo);
+
+  static ezSharedPtr<ezRenderGraphPassObserver> CreateObserver();
+
+  ///@}
+
   static ezEvent<const ezRenderGraphRenderEvent&, ezMutex> s_RenderEvent;
 
   /// Prints all operations and barriers affecting a texture resource up to the current execution point.
@@ -56,6 +72,7 @@ public:
 
 private:
   friend class ezRenderGraph;
+  friend class ezRenderGraphPassObserver;
 
   static void OnEngineStartup();
   static void OnEngineShutdown();
@@ -65,6 +82,10 @@ private:
   static void DeinitPool(ezGALDevice* pDevice);
   static void BeginFrame();
   static void OnGraphDestroyed(ezRenderGraph* pGraph);
+  static ezUInt64 GetRenderGraphId(ezRenderGraph* pGraph);
+  static ezRenderGraph* GetRenderGraphById(ezUInt64 uiRenderGraphId);
+  static ezUInt32 GetSwapChainId(ezGALSwapChainHandle hSwapChain);
+  static ezGALSwapChainHandle GetSwapChainById(ezUInt32 uiSwapChainId);
 
   EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(RendererCore, RenderGraphManager);
 
@@ -74,8 +95,13 @@ private:
   static ezUniquePtr<ezRenderGraphResourcePool> s_pPool;
   static ezUniquePtr<ezGALResourceStateTracker> s_pStateTracker;
 
+  // Pass observers
+  static ezDynamicArray<ezSharedPtr<ezRenderGraphPassObserver>> s_Observers;
+  static ezSharedPtr<ezRenderGraph> s_pObserverGraph;
+
   // Execution tracking for diagnostics
   static ezDynamicArray<ezRenderGraph*> s_ExecutingGraphs; ///< Executed this frame, kept alive via s_EnqueuedRenderGraphs
+  static ezDynamicArray<ezRenderGraphPassObserver*> s_ExecutingObservers;
   static ezUInt32 s_uiCurrentGraphIndex;
   static ezUInt32 s_uiCurrentPassIndex;
 };

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphPassObserver.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphPassObserver.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <Core/ResourceManager/ResourceHandle.h>
+#include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Strings/String.h>
+#include <RendererCore/RendererCoreDLL.h>
+#include <RendererCore/Shader/ShaderResource.h>
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Resources/ReadbackHelper.h>
+
+using ezTexture2DResourceHandle = ezTypedResourceHandle<class ezTexture2DResource>;
+
+class ezGALDevice;
+class ezRenderGraph;
+class ezStreamReader;
+class ezStreamWriter;
+
+/// Identifies a specific texture access within a render graph pass to observe.
+/// Optionally also sets a target swap-chain to blit a preview image on.
+struct ezRenderGraphObserverRequest
+{
+  // Source texture
+  ezUInt64 m_uiRenderGraphId = 0;
+  ezString m_sPassName;
+  ezUInt16 m_uiAccessIndex = 0; ///< Nth texture access (reads then writes) within the pass.
+
+  // Preview target
+  ezUInt32 m_uiSwapChainId = 0xFFFFFFFF; ///< If invalid, no preview will be rendered.
+
+  // Sub-resource
+  ezUInt16 m_uiArraySlice = 0;
+  ezUInt8 m_uiMipLevel = 0;
+  ezUInt8 m_uiChannelMask = EZ_BIT(0) | EZ_BIT(1) | EZ_BIT(2) | EZ_BIT(3); ///< red, green, blue, alpha
+  ezInt8 m_iSampleIndex = -1;   ///< Negative = auto-resolve, 0+ = specific MSAA sample.
+
+  // Value Clamp
+  float m_fRangeMin = 0.0f;
+  float m_fRangeMax = 1.0f;
+
+  // Zoom
+  float m_fZoom = 1.0f;
+  ezVec2 m_vPanCenter = ezVec2(0.5f);
+
+  // Pixel readback
+  ezVec2I32 m_vPixelPosition = ezVec2I32(-1, -1); ///< Updated while pixel sampling is active. If negative, no pixel is selected.
+  bool m_bHighlightPixel = false;                 ///< If true, preview rendering highlights the selected pixel row and column.
+};
+
+/// Contains the readback data produced for the active render graph observer request.
+struct ezRenderGraphObserverResponse
+{
+  float m_fImageMin = 0.0f;
+  float m_fImageMax = 1.0f;
+  ezStaticArray<ezUInt8, 1024> m_Histogram; ///< Four 256-bin RGBA histograms, relative to m_fRangeMin / m_fRangeMax and normalized to the highest non-flat channel value.
+  bool m_bHistogramValid = false;
+  ezVariant m_PixelValue;
+};
+
+EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphObserverRequest& value);
+EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphObserverRequest& ref_value);
+EZ_RENDERERCORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezRenderGraphObserverResponse& value);
+EZ_RENDERERCORE_DLL void operator>>(ezStreamReader& inout_stream, ezRenderGraphObserverResponse& ref_value);
+
+/// Observes a texture at a specific point in the render graph pipeline by copying it into a persistent texture after the target pass executes. Register instances with ezRenderGraphManager. The render graph will compute barriers and execute the copy without modifying its own data structures.
+class EZ_RENDERERCORE_DLL ezRenderGraphPassObserver : public ezRefCounted
+{
+public:
+  ~ezRenderGraphPassObserver();
+
+  /// Thread-safe. Can be called from any thread. The request is applied
+  /// on the render thread before barrier computation.
+  void SetRequest(const ezRenderGraphObserverRequest& request);
+
+  /// Returns the active request. Only valid to call from the render thread.
+  const ezRenderGraphObserverRequest& GetRequest() const { return m_Request; }
+
+  /// Returns the persistent copy of the observed texture as a resource handle.
+  /// Can be used with material texture bindings. Invalid if no capture has occurred.
+  const ezTexture2DResourceHandle& GetCopyTextureResource() const { return m_hCopyTextureResource; }
+
+  /// Returns the underlying GAL handle of the copy texture. Used internally for
+  /// the GPU copy operation.
+  ezGALTextureHandle GetCopyTexture() const { return m_hCopyTexture; }
+
+  /// Thread-safe. Returns the most recent inspection data that has finished readback.
+  ezRenderGraphObserverResponse GetResponse() const;
+
+  /// \name Internal — called by ezRenderGraph during ComputeBarriers / Execute
+  ///@{
+
+  /// Clears per-frame state. Called at the start of each frame's barrier computation.
+  void Reset();
+
+  /// Copies the pending request into the active request. Called on the
+  /// render thread under the manager's mutex before barrier computation.
+  void ApplyPendingRequest();
+
+  /// (Re)creates the copy texture to match the source description if needed.
+  void EnsureCopyTexture(const ezGALTextureCreationDescription& srcDesc);
+
+  void RecordPreview(ezRenderGraph& ref_graph);
+
+  ///@}
+
+private:
+  friend class ezRenderGraph;
+  friend class ezRenderGraphManager;
+  ezRenderGraphPassObserver(ezGALDevice* pDevice);
+
+  void EnsureInspectionResources();
+  void DestroyInspectionResources();
+  void PollReadbacks();
+  void ProcessPixelReadback(ezArrayPtr<const ezUInt8> memory);
+  void ProcessHistogramReadback(ezArrayPtr<const ezUInt8> memory);
+  void ProcessMinMaxReadback(ezArrayPtr<const ezUInt8> memory);
+
+  mutable ezMutex m_Mutex;
+  ezGALDevice* m_pDevice = nullptr;
+  ezRenderGraphObserverRequest m_Request;        ///< Active request, only accessed on render thread.
+  ezRenderGraphObserverRequest m_PendingRequest; ///< Written by any thread via SetRequest(), guarded by m_Mutex.
+  ezRenderGraphObserverResponse m_Response;      ///< Guarded by m_Mutex.
+  bool m_bPendingRequestDirty = false;           ///< True when m_PendingRequest has been set but not yet applied.
+  ezRenderGraph* m_pGraph = nullptr;
+  ezGALSwapChainHandle m_hSwapChain;
+  ezGALTextureHandle m_hCopyTexture;
+  ezTexture2DResourceHandle m_hCopyTextureResource;
+
+  ezGALBufferHandle m_hPixelReadbackBuffer;
+  ezGALBufferHandle m_hHistogramBuffer;
+  ezGALBufferHandle m_hMinMaxBuffer;
+  ezGALReadbackBufferHelper m_PixelReadback;
+  ezGALReadbackBufferHelper m_HistogramReadback;
+  ezGALReadbackBufferHelper m_MinMaxReadback;
+  ezShaderResourceHandle m_hReadbackPixelShader;
+  ezShaderResourceHandle m_hClearHistogramShader;
+  ezShaderResourceHandle m_hBuildHistogramShader;
+  ezShaderResourceHandle m_hClearMinMaxShader;
+  ezShaderResourceHandle m_hBuildMinMaxShader;
+  ezShaderResourceHandle m_hPreviewShader;
+  bool m_bPixelReadbackInFlight = false;
+  bool m_bHistogramReadbackInFlight = false;
+  bool m_bMinMaxReadbackInFlight = false;
+
+  bool m_bValid = false;
+  ezUInt32 m_uiSortedPassIndex = 0xFFFFFFFF;
+  ezGALTextureHandle m_hResolvedSourceTexture;
+
+  ezHybridArray<ezGALTextureBarrier, 4> m_PreCopyBarriers;
+  ezHybridArray<ezGALTextureBarrier, 4> m_PostCopyBarriers;
+
+
+};

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphPassObserver.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphPassObserver.h
@@ -32,7 +32,7 @@ struct ezRenderGraphObserverRequest
   ezUInt16 m_uiArraySlice = 0;
   ezUInt8 m_uiMipLevel = 0;
   ezUInt8 m_uiChannelMask = EZ_BIT(0) | EZ_BIT(1) | EZ_BIT(2) | EZ_BIT(3); ///< red, green, blue, alpha
-  ezInt8 m_iSampleIndex = -1;   ///< Negative = auto-resolve, 0+ = specific MSAA sample.
+  ezInt8 m_iSampleIndex = -1;                                              ///< Negative = auto-resolve, 0+ = specific MSAA sample.
 
   // Value Clamp
   float m_fRangeMin = 0.0f;
@@ -148,6 +148,4 @@ private:
 
   ezHybridArray<ezGALTextureBarrier, 4> m_PreCopyBarriers;
   ezHybridArray<ezGALTextureBarrier, 4> m_PostCopyBarriers;
-
-
 };

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -243,6 +243,8 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALTextureCreationDescription : public ezHash
   void SetAsRenderTarget(ezUInt32 uiWidth, ezUInt32 uiHeight, ezGALResourceFormat::Enum format, ezGALMSAASampleCount::Enum sampleCount = ezGALMSAASampleCount::None);
   void SetAsRenderTarget(ezUInt32 uiWidth, ezUInt32 uiHeight, ezUInt32 uiArraySize, ezGALResourceFormat::Enum format, ezGALMSAASampleCount::Enum sampleCount = ezGALMSAASampleCount::None);
   ezResult Validate(ezGALDevice* pDevice, ezArrayPtr<ezGALSystemMemoryDescription> initialData = {}) const;
+  ezUInt32 GetNumberOfSlices() const;
+  ezVec3U32 GetMipMapSize(ezUInt32 uiMipLevel) const;
 
   /// Returns the most appropriate default resource state based on the texture's allowed views and format.
   ezBitflags<ezGALResourceState> GetDefaultState() const;

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
@@ -82,7 +82,7 @@ ezResult ezGALTextureCreationDescription::Validate(ezGALDevice* pDevice, ezArray
 
 ezUInt32 ezGALTextureCreationDescription::GetNumberOfSlices() const
 {
-  if (m_Type ==ezGALTextureType::TextureCube || m_Type == ezGALTextureType::TextureCubeArray)
+  if (m_Type == ezGALTextureType::TextureCube || m_Type == ezGALTextureType::TextureCubeArray)
     return m_uiArraySize * 6;
   return m_uiArraySize;
 }

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
@@ -80,6 +80,22 @@ ezResult ezGALTextureCreationDescription::Validate(ezGALDevice* pDevice, ezArray
   return EZ_SUCCESS;
 }
 
+ezUInt32 ezGALTextureCreationDescription::GetNumberOfSlices() const
+{
+  if (m_Type ==ezGALTextureType::TextureCube || m_Type == ezGALTextureType::TextureCubeArray)
+    return m_uiArraySize * 6;
+  return m_uiArraySize;
+}
+
+ezVec3U32 ezGALTextureCreationDescription::GetMipMapSize(ezUInt32 uiMipLevel) const
+{
+  ezVec3U32 size = {m_uiWidth, m_uiHeight, m_uiDepth};
+  size.x = ezMath::Max(1u, size.x >> uiMipLevel);
+  size.y = ezMath::Max(1u, size.y >> uiMipLevel);
+  size.z = ezMath::Max(1u, size.z >> uiMipLevel);
+  return size;
+}
+
 ezBitflags<ezGALResourceState> ezGALTextureCreationDescription::GetDefaultState() const
 {
   if (m_TextureFlags.IsSet(ezGALTextureUsageFlags::Presentable))

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -166,8 +166,9 @@ public:
 
   // Swap chain functions
 
-  ezGALTextureHandle GetBackBufferTextureFromSwapChain(ezGALSwapChainHandle hSwapChain);
+  ezGALTextureHandle GetBackBufferTextureFromSwapChain(ezGALSwapChainHandle hSwapChain) const;
 
+  void GetAllSwapChains(ezDynamicArray<ezGALSwapChainHandle>& out_swapChains) const;
 
   // Misc functions
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1594,7 +1594,7 @@ ezReadbackTextureLock ezGALDevice::LockTexture(ezGALReadbackTextureHandle hReadb
   return ezReadbackTextureLock(this, pReadbackTexture, subResources, out_memory);
 }
 
-ezGALTextureHandle ezGALDevice::GetBackBufferTextureFromSwapChain(ezGALSwapChainHandle hSwapChain)
+ezGALTextureHandle ezGALDevice::GetBackBufferTextureFromSwapChain(ezGALSwapChainHandle hSwapChain) const
 {
   ezGALSwapChain* pSwapChain = nullptr;
 
@@ -1609,7 +1609,14 @@ ezGALTextureHandle ezGALDevice::GetBackBufferTextureFromSwapChain(ezGALSwapChain
   }
 }
 
-
+void ezGALDevice::GetAllSwapChains(ezDynamicArray<ezGALSwapChainHandle>& out_swapChains) const
+{
+  out_swapChains.Reserve(m_SwapChains.GetCount());
+  for (auto it = m_SwapChains.GetIterator(); it.IsValid(); ++it)
+  {
+    out_swapChains.PushBack(ezGALSwapChainHandle(it.Id()));
+  }
+}
 
 // Misc functions
 

--- a/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
@@ -15,11 +15,7 @@ ezGALTexture::~ezGALTexture()
 
 ezVec3U32 ezGALTexture::GetMipMapSize(ezUInt32 uiMipLevel) const
 {
-  ezVec3U32 size = {m_Description.m_uiWidth, m_Description.m_uiHeight, m_Description.m_uiDepth};
-  size.x = ezMath::Max(1u, size.x >> uiMipLevel);
-  size.y = ezMath::Max(1u, size.y >> uiMipLevel);
-  size.z = ezMath::Max(1u, size.z >> uiMipLevel);
-  return size;
+  return m_Description.GetMipMapSize(uiMipLevel);
 }
 
 ezGALTextureRange ezGALTexture::ClampRange(ezGALTextureRange range) const

--- a/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
+++ b/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
@@ -17,46 +17,46 @@ template <typename T>
 struct ezComPtr
 {
 public:
-  ezComPtr() {}
+  ezComPtr() = default;
   ~ezComPtr()
   {
-    if (m_ptr != nullptr)
+    if (m_pPtr != nullptr)
     {
-      m_ptr->Release();
-      m_ptr = nullptr;
+      m_pPtr->Release();
+      m_pPtr = nullptr;
     }
   }
 
   ezComPtr(const ezComPtr& other)
-    : m_ptr(other.m_ptr)
+    : m_pPtr(other.m_pPtr)
   {
-    if (m_ptr)
+    if (m_pPtr)
     {
-      m_ptr->AddRef();
+      m_pPtr->AddRef();
     }
   }
 
-  T* operator->() { return m_ptr; }
-  T* const operator->() const { return m_ptr; }
+  T* operator->() { return m_pPtr; }
+  T* const operator->() const { return m_pPtr; }
 
   T** put()
   {
-    EZ_ASSERT_DEV(m_ptr == nullptr, "Can only put into an empty ezComPtr");
-    return &m_ptr;
+    EZ_ASSERT_DEV(m_pPtr == nullptr, "Can only put into an empty ezComPtr");
+    return &m_pPtr;
   }
 
   bool operator==(nullptr_t)
   {
-    return m_ptr == nullptr;
+    return m_pPtr == nullptr;
   }
 
   bool operator!=(nullptr_t)
   {
-    return m_ptr != nullptr;
+    return m_pPtr != nullptr;
   }
 
 private:
-  T* m_ptr = nullptr;
+  T* m_pPtr = nullptr;
 };
 
 ezComPtr<IDxcUtils> s_pDxcUtils;
@@ -152,29 +152,29 @@ ezResult ezShaderCompilerDXC::Initialize()
   return EZ_SUCCESS;
 }
 
-ezResult ezShaderCompilerDXC::Compile(ezShaderProgramData& inout_Data, ezLogInterface* pLog)
+ezResult ezShaderCompilerDXC::Compile(ezShaderProgramData& inout_data, ezLogInterface* pLog)
 {
   EZ_SUCCEED_OR_RETURN(Initialize());
 
   for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
   {
-    if (inout_Data.m_uiSourceHash[stage] == 0)
+    if (inout_data.m_uiSourceHash[stage] == 0)
       continue;
-    if (inout_Data.m_bWriteToDisk[stage] == false)
+    if (inout_data.m_bWriteToDisk[stage] == false)
     {
       ezLog::Debug("Shader for stage '{}' is already compiled.", ezGALShaderStage::Names[stage]);
       continue;
     }
 
-    const ezStringBuilder sShaderSource = inout_Data.m_sShaderSource[stage];
+    const ezStringBuilder sShaderSource = inout_data.m_sShaderSource[stage];
 
     if (!sShaderSource.IsEmpty() && sShaderSource.FindSubString("main") != nullptr)
     {
-      const ezStringBuilder sSourceFile = inout_Data.m_sSourceFile;
+      const ezStringBuilder sSourceFile = inout_data.m_sSourceFile;
 
-      if (CompileSPIRVShader(sSourceFile, sShaderSource, inout_Data.m_Flags.IsSet(ezShaderCompilerFlags::Debug), GetProfileName(inout_Data.m_sPlatform, (ezGALShaderStage::Enum)stage), "main", inout_Data.m_ByteCode[stage]->m_ByteCode).Succeeded())
+      if (CompileSPIRVShader(sSourceFile, sShaderSource, inout_data.m_Flags.IsSet(ezShaderCompilerFlags::Debug), GetProfileName(inout_data.m_sPlatform, (ezGALShaderStage::Enum)stage), "main", inout_data.m_ByteCode[stage]->m_ByteCode).Succeeded())
       {
-        EZ_SUCCEED_OR_RETURN(ReflectShaderStage(inout_Data, (ezGALShaderStage::Enum)stage));
+        EZ_SUCCEED_OR_RETURN(ReflectShaderStage(inout_data, (ezGALShaderStage::Enum)stage));
       }
       else
       {

--- a/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.h
+++ b/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.h
@@ -12,7 +12,7 @@ class EZ_SHADERCOMPILERDXC_DLL ezShaderCompilerDXC : public ezShaderProgramCompi
 
 public:
   virtual ezResult ModifyShaderSource(ezShaderProgramData& inout_data, ezLogInterface* pLog) override;
-  virtual ezResult Compile(ezShaderProgramData& inout_Data, ezLogInterface* pLog) override;
+  virtual ezResult Compile(ezShaderProgramData& inout_data, ezLogInterface* pLog) override;
 
 protected:
   virtual void ConfigureDxcArgs(ezDynamicArray<ezStringWChar>& inout_Args);

--- a/Code/EnginePlugins/InspectorPlugin/CMakeLists.txt
+++ b/Code/EnginePlugins/InspectorPlugin/CMakeLists.txt
@@ -10,4 +10,5 @@ ez_create_target(LIBRARY ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
   Core
+  RendererCore
 )

--- a/Code/EnginePlugins/InspectorPlugin/InspectorPlugin.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/InspectorPlugin.cpp
@@ -48,6 +48,9 @@ void RemoveFileSystemEventHandler();
 void AddResourceManagerEventHandler();
 void RemoveResourceManagerEventHandler();
 
+void AddRenderGraphEventHandler();
+void RemoveRenderGraphEventHandler();
+
 void SetAppStats();
 
 // clang-format off
@@ -74,12 +77,14 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(InspectorPlugin, InspectorPluginMain)
     AddTimeEventHandler();
     AddFileSystemEventHandler();
     AddResourceManagerEventHandler();
+    AddRenderGraphEventHandler();
 
     SetAppStats();
   }
 
   ON_CORESYSTEMS_SHUTDOWN
   {
+    RemoveRenderGraphEventHandler();
     RemoveResourceManagerEventHandler();
     RemoveFileSystemEventHandler();
     RemoveTimeEventHandler();

--- a/Code/EnginePlugins/InspectorPlugin/RenderGraphObserver.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/RenderGraphObserver.cpp
@@ -1,10 +1,10 @@
 #include <InspectorPlugin/InspectorPluginPCH.h>
 
 #include <Foundation/Communication/Telemetry.h>
+#include <Foundation/Configuration/Startup.h>
 #include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
 #include <RendererCore/RenderGraph/RenderGraphManager.h>
 #include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
-#include <RendererFoundation/Device/Device.h>
 
 namespace RenderGraphObserverDetail
 {
@@ -194,6 +194,22 @@ namespace RenderGraphObserverDetail
   }
 } // namespace RenderGraphObserverDetail
 
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(InspectorPlugin, RenderGraphObserver)
+
+  BEGIN_SUBSYSTEM_DEPENDENCIES
+    "RenderGraphManager"
+  END_SUBSYSTEM_DEPENDENCIES
+
+  ON_HIGHLEVELSYSTEMS_SHUTDOWN
+  {
+    RenderGraphObserverDetail::s_pObserver = nullptr;
+    RenderGraphObserverDetail::s_bObserverResponseEnabled = false;
+  }
+
+EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
+
 void AddRenderGraphEventHandler()
 {
   ezTelemetry::AcceptMessagesForSystem(RenderGraphObserverDetail::s_uiSystemId, true, RenderGraphObserverDetail::HandleMessages, nullptr);
@@ -206,6 +222,4 @@ void RemoveRenderGraphEventHandler()
   ezRenderGraphManager::s_RenderEvent.RemoveEventHandler(RenderGraphObserverDetail::RenderGraphRenderEventHandler);
   ezTelemetry::RemoveEventHandler(RenderGraphObserverDetail::TelemetryEventsHandler);
   ezTelemetry::AcceptMessagesForSystem(RenderGraphObserverDetail::s_uiSystemId, false);
-  RenderGraphObserverDetail::s_pObserver = nullptr;
-  RenderGraphObserverDetail::s_bObserverResponseEnabled = false;
 }

--- a/Code/EnginePlugins/InspectorPlugin/RenderGraphObserver.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/RenderGraphObserver.cpp
@@ -1,0 +1,211 @@
+#include <InspectorPlugin/InspectorPluginPCH.h>
+
+#include <Foundation/Communication/Telemetry.h>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
+#include <RendererCore/RenderGraph/RenderGraphManager.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
+#include <RendererFoundation/Device/Device.h>
+
+namespace RenderGraphObserverDetail
+{
+  static constexpr ezUInt32 s_uiSystemId = 'RGPH';
+  static constexpr ezUInt16 s_uiProtocolVersion = 1;
+
+  static ezSharedPtr<ezRenderGraphPassObserver> s_pObserver;
+  static ezRenderGraphInspectionSummary s_LastSummary;
+  static ezRenderGraphInspectionInfo s_LastInfo;
+  static ezUInt64 s_uiRequestedInfoGraph = 0;
+  static ezUInt64 s_uiLastInfoGraph = 0;
+  static bool s_bLastInfoValid = false;
+  static bool s_bSummaryDirty = false;
+  static bool s_bInfoDirty = false;
+  static ezTime s_LastSummaryBroadcast;
+  static ezTime s_LastResponseBroadcast;
+  static bool s_bObserverResponseEnabled = false;
+
+  static void EnsureObserver()
+  {
+    if (s_pObserver == nullptr)
+    {
+      s_pObserver = ezRenderGraphManager::CreateObserver();
+    }
+  }
+
+  static void SendSummary()
+  {
+    ezTelemetryMessage msg;
+    msg.SetMessageID(s_uiSystemId, 'SUMM');
+    msg.GetWriter() << s_uiProtocolVersion;
+    msg.GetWriter() << s_LastSummary;
+    ezTelemetry::Broadcast(ezTelemetry::Reliable, msg);
+    s_bSummaryDirty = false;
+  }
+
+  static void SendInspectionInfo(ezUInt64 uiGraphIdentity)
+  {
+    ezTelemetryMessage msg;
+    msg.SetMessageID(s_uiSystemId, 'INFO');
+    msg.GetWriter() << s_uiProtocolVersion;
+    msg.GetWriter() << uiGraphIdentity;
+
+    const bool bSuccess = s_bLastInfoValid && s_uiLastInfoGraph == uiGraphIdentity;
+    msg.GetWriter() << bSuccess;
+    if (bSuccess)
+    {
+      msg.GetWriter() << s_LastInfo;
+    }
+
+    ezTelemetry::Broadcast(ezTelemetry::Reliable, msg);
+    if (uiGraphIdentity == s_uiLastInfoGraph)
+    {
+      s_bInfoDirty = false;
+    }
+  }
+
+  static void RenderGraphRenderEventHandler(const ezRenderGraphRenderEvent& e)
+  {
+    if (e.m_Type != ezRenderGraphRenderEvent::Type::AfterGraphExecution)
+      return;
+
+    ezRenderGraphManager::GetExecutionSummary(s_LastSummary);
+    s_bSummaryDirty = true;
+
+    if (s_uiRequestedInfoGraph != 0)
+    {
+      s_bLastInfoValid = ezRenderGraphManager::GetRenderGraphInspectionInfo(s_uiRequestedInfoGraph, s_LastInfo).Succeeded();
+      if (!s_bLastInfoValid)
+      {
+        s_LastInfo.Clear();
+      }
+
+      s_uiLastInfoGraph = s_uiRequestedInfoGraph;
+      s_bInfoDirty = true;
+    }
+  }
+
+  static void SendObserverResponse()
+  {
+    if (s_pObserver == nullptr)
+      return;
+
+    ezTelemetryMessage msg;
+    msg.SetMessageID(s_uiSystemId, 'RESP');
+    msg.GetWriter() << s_uiProtocolVersion;
+    msg.GetWriter() << s_pObserver->GetResponse();
+    ezTelemetry::Broadcast(ezTelemetry::Reliable, msg);
+  }
+
+  static void ClearObserverRequest()
+  {
+    if (s_pObserver == nullptr)
+      return;
+
+    ezRenderGraphObserverRequest request;
+    s_pObserver->SetRequest(request);
+    s_bObserverResponseEnabled = false;
+  }
+
+  static void HandleMessages(void*)
+  {
+    ezTelemetryMessage msg;
+    while (ezTelemetry::RetrieveMessage(s_uiSystemId, msg) == EZ_SUCCESS)
+    {
+      ezUInt16 uiVersion = 0;
+
+      switch (msg.GetMessageID())
+      {
+        case 'RSUM':
+          SendSummary();
+          break;
+
+        case 'RINF':
+        {
+          ezUInt64 uiGraphIdentity = 0;
+          msg.GetReader() >> uiVersion;
+          msg.GetReader() >> uiGraphIdentity;
+          s_uiRequestedInfoGraph = uiGraphIdentity;
+          SendInspectionInfo(uiGraphIdentity);
+        }
+        break;
+
+        case 'RREQ':
+        {
+          ezRenderGraphObserverRequest request;
+          msg.GetReader() >> uiVersion;
+          msg.GetReader() >> request;
+
+          EnsureObserver();
+          s_pObserver->SetRequest(request);
+          s_bObserverResponseEnabled = request.m_uiRenderGraphId != 0 && !request.m_sPassName.IsEmpty();
+        }
+        break;
+
+        case 'RCLR':
+          ClearObserverRequest();
+          break;
+
+        default:
+          break;
+      }
+    }
+  }
+
+  static void TelemetryEventsHandler(const ezTelemetry::TelemetryEventData& e)
+  {
+    switch (e.m_EventType)
+    {
+      case ezTelemetry::TelemetryEventData::ConnectedToClient:
+        s_bSummaryDirty = true;
+        break;
+
+      case ezTelemetry::TelemetryEventData::DisconnectedFromClient:
+        s_pObserver = nullptr;
+        s_bObserverResponseEnabled = false;
+        break;
+
+      case ezTelemetry::TelemetryEventData::PerFrameUpdate:
+      {
+        if (!ezTelemetry::IsConnectedToClient())
+          return;
+
+        const ezTime now = ezTime::Now();
+        if (s_bSummaryDirty && (now - s_LastSummaryBroadcast > ezTime::MakeFromSeconds(0.5)))
+        {
+          s_LastSummaryBroadcast = now;
+          SendSummary();
+        }
+
+        if (s_bInfoDirty)
+        {
+          SendInspectionInfo(s_uiLastInfoGraph);
+        }
+
+        if (s_bObserverResponseEnabled && (now - s_LastResponseBroadcast > ezTime::MakeFromSeconds(0.1)))
+        {
+          s_LastResponseBroadcast = now;
+          SendObserverResponse();
+        }
+      }
+      break;
+
+      default:
+        break;
+    }
+  }
+} // namespace RenderGraphObserverDetail
+
+void AddRenderGraphEventHandler()
+{
+  ezTelemetry::AcceptMessagesForSystem(RenderGraphObserverDetail::s_uiSystemId, true, RenderGraphObserverDetail::HandleMessages, nullptr);
+  ezTelemetry::AddEventHandler(RenderGraphObserverDetail::TelemetryEventsHandler);
+  ezRenderGraphManager::s_RenderEvent.AddEventHandler(RenderGraphObserverDetail::RenderGraphRenderEventHandler);
+}
+
+void RemoveRenderGraphEventHandler()
+{
+  ezRenderGraphManager::s_RenderEvent.RemoveEventHandler(RenderGraphObserverDetail::RenderGraphRenderEventHandler);
+  ezTelemetry::RemoveEventHandler(RenderGraphObserverDetail::TelemetryEventsHandler);
+  ezTelemetry::AcceptMessagesForSystem(RenderGraphObserverDetail::s_uiSystemId, false);
+  RenderGraphObserverDetail::s_pObserver = nullptr;
+  RenderGraphObserverDetail::s_bObserverResponseEnabled = false;
+}

--- a/Code/Tools/Inspector/CMakeLists.txt
+++ b/Code/Tools/Inspector/CMakeLists.txt
@@ -19,6 +19,7 @@ ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets)
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
   Core
+  RendererCore
   GuiFoundation
   ads
 )

--- a/Code/Tools/Inspector/Inspector.cpp
+++ b/Code/Tools/Inspector/Inspector.cpp
@@ -14,6 +14,7 @@
 #include <Inspector/MemoryWidget.moc.h>
 #include <Inspector/PluginsWidget.moc.h>
 #include <Inspector/ReflectionWidget.moc.h>
+#include <Inspector/RenderGraphWidget.moc.h>
 #include <Inspector/ResourceWidget.moc.h>
 #include <Inspector/SubsystemsWidget.moc.h>
 #include <Inspector/TimeWidget.moc.h>
@@ -106,6 +107,7 @@ public:
     ezTelemetry::AcceptMessagesForSystem('RFLC', true, ezQtReflectionWidget::ProcessTelemetry, nullptr);
     ezTelemetry::AcceptMessagesForSystem('TRAN', true, ezQtDataWidget::ProcessTelemetry, nullptr);
     ezTelemetry::AcceptMessagesForSystem('RESM', true, ezQtResourceWidget::ProcessTelemetry, nullptr);
+    ezTelemetry::AcceptMessagesForSystem('RGPH', true, ezQtRenderGraphWidget::ProcessTelemetry, nullptr);
 
     QSettings Settings;
     const QString sServer = Settings.value("LastConnection", QLatin1String("localhost:1040")).toString();

--- a/Code/Tools/Inspector/MainWindow.cpp
+++ b/Code/Tools/Inspector/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include <Inspector/MemoryWidget.moc.h>
 #include <Inspector/PluginsWidget.moc.h>
 #include <Inspector/ReflectionWidget.moc.h>
+#include <Inspector/RenderGraphWidget.moc.h>
 #include <Inspector/ResourceWidget.moc.h>
 #include <Inspector/SubsystemsWidget.moc.h>
 #include <Inspector/TimeWidget.moc.h>
@@ -59,6 +60,7 @@ ezQtMainWindow::ezQtMainWindow()
   ezQtReflectionWidget* pReflectionWidget = new ezQtReflectionWidget(m_DockManager);
   ezQtDataWidget* pDataWidget = new ezQtDataWidget(m_DockManager);
   ezQtResourceWidget* pResourceWidget = new ezQtResourceWidget(m_DockManager);
+  ezQtRenderGraphWidget* pRenderGraphWidget = new ezQtRenderGraphWidget(m_DockManager);
 
   EZ_VERIFY(nullptr != QWidget::connect(pMainWidget, &ads::CDockWidget::viewToggled, this, &ezQtMainWindow::DockWidgetVisibilityChanged), "");
   EZ_VERIFY(nullptr != QWidget::connect(pLogWidget, &ads::CDockWidget::viewToggled, this, &ezQtMainWindow::DockWidgetVisibilityChanged), "");
@@ -74,6 +76,7 @@ ezQtMainWindow::ezQtMainWindow()
     nullptr != QWidget::connect(pGlobalEventesWidget, &ads::CDockWidget::viewToggled, this, &ezQtMainWindow::DockWidgetVisibilityChanged), "");
   EZ_VERIFY(nullptr != QWidget::connect(pDataWidget, &ads::CDockWidget::viewToggled, this, &ezQtMainWindow::DockWidgetVisibilityChanged), "");
   EZ_VERIFY(nullptr != QWidget::connect(pResourceWidget, &ads::CDockWidget::viewToggled, this, &ezQtMainWindow::DockWidgetVisibilityChanged), "");
+  EZ_VERIFY(nullptr != QWidget::connect(pRenderGraphWidget, &ads::CDockWidget::viewToggled, this, &ezQtMainWindow::DockWidgetVisibilityChanged), "");
 
   QMenu* pHistoryMenu = new QMenu;
   pHistoryMenu->setTearOffEnabled(true);
@@ -117,6 +120,7 @@ ezQtMainWindow::ezQtMainWindow()
   m_DockManager->addDockWidgetTab(ads::RightDockWidgetArea, pPluginsWidget);
   m_DockManager->addDockWidgetTab(ads::RightDockWidgetArea, pReflectionWidget);
   m_DockManager->addDockWidgetTab(ads::RightDockWidgetArea, pResourceWidget);
+  m_DockManager->addDockWidgetTab(ads::RightDockWidgetArea, pRenderGraphWidget);
   m_DockManager->addDockWidgetTab(ads::RightDockWidgetArea, pSubsystemsWidget);
 
   m_DockManager->addDockWidget(ads::BottomDockWidgetArea, pFileWidget);
@@ -273,6 +277,7 @@ void ezQtMainWindow::UpdateNetwork()
     ezQtGlobalEventsWidget::s_pWidget->ResetStats();
     ezQtDataWidget::s_pWidget->ResetStats();
     ezQtResourceWidget::s_pWidget->ResetStats();
+    ezQtRenderGraphWidget::s_pWidget->ResetStats();
   }
 
   UpdateAlwaysOnTop();
@@ -284,6 +289,7 @@ void ezQtMainWindow::UpdateNetwork()
   ezQtTimeWidget::s_pWidget->UpdateStats();
   ezQtFileWidget::s_pWidget->UpdateStats();
   ezQtResourceWidget::s_pWidget->UpdateStats();
+  ezQtRenderGraphWidget::s_pWidget->UpdateStats();
   // ezQtDataWidget::s_pWidget->UpdateStats();
 
   for (ezInt32 i = 0; i < 10; ++i)
@@ -324,6 +330,7 @@ void ezQtMainWindow::DockWidgetVisibilityChanged(bool bVisible)
   ActionShowWindowGlobalEvents->setChecked(!ezQtGlobalEventsWidget::s_pWidget->isClosed());
   ActionShowWindowData->setChecked(!ezQtDataWidget::s_pWidget->isClosed());
   ActionShowWindowResource->setChecked(!ezQtResourceWidget::s_pWidget->isClosed());
+  ActionShowWindowRenderGraph->setChecked(!ezQtRenderGraphWidget::s_pWidget->isClosed());
 
   for (ezInt32 i = 0; i < 10; ++i)
     m_pStatHistoryWidgets[i]->m_ShowWindowAction.setChecked(!m_pStatHistoryWidgets[i]->isClosed());

--- a/Code/Tools/Inspector/MainWindow.moc.h
+++ b/Code/Tools/Inspector/MainWindow.moc.h
@@ -48,6 +48,7 @@ private Q_SLOTS:
   void on_ActionShowWindowGlobalEvents_triggered();
   void on_ActionShowWindowData_triggered();
   void on_ActionShowWindowResource_triggered();
+  void on_ActionShowWindowRenderGraph_triggered();
 
   void on_ActionOnTopWhenConnected_triggered();
   void on_ActionAlwaysOnTop_triggered();

--- a/Code/Tools/Inspector/MainWindow.ui
+++ b/Code/Tools/Inspector/MainWindow.ui
@@ -59,6 +59,7 @@
     <addaction name="ActionShowWindowPlugins"/>
     <addaction name="ActionShowWindowReflection"/>
     <addaction name="ActionShowWindowResource"/>
+    <addaction name="ActionShowWindowRenderGraph"/>
     <addaction name="ActionShowWindowSubsystems"/>
     <addaction name="ActionShowWindowTime"/>
    </widget>
@@ -247,6 +248,14 @@
    </property>
    <property name="text">
     <string>Resources</string>
+   </property>
+  </action>
+  <action name="ActionShowWindowRenderGraph">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Render Graph</string>
    </property>
   </action>
  </widget>

--- a/Code/Tools/Inspector/MainWindowActions.cpp
+++ b/Code/Tools/Inspector/MainWindowActions.cpp
@@ -11,6 +11,7 @@
 #include <Inspector/MemoryWidget.moc.h>
 #include <Inspector/PluginsWidget.moc.h>
 #include <Inspector/ReflectionWidget.moc.h>
+#include <Inspector/RenderGraphWidget.moc.h>
 #include <Inspector/ResourceWidget.moc.h>
 #include <Inspector/SubsystemsWidget.moc.h>
 #include <Inspector/TimeWidget.moc.h>
@@ -85,6 +86,12 @@ void ezQtMainWindow::on_ActionShowWindowResource_triggered()
 {
   ezQtResourceWidget::s_pWidget->toggleView(ActionShowWindowResource->isChecked());
   ezQtResourceWidget::s_pWidget->raise();
+}
+
+void ezQtMainWindow::on_ActionShowWindowRenderGraph_triggered()
+{
+  ezQtRenderGraphWidget::s_pWidget->toggleView(ActionShowWindowRenderGraph->isChecked());
+  ezQtRenderGraphWidget::s_pWidget->raise();
 }
 
 void ezQtMainWindow::on_ActionOnTopWhenConnected_triggered()

--- a/Code/Tools/Inspector/RenderGraphHistogramWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphHistogramWidget.cpp
@@ -79,22 +79,22 @@ void ezQtRenderGraphHistogramWidget::paintEvent(QPaintEvent*)
     UpdateHistogram(plotRect);
   }
   // TODO: DPI scaling?
-  painter.drawImage(plotRect.adjusted(2, 2, -2, -2), m_histogramImage);
+  painter.drawImage(plotRect.adjusted(2, 2, -2, -2), m_HistogramImage);
 }
 
 void ezQtRenderGraphHistogramWidget::UpdateHistogram(const QRect plotRect)
 {
-  if (m_histogramImage.isNull())
+  if (m_HistogramImage.isNull())
   {
-    m_histogramImage = QImage(256, plotRect.height() - 4, QImage::Format_ARGB32_Premultiplied);
+    m_HistogramImage = QImage(256, plotRect.height() - 4, QImage::Format_ARGB32_Premultiplied);
   }
-  m_histogramImage.fill(Qt::transparent);
+  m_HistogramImage.fill(Qt::transparent);
   if (m_Histogram.IsEmpty())
     return;
 
 
 
-  const ezUInt32 uiImageHeight = (ezUInt32)m_histogramImage.height();
+  const ezUInt32 uiImageHeight = (ezUInt32)m_HistogramImage.height();
   const ezUInt32 uiMaxImageHeight = uiImageHeight - 1u;
   for (ezUInt32 bin = 0; bin < 256; ++bin)
   {
@@ -115,7 +115,7 @@ void ezQtRenderGraphHistogramWidget::UpdateHistogram(const QRect plotRect)
       const bool bB = y <= uiBHeight;
       const bool bA = y <= uiAHeight;
       const ezUInt32 uiLookup = EZ_BIT(0) * bR | EZ_BIT(1) * bG | EZ_BIT(2) * bB | EZ_BIT(3) * bA;
-      m_histogramImage.setPixelColor((ezInt32)bin, (ezInt32)uiImageHeight - (ezInt32)y - 1, m_Colors[uiLookup]);
+      m_HistogramImage.setPixelColor((ezInt32)bin, (ezInt32)uiImageHeight - (ezInt32)y - 1, m_Colors[uiLookup]);
     }
   }
 }

--- a/Code/Tools/Inspector/RenderGraphHistogramWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphHistogramWidget.cpp
@@ -1,0 +1,121 @@
+#include <Inspector/InspectorPCH.h>
+
+#include <Foundation/Math/ColorScheme.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <Inspector/RenderGraphHistogramWidget.moc.h>
+
+#include <QImage>
+#include <QPainter>
+#include <QSizePolicy>
+#include <QStyle>
+#include <QStyleOptionFrame>
+
+ezQtRenderGraphHistogramWidget::ezQtRenderGraphHistogramWidget(QWidget* pParent)
+  : QWidget(pParent)
+{
+  setFixedSize(260, 96);
+  setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+  m_Colors[0] = QColor();
+  m_Colors[EZ_BIT(0)] = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Red));
+  m_Colors[EZ_BIT(1)] = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green));
+  m_Colors[EZ_BIT(2)] = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Blue));
+  m_Colors[EZ_BIT(0) | EZ_BIT(1)] = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Yellow));
+  m_Colors[EZ_BIT(0) | EZ_BIT(2)] = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Violet));
+  m_Colors[EZ_BIT(1) | EZ_BIT(2)] = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Cyan));
+  m_Colors[EZ_BIT(0) | EZ_BIT(1) | EZ_BIT(2)] = palette().color(QPalette::Text);
+  m_Colors[EZ_BIT(3)] = palette().color(QPalette::Midlight);
+  for (ezUInt32 i = 1; i < 8; ++i)
+  {
+    m_Colors[i + 8] = m_Colors[i].darker();
+  }
+}
+
+void ezQtRenderGraphHistogramWidget::SetHistogram(ezArrayPtr<const ezUInt8> histogram)
+{
+  m_Histogram.SetCount(histogram.GetCount());
+  for (ezUInt32 i = 0; i < histogram.GetCount(); ++i)
+  {
+    m_Histogram[i] = histogram[i];
+  }
+
+  if (!m_bRepaintPending)
+  {
+    m_bRepaintPending = true;
+    update();
+  }
+}
+
+void ezQtRenderGraphHistogramWidget::Clear()
+{
+  m_Histogram.Clear();
+  if (!m_bRepaintPending)
+  {
+    m_bRepaintPending = true;
+    update();
+  }
+}
+
+void ezQtRenderGraphHistogramWidget::paintEvent(QPaintEvent*)
+{
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, false);
+
+  QStyleOptionFrame option;
+  option.initFrom(this);
+  option.rect = rect();
+  option.lineWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth, &option, this);
+  option.midLineWidth = 0;
+  option.state |= QStyle::State_Sunken;
+
+  style()->drawPrimitive(QStyle::PE_PanelLineEdit, &option, &painter, this);
+
+  const QRect plotRect = rect().adjusted(option.lineWidth, option.lineWidth, -option.lineWidth, -option.lineWidth);
+  painter.fillRect(plotRect, palette().color(QPalette::Dark));
+
+  if (m_bRepaintPending)
+  {
+    m_bRepaintPending = false;
+    UpdateHistogram(plotRect);
+  }
+  // TODO: DPI scaling?
+  painter.drawImage(plotRect.adjusted(2, 2, -2, -2), m_histogramImage);
+}
+
+void ezQtRenderGraphHistogramWidget::UpdateHistogram(const QRect plotRect)
+{
+  if (m_histogramImage.isNull())
+  {
+    m_histogramImage = QImage(256, plotRect.height() - 4, QImage::Format_ARGB32_Premultiplied);
+  }
+  m_histogramImage.fill(Qt::transparent);
+  if (m_Histogram.IsEmpty())
+    return;
+
+
+
+  const ezUInt32 uiImageHeight = (ezUInt32)m_histogramImage.height();
+  const ezUInt32 uiMaxImageHeight = uiImageHeight - 1u;
+  for (ezUInt32 bin = 0; bin < 256; ++bin)
+  {
+    // TODO: Interleave rgba?
+    const ezUInt32 uiR = m_Histogram[bin];
+    const ezUInt32 uiG = m_Histogram[256 + bin];
+    const ezUInt32 uiB = m_Histogram[512 + bin];
+    const ezUInt32 uiA = m_Histogram[768 + bin];
+    const ezUInt32 uiRHeight = (uiR * uiMaxImageHeight + 254u) / 255u;
+    const ezUInt32 uiGHeight = (uiG * uiMaxImageHeight + 254u) / 255u;
+    const ezUInt32 uiBHeight = (uiB * uiMaxImageHeight + 254u) / 255u;
+    const ezUInt32 uiAHeight = (uiA * uiMaxImageHeight + 254u) / 255u;
+    const ezUInt32 uiMaxHeight = ezMath::Min(uiMaxImageHeight, ezMath::Max(uiRHeight, uiGHeight, uiBHeight, uiAHeight));
+    for (ezUInt32 y = 0; y <= uiMaxHeight; ++y)
+    {
+      const bool bR = y <= uiRHeight;
+      const bool bG = y <= uiGHeight;
+      const bool bB = y <= uiBHeight;
+      const bool bA = y <= uiAHeight;
+      const ezUInt32 uiLookup = EZ_BIT(0) * bR | EZ_BIT(1) * bG | EZ_BIT(2) * bB | EZ_BIT(3) * bA;
+      m_histogramImage.setPixelColor((ezInt32)bin, (ezInt32)uiImageHeight - (ezInt32)y - 1, m_Colors[uiLookup]);
+    }
+  }
+}

--- a/Code/Tools/Inspector/RenderGraphHistogramWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphHistogramWidget.moc.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Types/ArrayPtr.h>
+#include <QWidget>
+
+class QPaintEvent;
+
+/// Displays the normalized RGBA histogram returned by the render graph observer.
+class ezQtRenderGraphHistogramWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit ezQtRenderGraphHistogramWidget(QWidget* pParent = nullptr);
+
+  void SetHistogram(ezArrayPtr<const ezUInt8> histogram);
+  void Clear();
+  void UpdateHistogram(QRect plotRect);
+
+protected:
+  void paintEvent(QPaintEvent*) override;
+
+private:
+  ezDynamicArray<ezUInt8> m_Histogram;
+  bool m_bRepaintPending = false;
+  QColor m_Colors[16];
+  QImage m_histogramImage;
+};

--- a/Code/Tools/Inspector/RenderGraphHistogramWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphHistogramWidget.moc.h
@@ -26,5 +26,5 @@ private:
   ezDynamicArray<ezUInt8> m_Histogram;
   bool m_bRepaintPending = false;
   QColor m_Colors[16];
-  QImage m_histogramImage;
+  QImage m_HistogramImage;
 };

--- a/Code/Tools/Inspector/RenderGraphOverviewWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphOverviewWidget.cpp
@@ -130,9 +130,8 @@ void ezQtRenderGraphOverviewWidget::SetInfo(ezUInt64 uiSelectedGraphId, const ez
     if (uiResolvedIndex != 0xFFFF)
       m_TextureColumnResources.PushBack({uiResolvedIndex, (ezUInt16)i});
   }
-  std::sort(begin(m_TextureColumnResources), end(m_TextureColumnResources), [](const TextureColumnResource& lhs, const TextureColumnResource& rhs) {
-    return lhs.m_uiResolvedIndex < rhs.m_uiResolvedIndex;
-  });
+  std::sort(begin(m_TextureColumnResources), end(m_TextureColumnResources), [](const TextureColumnResource& lhs, const TextureColumnResource& rhs)
+    { return lhs.m_uiResolvedIndex < rhs.m_uiResolvedIndex; });
 
   m_BufferColumnResources.Clear();
   for (ezUInt32 i = 0; i < m_Info.m_Buffers.GetCount(); ++i)
@@ -141,9 +140,8 @@ void ezQtRenderGraphOverviewWidget::SetInfo(ezUInt64 uiSelectedGraphId, const ez
     if (uiResolvedIndex != 0xFFFF)
       m_BufferColumnResources.PushBack({uiResolvedIndex, (ezUInt16)i});
   }
-  std::sort(begin(m_BufferColumnResources), end(m_BufferColumnResources), [](const BufferColumnResource& lhs, const BufferColumnResource& rhs) {
-    return lhs.m_uiResolvedIndex < rhs.m_uiResolvedIndex;
-  });
+  std::sort(begin(m_BufferColumnResources), end(m_BufferColumnResources), [](const BufferColumnResource& lhs, const BufferColumnResource& rhs)
+    { return lhs.m_uiResolvedIndex < rhs.m_uiResolvedIndex; });
 
   // Compute size
   const QSize required(s_iPassLabelWidth + s_iContentPadding + ezMath::Max<ezInt32>(1, (ezInt32)m_uiTotalResourceColumnCount) * s_iCellSize,
@@ -285,7 +283,8 @@ const ezRenderGraphInspectionInfo::AccessInfo* ezQtRenderGraphOverviewWidget::Fi
     return nullptr;
 
   auto it = std::lower_bound(begin(m_Info.m_Accesses), end(m_Info.m_Accesses), hover.m_uiPassIndex,
-    [](const ezRenderGraphInspectionInfo::AccessInfo& access, ezUInt16 uiPassIndex) { return access.m_uiPassIndex < uiPassIndex; });
+    [](const ezRenderGraphInspectionInfo::AccessInfo& access, ezUInt16 uiPassIndex)
+    { return access.m_uiPassIndex < uiPassIndex; });
 
   const ezRenderGraphInspectionInfo::AccessInfo* pMatch = nullptr;
   for (; it != end(m_Info.m_Accesses) && it->m_uiPassIndex == hover.m_uiPassIndex; ++it)
@@ -324,7 +323,8 @@ QString ezQtRenderGraphOverviewWidget::MakeAccessesTooltip(const HoverInfo& hove
     return QString();
 
   auto it = std::lower_bound(begin(m_Info.m_Accesses), end(m_Info.m_Accesses), hover.m_uiPassIndex,
-    [](const ezRenderGraphInspectionInfo::AccessInfo& access, ezUInt16 uiPassIndex) { return access.m_uiPassIndex < uiPassIndex; });
+    [](const ezRenderGraphInspectionInfo::AccessInfo& access, ezUInt16 uiPassIndex)
+    { return access.m_uiPassIndex < uiPassIndex; });
 
   ezStringBuilder tooltip;
   bool bHasAccess = false;
@@ -375,7 +375,8 @@ ezUInt16 ezQtRenderGraphOverviewWidget::FindTextureLifetimeResource(const HoverI
     return 0xFFFF;
 
   auto it = std::lower_bound(begin(m_TextureColumnResources), end(m_TextureColumnResources), hover.m_uiResourceColumn,
-    [](const TextureColumnResource& resource, ezUInt16 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+    [](const TextureColumnResource& resource, ezUInt16 uiResolvedIndex)
+    { return resource.m_uiResolvedIndex < uiResolvedIndex; });
 
   for (; it != end(m_TextureColumnResources) && it->m_uiResolvedIndex == hover.m_uiResourceColumn; ++it)
   {
@@ -398,7 +399,8 @@ ezUInt16 ezQtRenderGraphOverviewWidget::FindBufferLifetimeResource(const HoverIn
 
   const ezUInt32 uiBufferColumn = hover.m_uiResourceColumn - m_uiTextureColumnCount;
   auto it = std::lower_bound(begin(m_BufferColumnResources), end(m_BufferColumnResources), uiBufferColumn,
-    [](const BufferColumnResource& resource, ezUInt32 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+    [](const BufferColumnResource& resource, ezUInt32 uiResolvedIndex)
+    { return resource.m_uiResolvedIndex < uiResolvedIndex; });
 
   for (; it != end(m_BufferColumnResources) && it->m_uiResolvedIndex == uiBufferColumn; ++it)
   {
@@ -458,7 +460,8 @@ QString ezQtRenderGraphOverviewWidget::MakeHoverTooltip(const HoverInfo& hover) 
 QString ezQtRenderGraphOverviewWidget::MakeTextureColumnTooltip(ezUInt32 uiResolvedIndex) const
 {
   auto it = std::lower_bound(begin(m_TextureColumnResources), end(m_TextureColumnResources), uiResolvedIndex,
-    [](const TextureColumnResource& resource, ezUInt32 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+    [](const TextureColumnResource& resource, ezUInt32 uiResolvedIndex)
+    { return resource.m_uiResolvedIndex < uiResolvedIndex; });
 
   QString tooltip;
   for (; it != end(m_TextureColumnResources) && it->m_uiResolvedIndex == uiResolvedIndex; ++it)
@@ -473,7 +476,8 @@ QString ezQtRenderGraphOverviewWidget::MakeTextureColumnTooltip(ezUInt32 uiResol
 QString ezQtRenderGraphOverviewWidget::MakeBufferColumnTooltip(ezUInt32 uiResolvedIndex) const
 {
   auto it = std::lower_bound(begin(m_BufferColumnResources), end(m_BufferColumnResources), uiResolvedIndex,
-    [](const BufferColumnResource& resource, ezUInt32 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+    [](const BufferColumnResource& resource, ezUInt32 uiResolvedIndex)
+    { return resource.m_uiResolvedIndex < uiResolvedIndex; });
 
   QString tooltip;
   for (; it != end(m_BufferColumnResources) && it->m_uiResolvedIndex == uiResolvedIndex; ++it)
@@ -516,7 +520,9 @@ void ezQtRenderGraphOverviewWidget::DrawPassNames(QPainter& painter)
   {
     const auto& pass = m_Info.m_Passes[passIndex];
     const QRect labelRect(0, s_iHeaderHeight + (ezInt32)passIndex * s_iCellSize, s_iPassLabelWidth, s_iCellSize);
-    const QColor textColor = !pass.m_bAlive ? palette().color(QPalette::Disabled, QPalette::Text) : pass.m_QueueType == ezGALQueueType::Compute ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green)) : pass.m_QueueType == ezGALQueueType::Transfer ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Blue)) : palette().color(QPalette::Text);
+    const QColor textColor = !pass.m_bAlive ? palette().color(QPalette::Disabled, QPalette::Text) : pass.m_QueueType == ezGALQueueType::Compute  ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green))
+                                                                                                  : pass.m_QueueType == ezGALQueueType::Transfer ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Blue))
+                                                                                                                                                 : palette().color(QPalette::Text);
     painter.fillRect(labelRect, passIndex % 2 == 0 ? palette().color(QPalette::Base) : palette().color(QPalette::AlternateBase));
     painter.setPen(textColor);
     painter.drawText(labelRect.adjusted(6, 0, -4, 0), Qt::AlignVCenter | Qt::AlignLeft, ezMakeQString(pass.m_sName));

--- a/Code/Tools/Inspector/RenderGraphOverviewWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphOverviewWidget.cpp
@@ -1,0 +1,666 @@
+#include <Inspector/InspectorPCH.h>
+
+#include <Foundation/Math/ColorScheme.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <Inspector/RenderGraphOverviewWidget.moc.h>
+#include <RendererFoundation/RendererReflection.h>
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPolygon>
+
+#include <algorithm>
+
+namespace
+{
+  QColor GetAccessColor(ezBitflags<ezGALResourceState> access)
+  {
+    const bool bRead = access.IsAnySet(ezGALResourceState::AllReadStates);
+    const bool bWrite = access.IsAnySet(ezGALResourceState::AllWriteStates);
+
+    if (access.IsSet(ezGALResourceState::RenderTarget))
+      return ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Orange));
+
+    if (access.IsSet(ezGALResourceState::DepthStencilWrite))
+      return ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Grape));
+    if (access.IsSet(ezGALResourceState::DepthStencilRead))
+      return ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Cyan));
+
+    if (bWrite)
+      return ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Red));
+    if (bRead)
+      return ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Lime));
+
+    return ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Gray));
+  }
+
+  QString MakePassTooltip(ezUInt32 uiPassIndex, const ezRenderGraphInspectionInfo::PassInfo& pass)
+  {
+    ezStringBuilder text;
+    text.SetFormat("Pass {}\n{}\nQueue: {}\n{}", uiPassIndex, pass.m_sName, ezArgEnum(pass.m_QueueType), pass.m_bAlive ? "Alive" : "Culled");
+    return ezMakeQString(text);
+  }
+
+  QString MakeTextureTooltip(ezUInt32 uiTextureIndex, const ezRenderGraphInspectionInfo::TextureResourceInfo& texture)
+  {
+    ezStringBuilder text;
+    text.SetFormat("Texture {} {}\nFormat: {}\nSize: {}x{}", uiTextureIndex,
+      texture.m_bImported ? "(Imported)" : "(Transient)", ezArgEnum(texture.m_Desc.m_Format), texture.m_Desc.m_uiWidth, texture.m_Desc.m_uiHeight);
+    if (texture.m_Desc.m_uiDepth > 1)
+      text.AppendFormat("x{}", texture.m_Desc.m_uiDepth);
+    if (texture.m_Desc.m_uiArraySize > 1)
+      text.AppendFormat("\nSlices: {}", texture.m_Desc.m_uiArraySize);
+    if (texture.m_Desc.m_uiMipLevelCount > 1)
+      text.AppendFormat("\nMipLevels: {}", texture.m_Desc.m_uiMipLevelCount);
+    if (texture.m_Desc.m_SampleCount != ezGALMSAASampleCount::None)
+      text.AppendFormat("\nMSAA Samples: {}", texture.m_Desc.m_SampleCount.GetValue());
+
+    text.AppendFormat("\nFlags: {}", ezArgEnum(texture.m_Desc.m_TextureFlags));
+    text.AppendFormat("\nPasses: {} - {}\nResolved: {}", texture.m_uiFirstUsePassIndex, texture.m_uiLastUsePassIndex, texture.m_uiResolvedIndex);
+
+    return ezMakeQString(text);
+  }
+
+  QString MakeBufferTooltip(ezUInt32 uiBufferIndex, const ezRenderGraphInspectionInfo::BufferResourceInfo& buffer)
+  {
+    ezStringBuilder text;
+    text.SetFormat("Buffer {} {}\nSize: {} bytes\nStruct: {} bytes\nFormat: {}", uiBufferIndex,
+      buffer.m_bImported ? "(Imported)" : "(Transient)", buffer.m_Desc.m_uiTotalSize, buffer.m_Desc.m_uiStructSize, ezArgEnum(buffer.m_Desc.m_Format));
+
+    text.AppendFormat("\nFlags: {}", ezArgEnum(buffer.m_Desc.m_BufferFlags));
+    text.AppendFormat("\nPasses: {} - {}\nResolved: {}", buffer.m_uiFirstUsePassIndex, buffer.m_uiLastUsePassIndex, buffer.m_uiResolvedIndex);
+
+    return ezMakeQString(text);
+  }
+
+  void AppendAccessTooltipDetails(ezStringBuilder& ref_text, const ezRenderGraphInspectionInfo::AccessInfo& access)
+  {
+    ref_text.AppendFormat("\nAccess: {}", ezArgEnum(access.m_Access));
+
+    if (access.m_bIsTexture)
+    {
+      const auto& range = access.m_TextureRange;
+      ref_text.AppendFormat("\nRange: mip {}+{}, slice {}+{}", range.m_uiBaseMipLevel, range.m_uiMipLevels,
+        range.m_uiBaseArraySlice, range.m_uiArraySlices);
+    }
+  }
+} // namespace
+
+ezQtRenderGraphOverviewWidget::ezQtRenderGraphOverviewWidget(QWidget* pParent)
+  : QWidget(pParent)
+{
+  setMinimumSize(600, 300);
+  setMouseTracking(true);
+}
+
+void ezQtRenderGraphOverviewWidget::SetInfo(ezUInt64 uiSelectedGraphId, const ezRenderGraphInspectionInfo& info)
+{
+  if (m_uiSelectedGraphId != uiSelectedGraphId)
+  {
+    // While a render graph is selected, we allow the size to only grow to not have the scroll bars flickers (see below).
+    // This is reset here when we change to a different graph.
+    m_uiSelectedGraphId = uiSelectedGraphId;
+    m_MinContentSize = QSize(600, 300);
+  }
+
+  m_Info = info;
+
+  // Build caches
+  ezUInt16 uiMaxResolvedTexture = 0;
+  for (const auto& texture : m_Info.m_Textures)
+  {
+    if (texture.m_uiResolvedIndex != 0xFFFF)
+      uiMaxResolvedTexture = ezMath::Max(uiMaxResolvedTexture, texture.m_uiResolvedIndex);
+  }
+  m_uiTextureColumnCount = m_Info.m_Textures.IsEmpty() ? 0 : uiMaxResolvedTexture + 1;
+
+  ezUInt16 uiMaxResolvedBuffer = 0;
+  for (const auto& buffer : m_Info.m_Buffers)
+  {
+    if (buffer.m_uiResolvedIndex != 0xFFFF)
+      uiMaxResolvedBuffer = ezMath::Max(uiMaxResolvedBuffer, buffer.m_uiResolvedIndex);
+  }
+  m_uiBufferColumnCount = m_Info.m_Buffers.IsEmpty() ? 0 : uiMaxResolvedBuffer + 1;
+  m_uiTotalResourceColumnCount = m_uiTextureColumnCount + m_uiBufferColumnCount;
+
+  m_TextureColumnResources.Clear();
+  for (ezUInt32 i = 0; i < m_Info.m_Textures.GetCount(); ++i)
+  {
+    const ezUInt16 uiResolvedIndex = m_Info.m_Textures[i].m_uiResolvedIndex;
+    if (uiResolvedIndex != 0xFFFF)
+      m_TextureColumnResources.PushBack({uiResolvedIndex, (ezUInt16)i});
+  }
+  std::sort(begin(m_TextureColumnResources), end(m_TextureColumnResources), [](const TextureColumnResource& lhs, const TextureColumnResource& rhs) {
+    return lhs.m_uiResolvedIndex < rhs.m_uiResolvedIndex;
+  });
+
+  m_BufferColumnResources.Clear();
+  for (ezUInt32 i = 0; i < m_Info.m_Buffers.GetCount(); ++i)
+  {
+    const ezUInt16 uiResolvedIndex = m_Info.m_Buffers[i].m_uiResolvedIndex;
+    if (uiResolvedIndex != 0xFFFF)
+      m_BufferColumnResources.PushBack({uiResolvedIndex, (ezUInt16)i});
+  }
+  std::sort(begin(m_BufferColumnResources), end(m_BufferColumnResources), [](const BufferColumnResource& lhs, const BufferColumnResource& rhs) {
+    return lhs.m_uiResolvedIndex < rhs.m_uiResolvedIndex;
+  });
+
+  // Compute size
+  const QSize required(s_iPassLabelWidth + s_iContentPadding + ezMath::Max<ezInt32>(1, (ezInt32)m_uiTotalResourceColumnCount) * s_iCellSize,
+    s_iHeaderHeight + s_iContentPadding + ezMath::Max<ezInt32>(1, (ezInt32)m_Info.m_Passes.GetCount()) * s_iCellSize);
+  m_MinContentSize.setWidth(ezMath::Max(m_MinContentSize.width(), required.width()));
+  m_MinContentSize.setHeight(ezMath::Max(m_MinContentSize.height(), required.height()));
+  setMinimumSize(m_MinContentSize);
+  update();
+}
+
+void ezQtRenderGraphOverviewWidget::SetRequest(const ezRenderGraphObserverRequest& request)
+{
+  m_sObservedPassName = request.m_sPassName;
+  m_uiObservedAccessIndex = request.m_uiAccessIndex;
+  update();
+}
+
+void ezQtRenderGraphOverviewWidget::Clear()
+{
+  m_Info = ezRenderGraphInspectionInfo();
+  m_uiTextureColumnCount = 0;
+  m_uiBufferColumnCount = 0;
+  m_uiTotalResourceColumnCount = 0;
+  m_TextureColumnResources.Clear();
+  m_BufferColumnResources.Clear();
+  m_sObservedPassName.Clear();
+  m_uiObservedAccessIndex = 0;
+  m_MinContentSize = QSize(600, 300);
+  setMinimumSize(m_MinContentSize);
+  update();
+}
+
+void ezQtRenderGraphOverviewWidget::paintEvent(QPaintEvent*)
+{
+  QPainter painter(this);
+  painter.fillRect(rect(), palette().color(QPalette::Dark));
+  painter.setRenderHint(QPainter::Antialiasing, false);
+
+  if (m_Info.m_Passes.IsEmpty() || m_uiTotalResourceColumnCount == 0)
+  {
+    painter.setPen(palette().color(QPalette::Text));
+    painter.drawText(8, 18, "Graph has no passes or resources.");
+    return;
+  }
+
+  {
+    painter.setPen(palette().color(QPalette::Text));
+    ezStringBuilder text;
+    text.SetFormat("Passes: {}  Textures: {}  Buffers: {}  Accesses: {}", m_Info.m_Passes.GetCount(), m_Info.m_Textures.GetCount(), m_Info.m_Buffers.GetCount(),
+      m_Info.m_Accesses.GetCount());
+    painter.drawText(8, 18, ezMakeQString(text));
+  }
+
+  DrawResourceNames(painter);
+  DrawPassNames(painter);
+  DrawGrid(painter);
+  DrawResourceLifetimes(painter);
+  DrawAccesses(painter);
+}
+
+void ezQtRenderGraphOverviewWidget::mousePressEvent(QMouseEvent* e)
+{
+  const HoverInfo hover = GetHoverInfo(e->pos());
+  const ezRenderGraphInspectionInfo::AccessInfo* pAccess = FindAccess(hover);
+  if (pAccess != nullptr && pAccess->m_bIsTexture)
+  {
+    Q_EMIT AccessSelected(pAccess->m_uiPassIndex, pAccess->m_uiAccessIndex);
+    return;
+  }
+
+  Q_EMIT AccessDeselected();
+}
+
+void ezQtRenderGraphOverviewWidget::mouseMoveEvent(QMouseEvent* e)
+{
+  setToolTip(MakeHoverTooltip(GetHoverInfo(e->pos())));
+  QWidget::mouseMoveEvent(e);
+}
+
+ezQtRenderGraphOverviewWidget::HoverInfo ezQtRenderGraphOverviewWidget::GetHoverInfo(const QPoint& pos) const
+{
+  HoverInfo hover;
+  hover.m_Position = pos;
+
+  if (pos.x() < 0 || pos.y() < 0)
+    return hover;
+
+  if (pos.y() < s_iHeaderHeight)
+  {
+    if (pos.x() >= s_iPassLabelWidth)
+    {
+      const ezUInt32 uiResourceColumn = (ezUInt32)((pos.x() - s_iPassLabelWidth) / s_iCellSize);
+      if (uiResourceColumn < m_uiTextureColumnCount)
+      {
+        hover.m_Area = HoverInfo::Area::TextureHeader;
+        hover.m_uiResourceColumn = (ezUInt16)uiResourceColumn;
+        hover.m_bIsTexture = true;
+      }
+      else if (uiResourceColumn < m_uiTotalResourceColumnCount)
+      {
+        hover.m_Area = HoverInfo::Area::BufferHeader;
+        hover.m_uiResourceColumn = (ezUInt16)(uiResourceColumn - m_uiTextureColumnCount);
+        hover.m_bIsTexture = false;
+      }
+    }
+
+    return hover;
+  }
+
+  const ezUInt32 uiPassIndex = (ezUInt32)((pos.y() - s_iHeaderHeight) / s_iCellSize);
+  if (uiPassIndex >= m_Info.m_Passes.GetCount())
+    return hover;
+
+  hover.m_uiPassIndex = (ezUInt16)uiPassIndex;
+
+  if (pos.x() < s_iPassLabelWidth)
+  {
+    hover.m_Area = HoverInfo::Area::PassHeader;
+    return hover;
+  }
+
+  const ezUInt32 uiResourceColumn = (ezUInt32)((pos.x() - s_iPassLabelWidth) / s_iCellSize);
+  if (uiResourceColumn >= m_uiTotalResourceColumnCount)
+  {
+    hover.m_Area = HoverInfo::Area::None;
+    hover.m_uiPassIndex = 0xFFFF;
+    return hover;
+  }
+
+  hover.m_Area = HoverInfo::Area::ResourceCell;
+  hover.m_uiResourceColumn = (ezUInt16)uiResourceColumn;
+  hover.m_bIsTexture = uiResourceColumn < m_uiTextureColumnCount;
+  return hover;
+}
+
+const ezRenderGraphInspectionInfo::AccessInfo* ezQtRenderGraphOverviewWidget::FindAccess(const HoverInfo& hover, bool bLastMatch) const
+{
+  if (hover.m_Area != HoverInfo::Area::ResourceCell || hover.m_uiPassIndex == 0xFFFF || hover.m_uiResourceColumn == 0xFFFF)
+    return nullptr;
+
+  auto it = std::lower_bound(begin(m_Info.m_Accesses), end(m_Info.m_Accesses), hover.m_uiPassIndex,
+    [](const ezRenderGraphInspectionInfo::AccessInfo& access, ezUInt16 uiPassIndex) { return access.m_uiPassIndex < uiPassIndex; });
+
+  const ezRenderGraphInspectionInfo::AccessInfo* pMatch = nullptr;
+  for (; it != end(m_Info.m_Accesses) && it->m_uiPassIndex == hover.m_uiPassIndex; ++it)
+  {
+    if (it->m_bIsTexture != hover.m_bIsTexture)
+      continue;
+
+    if (it->m_bIsTexture)
+    {
+      const auto& texture = m_Info.m_Textures[it->m_uiResourceIndex];
+      if (texture.m_uiResolvedIndex == hover.m_uiResourceColumn)
+      {
+        pMatch = &(*it);
+        if (!bLastMatch)
+          return pMatch;
+      }
+    }
+    else
+    {
+      const auto& buffer = m_Info.m_Buffers[it->m_uiResourceIndex];
+      if (m_uiTextureColumnCount + buffer.m_uiResolvedIndex == hover.m_uiResourceColumn)
+      {
+        pMatch = &(*it);
+        if (!bLastMatch)
+          return pMatch;
+      }
+    }
+  }
+
+  return pMatch;
+}
+
+QString ezQtRenderGraphOverviewWidget::MakeAccessesTooltip(const HoverInfo& hover) const
+{
+  if (hover.m_Area != HoverInfo::Area::ResourceCell || hover.m_uiPassIndex == 0xFFFF || hover.m_uiResourceColumn == 0xFFFF)
+    return QString();
+
+  auto it = std::lower_bound(begin(m_Info.m_Accesses), end(m_Info.m_Accesses), hover.m_uiPassIndex,
+    [](const ezRenderGraphInspectionInfo::AccessInfo& access, ezUInt16 uiPassIndex) { return access.m_uiPassIndex < uiPassIndex; });
+
+  ezStringBuilder tooltip;
+  bool bHasAccess = false;
+  // Iterate through all access in this pass
+  for (; it != end(m_Info.m_Accesses) && it->m_uiPassIndex == hover.m_uiPassIndex; ++it)
+  {
+    if (it->m_bIsTexture != hover.m_bIsTexture)
+      continue;
+
+    ezUInt32 uiResourceColumn = 0;
+    if (it->m_bIsTexture)
+    {
+      const auto& texture = m_Info.m_Textures[it->m_uiResourceIndex];
+      uiResourceColumn = texture.m_uiResolvedIndex;
+    }
+    else
+    {
+      const auto& buffer = m_Info.m_Buffers[it->m_uiResourceIndex];
+      uiResourceColumn = m_uiTextureColumnCount + buffer.m_uiResolvedIndex;
+    }
+
+    if (uiResourceColumn != hover.m_uiResourceColumn)
+      continue;
+
+    if (!bHasAccess)
+    {
+      tooltip.SetFormat("Pass: {}", m_Info.m_Passes[it->m_uiPassIndex].m_sName);
+      if (it->m_bIsTexture)
+        tooltip.AppendFormat("\nResource: Texture {}", it->m_uiResourceIndex);
+      else
+        tooltip.AppendFormat("\nResource: Buffer {}", it->m_uiResourceIndex);
+      bHasAccess = true;
+    }
+    else
+    {
+      tooltip.Append("\n");
+    }
+
+    AppendAccessTooltipDetails(tooltip, *it);
+  }
+
+  return bHasAccess ? ezMakeQString(tooltip) : QString();
+}
+
+ezUInt16 ezQtRenderGraphOverviewWidget::FindTextureLifetimeResource(const HoverInfo& hover) const
+{
+  if (hover.m_Area != HoverInfo::Area::ResourceCell || !hover.m_bIsTexture)
+    return 0xFFFF;
+
+  auto it = std::lower_bound(begin(m_TextureColumnResources), end(m_TextureColumnResources), hover.m_uiResourceColumn,
+    [](const TextureColumnResource& resource, ezUInt16 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+
+  for (; it != end(m_TextureColumnResources) && it->m_uiResolvedIndex == hover.m_uiResourceColumn; ++it)
+  {
+    const ezUInt16 uiTextureIndex = it->m_uiTextureIndex;
+    const auto& texture = m_Info.m_Textures[uiTextureIndex];
+    if (texture.m_uiFirstUsePassIndex == 0xFFFF || texture.m_uiResolvedIndex == 0xFFFF)
+      continue;
+
+    if (GetLifetimeRect(texture.m_uiFirstUsePassIndex, texture.m_uiLastUsePassIndex, texture.m_uiResolvedIndex).contains(hover.m_Position))
+      return uiTextureIndex;
+  }
+
+  return 0xFFFF;
+}
+
+ezUInt16 ezQtRenderGraphOverviewWidget::FindBufferLifetimeResource(const HoverInfo& hover) const
+{
+  if (hover.m_Area != HoverInfo::Area::ResourceCell || hover.m_bIsTexture)
+    return 0xFFFF;
+
+  const ezUInt32 uiBufferColumn = hover.m_uiResourceColumn - m_uiTextureColumnCount;
+  auto it = std::lower_bound(begin(m_BufferColumnResources), end(m_BufferColumnResources), uiBufferColumn,
+    [](const BufferColumnResource& resource, ezUInt32 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+
+  for (; it != end(m_BufferColumnResources) && it->m_uiResolvedIndex == uiBufferColumn; ++it)
+  {
+    const ezUInt16 uiBufferIndex = it->m_uiBufferIndex;
+    const auto& buffer = m_Info.m_Buffers[uiBufferIndex];
+    if (buffer.m_uiFirstUsePassIndex == 0xFFFF || buffer.m_uiResolvedIndex == 0xFFFF)
+      continue;
+
+    if (GetLifetimeRect(buffer.m_uiFirstUsePassIndex, buffer.m_uiLastUsePassIndex, m_uiTextureColumnCount + buffer.m_uiResolvedIndex).contains(hover.m_Position))
+      return uiBufferIndex;
+  }
+
+  return 0xFFFF;
+}
+
+QString ezQtRenderGraphOverviewWidget::MakeHoverTooltip(const HoverInfo& hover) const
+{
+  switch (hover.m_Area)
+  {
+    case HoverInfo::Area::PassHeader:
+      return MakePassTooltip(hover.m_uiPassIndex, m_Info.m_Passes[hover.m_uiPassIndex]);
+
+    case HoverInfo::Area::TextureHeader:
+      return MakeTextureColumnTooltip(hover.m_uiResourceColumn);
+
+    case HoverInfo::Area::BufferHeader:
+      return MakeBufferColumnTooltip(hover.m_uiResourceColumn);
+
+    case HoverInfo::Area::ResourceCell:
+    {
+      QString accessTooltip = MakeAccessesTooltip(hover);
+      if (!accessTooltip.isEmpty())
+        return accessTooltip;
+
+      if (hover.m_bIsTexture)
+      {
+        const ezUInt16 uiTextureIndex = FindTextureLifetimeResource(hover);
+        if (uiTextureIndex != 0xFFFF)
+          return MakeTextureTooltip(uiTextureIndex, m_Info.m_Textures[uiTextureIndex]);
+      }
+      else
+      {
+        const ezUInt16 uiBufferIndex = FindBufferLifetimeResource(hover);
+        if (uiBufferIndex != 0xFFFF)
+          return MakeBufferTooltip(uiBufferIndex, m_Info.m_Buffers[uiBufferIndex]);
+      }
+    }
+    break;
+
+    case HoverInfo::Area::None:
+      break;
+  }
+
+  return QString();
+}
+
+QString ezQtRenderGraphOverviewWidget::MakeTextureColumnTooltip(ezUInt32 uiResolvedIndex) const
+{
+  auto it = std::lower_bound(begin(m_TextureColumnResources), end(m_TextureColumnResources), uiResolvedIndex,
+    [](const TextureColumnResource& resource, ezUInt32 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+
+  QString tooltip;
+  for (; it != end(m_TextureColumnResources) && it->m_uiResolvedIndex == uiResolvedIndex; ++it)
+  {
+    if (!tooltip.isEmpty())
+      tooltip += "\n\n";
+    tooltip += MakeTextureTooltip(it->m_uiTextureIndex, m_Info.m_Textures[it->m_uiTextureIndex]);
+  }
+  return tooltip;
+}
+
+QString ezQtRenderGraphOverviewWidget::MakeBufferColumnTooltip(ezUInt32 uiResolvedIndex) const
+{
+  auto it = std::lower_bound(begin(m_BufferColumnResources), end(m_BufferColumnResources), uiResolvedIndex,
+    [](const BufferColumnResource& resource, ezUInt32 uiResolvedIndex) { return resource.m_uiResolvedIndex < uiResolvedIndex; });
+
+  QString tooltip;
+  for (; it != end(m_BufferColumnResources) && it->m_uiResolvedIndex == uiResolvedIndex; ++it)
+  {
+    if (!tooltip.isEmpty())
+      tooltip += "\n\n";
+    tooltip += MakeBufferTooltip(it->m_uiBufferIndex, m_Info.m_Buffers[it->m_uiBufferIndex]);
+  }
+  return tooltip;
+}
+
+QRect ezQtRenderGraphOverviewWidget::GetCellRect(ezUInt32 uiPassIndex, ezUInt32 uiResourceColumn) const
+{
+  return QRect(s_iPassLabelWidth + (ezInt32)uiResourceColumn * s_iCellSize, s_iHeaderHeight + (ezInt32)uiPassIndex * s_iCellSize, s_iCellSize, s_iCellSize);
+}
+
+void ezQtRenderGraphOverviewWidget::DrawResourceNames(QPainter& painter)
+{
+  for (ezUInt32 column = 0; column < m_uiTextureColumnCount; ++column)
+  {
+    const ezInt32 x = s_iPassLabelWidth + (ezInt32)column * s_iCellSize;
+    painter.fillRect(QRect(x, s_iHeaderHeight - s_iCellSize, s_iCellSize, s_iCellSize), column % 2 == 0 ? palette().color(QPalette::Mid) : palette().color(QPalette::AlternateBase));
+    painter.setPen(palette().color(QPalette::Text));
+    painter.drawText(QRect(x, s_iHeaderHeight - s_iCellSize, s_iCellSize, s_iCellSize), Qt::AlignCenter, QString::number(column));
+  }
+
+  for (ezUInt32 column = 0; column < m_uiBufferColumnCount; ++column)
+  {
+    const ezUInt32 resourceColumn = m_uiTextureColumnCount + column;
+    const ezInt32 x = s_iPassLabelWidth + (ezInt32)resourceColumn * s_iCellSize;
+    painter.fillRect(QRect(x, s_iHeaderHeight - s_iCellSize, s_iCellSize, s_iCellSize), resourceColumn % 2 == 0 ? palette().color(QPalette::Mid) : palette().color(QPalette::AlternateBase));
+    painter.setPen(ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Cyan)));
+    painter.drawText(QRect(x, s_iHeaderHeight - s_iCellSize, s_iCellSize, s_iCellSize), Qt::AlignCenter, QString::number(resourceColumn));
+  }
+}
+
+void ezQtRenderGraphOverviewWidget::DrawPassNames(QPainter& painter)
+{
+  for (ezUInt32 passIndex = 0; passIndex < m_Info.m_Passes.GetCount(); ++passIndex)
+  {
+    const auto& pass = m_Info.m_Passes[passIndex];
+    const QRect labelRect(0, s_iHeaderHeight + (ezInt32)passIndex * s_iCellSize, s_iPassLabelWidth, s_iCellSize);
+    const QColor textColor = !pass.m_bAlive ? palette().color(QPalette::Disabled, QPalette::Text) : pass.m_QueueType == ezGALQueueType::Compute ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green)) : pass.m_QueueType == ezGALQueueType::Transfer ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Blue)) : palette().color(QPalette::Text);
+    painter.fillRect(labelRect, passIndex % 2 == 0 ? palette().color(QPalette::Base) : palette().color(QPalette::AlternateBase));
+    painter.setPen(textColor);
+    painter.drawText(labelRect.adjusted(6, 0, -4, 0), Qt::AlignVCenter | Qt::AlignLeft, ezMakeQString(pass.m_sName));
+  }
+}
+
+void ezQtRenderGraphOverviewWidget::DrawGrid(QPainter& painter)
+{
+  const ezInt32 iGridWidth = (ezInt32)m_uiTotalResourceColumnCount * s_iCellSize;
+  const ezInt32 iGridHeight = (ezInt32)m_Info.m_Passes.GetCount() * s_iCellSize;
+  const QRect gridRect(s_iPassLabelWidth, s_iHeaderHeight, iGridWidth, iGridHeight);
+
+  painter.fillRect(gridRect, palette().color(QPalette::Dark));
+  painter.setPen(QPen(palette().color(QPalette::Midlight), 1));
+  for (ezUInt32 column = 0; column <= m_uiTotalResourceColumnCount; ++column)
+  {
+    const ezInt32 x = s_iPassLabelWidth + (ezInt32)column * s_iCellSize;
+    painter.drawLine(x, s_iHeaderHeight, x, s_iHeaderHeight + iGridHeight);
+  }
+  for (ezUInt32 passIndex = 0; passIndex <= m_Info.m_Passes.GetCount(); ++passIndex)
+  {
+    const ezInt32 y = s_iHeaderHeight + (ezInt32)passIndex * s_iCellSize;
+    painter.drawLine(s_iPassLabelWidth, y, s_iPassLabelWidth + iGridWidth, y);
+  }
+}
+
+void ezQtRenderGraphOverviewWidget::DrawResourceLifetimes(QPainter& painter)
+{
+  painter.setBrush(Qt::NoBrush);
+  for (ezUInt32 i = 0; i < m_Info.m_Textures.GetCount(); ++i)
+  {
+    const auto& texture = m_Info.m_Textures[i];
+    if (texture.m_uiFirstUsePassIndex == 0xFFFF || texture.m_uiResolvedIndex == 0xFFFF)
+      continue;
+
+    const QRect rect = GetLifetimeRect(texture.m_uiFirstUsePassIndex, texture.m_uiLastUsePassIndex, texture.m_uiResolvedIndex);
+    painter.setPen(QPen(texture.m_bImported ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Orange)) : ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Yellow)), 1));
+    painter.drawRect(rect);
+  }
+
+  for (ezUInt32 i = 0; i < m_Info.m_Buffers.GetCount(); ++i)
+  {
+    const auto& buffer = m_Info.m_Buffers[i];
+    if (buffer.m_uiFirstUsePassIndex == 0xFFFF || buffer.m_uiResolvedIndex == 0xFFFF)
+      continue;
+
+    const QRect rect = GetLifetimeRect(buffer.m_uiFirstUsePassIndex, buffer.m_uiLastUsePassIndex, m_uiTextureColumnCount + buffer.m_uiResolvedIndex);
+    painter.setPen(QPen(buffer.m_bImported ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Cyan)) : ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Blue)), 1));
+    painter.drawRect(rect);
+  }
+}
+
+QRect ezQtRenderGraphOverviewWidget::GetLifetimeRect(ezUInt32 uiFirstPass, ezUInt32 uiLastPass, ezUInt32 uiResourceColumn) const
+{
+  const ezInt32 x = s_iPassLabelWidth + (ezInt32)uiResourceColumn * s_iCellSize + s_iLifetimeGap;
+  const ezInt32 y = s_iHeaderHeight + (ezInt32)uiFirstPass * s_iCellSize + s_iLifetimeGap;
+  const ezInt32 width = s_iCellSize - 2 * s_iLifetimeGap;
+  const ezInt32 height = ((ezInt32)uiLastPass - (ezInt32)uiFirstPass + 1) * s_iCellSize - 2 * s_iLifetimeGap;
+  return QRect(x, y, width, height);
+}
+
+void ezQtRenderGraphOverviewWidget::DrawAccesses(QPainter& painter)
+{
+  ezDynamicArray<ezBitflags<ezGALResourceState>> accessMasks;
+  accessMasks.SetCount(m_uiTotalResourceColumnCount);
+
+  auto it = begin(m_Info.m_Accesses);
+  for (ezUInt32 passIndex = 0; passIndex < m_Info.m_Passes.GetCount(); ++passIndex)
+  {
+    ezMemoryUtils::ZeroFill(accessMasks.GetData(), accessMasks.GetCount());
+    ezUInt32 uiObservedResourceColumn = 0xFFFFFFFF;
+
+    // m_Accesses is sorted by pass index first.
+    while (it != end(m_Info.m_Accesses) && it->m_uiPassIndex < passIndex)
+    {
+      ++it;
+    }
+
+    // Accumulate all resource accesses on each resource
+    for (; it != end(m_Info.m_Accesses) && it->m_uiPassIndex == passIndex; ++it)
+    {
+      ezUInt32 resourceColumn = 0;
+      if (it->m_bIsTexture)
+      {
+        resourceColumn = m_Info.m_Textures[it->m_uiResourceIndex].m_uiResolvedIndex;
+      }
+      else
+      {
+        resourceColumn = m_uiTextureColumnCount + m_Info.m_Buffers[it->m_uiResourceIndex].m_uiResolvedIndex;
+      }
+
+      accessMasks[resourceColumn] |= it->m_Access;
+
+      if (it->m_bIsTexture &&
+          !m_sObservedPassName.IsEmpty() &&
+          m_Info.m_Passes[it->m_uiPassIndex].m_sName == m_sObservedPassName &&
+          it->m_uiAccessIndex == m_uiObservedAccessIndex)
+      {
+        uiObservedResourceColumn = resourceColumn;
+      }
+    }
+
+    // Draw accumulated accesses
+    painter.setPen(Qt::NoPen);
+    for (ezUInt32 resourceColumn = 0; resourceColumn < accessMasks.GetCount(); ++resourceColumn)
+    {
+      const ezBitflags<ezGALResourceState> accessMask = accessMasks[resourceColumn];
+      if (accessMask.IsNoFlagSet())
+        continue;
+
+      const QRect cellRect = GetCellRect(passIndex, resourceColumn);
+      const QRect markerRect = cellRect.adjusted(s_iAccessPadding, s_iAccessPadding, -s_iAccessPadding, -s_iAccessPadding);
+      const ezBitflags<ezGALResourceState> readMask = accessMask & ezBitflags<ezGALResourceState>(ezGALResourceState::AllReadStates);
+      const ezBitflags<ezGALResourceState> writeMask = accessMask & ezBitflags<ezGALResourceState>(ezGALResourceState::AllWriteStates);
+
+      if (!readMask.IsNoFlagSet() && !writeMask.IsNoFlagSet())
+      {
+        const QPoint topLeft = markerRect.topLeft();
+        const QPoint topRight(markerRect.right() + 1, markerRect.top());
+        const QPoint bottomLeft(markerRect.left(), markerRect.bottom() + 1);
+        const QPoint bottomRight(markerRect.right() + 1, markerRect.bottom() + 1);
+
+        QPolygon readTriangle;
+        readTriangle << topLeft << topRight << bottomLeft;
+        painter.setBrush(GetAccessColor(readMask));
+        painter.drawPolygon(readTriangle);
+
+        QPolygon writeTriangle;
+        writeTriangle << bottomRight << topRight << bottomLeft;
+        painter.setBrush(GetAccessColor(writeMask));
+        painter.drawPolygon(writeTriangle);
+      }
+      else
+      {
+        painter.fillRect(markerRect, GetAccessColor(accessMask));
+      }
+    }
+
+    if (uiObservedResourceColumn != 0xFFFFFFFF)
+    {
+      const QRect cellRect = GetCellRect(passIndex, uiObservedResourceColumn);
+      painter.setPen(QPen(palette().color(QPalette::Highlight), 2));
+      painter.setBrush(Qt::NoBrush);
+      painter.drawRect(cellRect.adjusted(s_iLifetimeGap, s_iLifetimeGap, -s_iLifetimeGap, -s_iLifetimeGap));
+    }
+  }
+}

--- a/Code/Tools/Inspector/RenderGraphOverviewWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphOverviewWidget.cpp
@@ -73,14 +73,14 @@ namespace
     return ezMakeQString(text);
   }
 
-  void AppendAccessTooltipDetails(ezStringBuilder& ref_text, const ezRenderGraphInspectionInfo::AccessInfo& access)
+  void AppendAccessTooltipDetails(ezStringBuilder& ref_sText, const ezRenderGraphInspectionInfo::AccessInfo& access)
   {
-    ref_text.AppendFormat("\nAccess: {}", ezArgEnum(access.m_Access));
+    ref_sText.AppendFormat("\nAccess: {}", ezArgEnum(access.m_Access));
 
     if (access.m_bIsTexture)
     {
       const auto& range = access.m_TextureRange;
-      ref_text.AppendFormat("\nRange: mip {}+{}, slice {}+{}", range.m_uiBaseMipLevel, range.m_uiMipLevels,
+      ref_sText.AppendFormat("\nRange: mip {}+{}, slice {}+{}", range.m_uiBaseMipLevel, range.m_uiMipLevels,
         range.m_uiBaseArraySlice, range.m_uiArraySlices);
     }
   }

--- a/Code/Tools/Inspector/RenderGraphOverviewWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphOverviewWidget.moc.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Strings/String.h>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QString>
+#include <QWidget>
+
+class QMouseEvent;
+class QPaintEvent;
+class QPainter;
+
+/// Visualizes render graph passes, resources, lifetimes, and access points for inspection.
+class ezQtRenderGraphOverviewWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit ezQtRenderGraphOverviewWidget(QWidget* pParent = nullptr);
+
+  void SetInfo(ezUInt64 uiSelectedGraphId, const ezRenderGraphInspectionInfo& info);
+  void SetRequest(const ezRenderGraphObserverRequest& request);
+  void Clear();
+
+Q_SIGNALS:
+  void AccessSelected(ezUInt16 uiPassIndex, ezUInt16 uiAccessIndex);
+  void AccessDeselected();
+
+protected:
+  void paintEvent(QPaintEvent*) override;
+  void mousePressEvent(QMouseEvent* e) override;
+  void mouseMoveEvent(QMouseEvent* e) override;
+
+private:
+  /// Maps one displayed texture column to the texture resource it represents.
+  struct TextureColumnResource
+  {
+    ezUInt16 m_uiResolvedIndex = 0xFFFF;
+    ezUInt16 m_uiTextureIndex = 0xFFFF;
+  };
+
+  /// Maps one displayed buffer column to the buffer resource it represents.
+  struct BufferColumnResource
+  {
+    ezUInt16 m_uiResolvedIndex = 0xFFFF;
+    ezUInt16 m_uiBufferIndex = 0xFFFF;
+  };
+
+  /// Describes the render graph overview element currently under the mouse cursor.
+  struct HoverInfo
+  {
+    enum class Area
+    {
+      None,
+      PassHeader,
+      TextureHeader,
+      BufferHeader,
+      ResourceCell,
+    };
+
+    Area m_Area = Area::None;
+    QPoint m_Position;
+    ezUInt16 m_uiPassIndex = 0xFFFF;
+    ezUInt16 m_uiResourceColumn = 0xFFFF;
+    bool m_bIsTexture = true;
+  };
+
+
+
+  HoverInfo GetHoverInfo(const QPoint& pos) const;
+  const ezRenderGraphInspectionInfo::AccessInfo* FindAccess(const HoverInfo& hover, bool bLastMatch = false) const;
+  QString MakeAccessesTooltip(const HoverInfo& hover) const;
+  ezUInt16 FindTextureLifetimeResource(const HoverInfo& hover) const;
+  ezUInt16 FindBufferLifetimeResource(const HoverInfo& hover) const;
+  QString MakeHoverTooltip(const HoverInfo& hover) const;
+  QString MakeTextureColumnTooltip(ezUInt32 uiResolvedIndex) const;
+  QString MakeBufferColumnTooltip(ezUInt32 uiResolvedIndex) const;
+  QRect GetCellRect(ezUInt32 uiPassIndex, ezUInt32 uiResourceColumn) const;
+  void DrawResourceNames(QPainter& painter);
+  void DrawPassNames(QPainter& painter);
+  void DrawGrid(QPainter& painter);
+  void DrawResourceLifetimes(QPainter& painter);
+  QRect GetLifetimeRect(ezUInt32 uiFirstPass, ezUInt32 uiLastPass, ezUInt32 uiResourceColumn) const;
+  void DrawAccesses(QPainter& painter);
+
+  static constexpr ezInt32 s_iCellSize = 18;
+  static constexpr ezInt32 s_iPassLabelWidth = 200;
+  static constexpr ezInt32 s_iHeaderHeight = 40;
+  static constexpr ezInt32 s_iContentPadding = 12;
+  static constexpr ezInt32 s_iLifetimeGap = 2;
+  static constexpr ezInt32 s_iAccessPadding = 4;
+
+  // Input inspection info
+  ezUInt64 m_uiSelectedGraphId = 0;
+  ezRenderGraphInspectionInfo m_Info;
+  QSize m_MinContentSize = QSize(600, 300);
+
+  // Caches
+  ezUInt32 m_uiTextureColumnCount = 0;
+  ezUInt32 m_uiBufferColumnCount = 0;
+  ezUInt32 m_uiTotalResourceColumnCount = 0;
+  ezDynamicArray<TextureColumnResource> m_TextureColumnResources; ///< Find transient textures matching the same m_uiResolvedIndex
+  ezDynamicArray<BufferColumnResource> m_BufferColumnResources; ///< Find transient buffers matching the same m_uiResolvedIndex
+
+  // Observed resource
+  ezString m_sObservedPassName;
+  ezUInt16 m_uiObservedAccessIndex = 0;
+};

--- a/Code/Tools/Inspector/RenderGraphOverviewWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphOverviewWidget.moc.h
@@ -3,13 +3,13 @@
 #include <Foundation/Basics.h>
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Strings/String.h>
-#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
-#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
 #include <QPoint>
 #include <QRect>
 #include <QSize>
 #include <QString>
 #include <QWidget>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
 
 class QMouseEvent;
 class QPaintEvent;
@@ -105,7 +105,7 @@ private:
   ezUInt32 m_uiBufferColumnCount = 0;
   ezUInt32 m_uiTotalResourceColumnCount = 0;
   ezDynamicArray<TextureColumnResource> m_TextureColumnResources; ///< Find transient textures matching the same m_uiResolvedIndex
-  ezDynamicArray<BufferColumnResource> m_BufferColumnResources; ///< Find transient buffers matching the same m_uiResolvedIndex
+  ezDynamicArray<BufferColumnResource> m_BufferColumnResources;   ///< Find transient buffers matching the same m_uiResolvedIndex
 
   // Observed resource
   ezString m_sObservedPassName;

--- a/Code/Tools/Inspector/RenderGraphPreviewWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphPreviewWidget.cpp
@@ -1,0 +1,168 @@
+#include <Inspector/InspectorPCH.h>
+
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <Inspector/RenderGraphPreviewWidget.moc.h>
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <QWheelEvent>
+
+ezQtRenderGraphPreviewWidget::ezQtRenderGraphPreviewWidget(QWidget* pParent)
+  : QWidget(pParent)
+{
+  setMinimumHeight(160);
+  setMouseTracking(true);
+
+  constexpr ezInt32 checker = 16;
+  m_CheckerboardImage = QImage(checker * 2, checker * 2, QImage::Format_ARGB32_Premultiplied);
+  m_CheckerboardImage.fill(palette().color(QPalette::Midlight));
+  QPainter checkerPainter(&m_CheckerboardImage);
+  checkerPainter.fillRect(QRect(0, 0, checker, checker), palette().color(QPalette::Light));
+  checkerPainter.fillRect(QRect(checker, checker, checker, checker), palette().color(QPalette::Light));
+}
+
+void ezQtRenderGraphPreviewWidget::SetTextureSize(ezVec2U32 size)
+{
+  m_vTextureSize = size;
+  update();
+}
+
+void ezQtRenderGraphPreviewWidget::SetTargetSize(ezVec2U32 size)
+{
+  m_vTargetSize = size;
+  update();
+}
+
+void ezQtRenderGraphPreviewWidget::SetView(float fZoom, ezVec2 panCenter)
+{
+  m_fZoom = ezMath::Clamp(fZoom, 0.1f, 64.0f);
+  m_vPanCenter = panCenter;
+  update();
+}
+
+void ezQtRenderGraphPreviewWidget::paintEvent(QPaintEvent*)
+{
+  QPainter painter(this);
+  painter.fillRect(rect(), palette().color(QPalette::Dark));
+  const QRect viewRect = GetPreviewRect();
+  painter.fillRect(viewRect, palette().color(QPalette::Base));
+
+  painter.save();
+  painter.setBrushOrigin(viewRect.topLeft());
+  painter.fillRect(viewRect, QBrush(m_CheckerboardImage));
+  painter.restore();
+
+  painter.setPen(QPen(palette().color(QPalette::Highlight), 2));
+  painter.drawRect(viewRect);
+  painter.setPen(palette().color(QPalette::Text));
+  ezStringBuilder text;
+  text.SetFormat("Remote preview target\nZoom: {}%%\nPan: {}, {}\nLeft Click to pan\nRight click to select pixel\nMouse wheel to zoom", (ezInt32)(m_fZoom * 100.0f), ezArgF(m_vPanCenter.x, 3), ezArgF(m_vPanCenter.y, 3));
+  painter.drawText(viewRect.adjusted(8, 8, -8, -8), Qt::AlignTop | Qt::AlignLeft, ezMakeQString(text));
+}
+
+void ezQtRenderGraphPreviewWidget::wheelEvent(QWheelEvent* e)
+{
+  const QPoint pos = e->position().toPoint();
+  const ezVec2 uvBeforeZoom = GetUvAtWidgetPosition(pos);
+  const float fZoomFactor = e->angleDelta().y() > 0 ? 1.2f : 1.0f / 1.2f;
+  m_fZoom = ezMath::Clamp(m_fZoom * fZoomFactor, 0.1f, 64.0f);
+  const ezVec2 uvAfterZoom = GetUvAtWidgetPosition(pos);
+  m_vPanCenter += uvBeforeZoom - uvAfterZoom;
+  EmitChange(pos);
+}
+
+void ezQtRenderGraphPreviewWidget::mousePressEvent(QMouseEvent* e)
+{
+  if (e->button() == Qt::LeftButton || e->button() == Qt::MiddleButton)
+  {
+    m_bDragging = true;
+    m_LastMousePos = e->pos();
+  }
+  else if (e->button() == Qt::RightButton)
+  {
+    m_bPixelSelectionActive = true;
+    EmitChange(e->pos());
+  }
+}
+
+void ezQtRenderGraphPreviewWidget::mouseMoveEvent(QMouseEvent* e)
+{
+  if (m_bDragging)
+  {
+    const ezVec2 extents = GetUvExtents();
+    const QRect viewRect = GetPreviewRect();
+    const QPoint delta = e->pos() - m_LastMousePos;
+    m_LastMousePos = e->pos();
+    m_vPanCenter.x -= (float)delta.x() / ezMath::Max(viewRect.width(), 1) * extents.x;
+    m_vPanCenter.y -= (float)delta.y() / ezMath::Max(viewRect.height(), 1) * extents.y;
+  }
+  EmitChange(e->pos());
+}
+
+void ezQtRenderGraphPreviewWidget::mouseReleaseEvent(QMouseEvent* e)
+{
+  if (e->button() == Qt::LeftButton || e->button() == Qt::MiddleButton)
+  {
+    m_bDragging = false;
+  }
+  else if (e->button() == Qt::RightButton)
+  {
+    m_bPixelSelectionActive = false;
+    EmitChange(e->pos());
+  }
+}
+
+ezVec2 ezQtRenderGraphPreviewWidget::GetUvExtents() const
+{
+  if (m_vTextureSize.x == 0 || m_vTextureSize.y == 0)
+  {
+    return ezVec2(1.0f);
+  }
+  const float fTexAspect = (float)m_vTextureSize.x / (float)ezMath::Max(m_vTextureSize.y, 1u);
+  const QRect viewRect = GetPreviewRect();
+  const float fViewAspect = (float)ezMath::Max(viewRect.width(), 1) / (float)ezMath::Max(viewRect.height(), 1);
+  return fTexAspect > fViewAspect ? ezVec2(1.0f / m_fZoom, 1.0f / m_fZoom * (fTexAspect / fViewAspect)) : ezVec2(1.0f / m_fZoom * (fViewAspect / fTexAspect), 1.0f / m_fZoom);
+}
+
+ezVec2 ezQtRenderGraphPreviewWidget::GetUvAtWidgetPosition(const QPoint& pos) const
+{
+  const ezVec2 extents = GetUvExtents();
+  const QRect viewRect = GetPreviewRect();
+  const float fX = ezMath::Clamp((float)(pos.x() - viewRect.left()) / (float)ezMath::Max(viewRect.width(), 1), 0.0f, 1.0f);
+  const float fY = ezMath::Clamp((float)(pos.y() - viewRect.top()) / (float)ezMath::Max(viewRect.height(), 1), 0.0f, 1.0f);
+  return ezVec2(m_vPanCenter.x - extents.x * 0.5f + fX * extents.x, m_vPanCenter.y - extents.y * 0.5f + fY * extents.y);
+}
+
+QRect ezQtRenderGraphPreviewWidget::GetPreviewRect() const
+{
+  const QRect available = rect().adjusted(8, 8, -8, -8);
+  if (m_vTargetSize.x == 0 || m_vTargetSize.y == 0 || available.width() <= 0 || available.height() <= 0)
+    return available;
+
+  const float fTargetAspect = (float)m_vTargetSize.x / (float)ezMath::Max(m_vTargetSize.y, 1u);
+  const float fAvailableAspect = (float)available.width() / (float)ezMath::Max(available.height(), 1);
+
+  if (fTargetAspect > fAvailableAspect)
+  {
+    const ezInt32 iHeight = ezMath::Max(1, (ezInt32)((float)available.width() / fTargetAspect));
+    const ezInt32 iTop = available.top() + (available.height() - iHeight) / 2;
+    return QRect(available.left(), iTop, available.width(), iHeight);
+  }
+
+  const ezInt32 iWidth = ezMath::Max(1, (ezInt32)((float)available.height() * fTargetAspect));
+  const ezInt32 iLeft = available.left() + (available.width() - iWidth) / 2;
+  return QRect(iLeft, available.top(), iWidth, available.height());
+}
+
+void ezQtRenderGraphPreviewWidget::EmitChange(const QPoint& pos)
+{
+  ezVec2I32 pixel(-1, -1);
+  if (m_bPixelSelectionActive && m_vTextureSize.x > 0 && m_vTextureSize.y > 0)
+  {
+    const ezVec2 uv = GetUvAtWidgetPosition(pos);
+    pixel.x = ezMath::Clamp((ezInt32)(uv.x * (float)m_vTextureSize.x), 0, (ezInt32)m_vTextureSize.x - 1);
+    pixel.y = ezMath::Clamp((ezInt32)(uv.y * (float)m_vTextureSize.y), 0, (ezInt32)m_vTextureSize.y - 1);
+  }
+  update();
+  Q_EMIT RequestChanged(m_fZoom, m_vPanCenter, pixel, m_bPixelSelectionActive, m_bPixelSelectionActive);
+}

--- a/Code/Tools/Inspector/RenderGraphPreviewWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphPreviewWidget.cpp
@@ -21,22 +21,22 @@ ezQtRenderGraphPreviewWidget::ezQtRenderGraphPreviewWidget(QWidget* pParent)
   checkerPainter.fillRect(QRect(checker, checker, checker, checker), palette().color(QPalette::Light));
 }
 
-void ezQtRenderGraphPreviewWidget::SetTextureSize(ezVec2U32 size)
+void ezQtRenderGraphPreviewWidget::SetTextureSize(ezVec2U32 vSize)
 {
-  m_vTextureSize = size;
+  m_vTextureSize = vSize;
   update();
 }
 
-void ezQtRenderGraphPreviewWidget::SetTargetSize(ezVec2U32 size)
+void ezQtRenderGraphPreviewWidget::SetTargetSize(ezVec2U32 vSize)
 {
-  m_vTargetSize = size;
+  m_vTargetSize = vSize;
   update();
 }
 
-void ezQtRenderGraphPreviewWidget::SetView(float fZoom, ezVec2 panCenter)
+void ezQtRenderGraphPreviewWidget::SetView(float fZoom, ezVec2 vPanCenter)
 {
   m_fZoom = ezMath::Clamp(fZoom, 0.1f, 64.0f);
-  m_vPanCenter = panCenter;
+  m_vPanCenter = vPanCenter;
   update();
 }
 

--- a/Code/Tools/Inspector/RenderGraphPreviewWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphPreviewWidget.moc.h
@@ -18,12 +18,12 @@ class ezQtRenderGraphPreviewWidget : public QWidget
 public:
   explicit ezQtRenderGraphPreviewWidget(QWidget* pParent = nullptr);
 
-  void SetTextureSize(ezVec2U32 size);
-  void SetTargetSize(ezVec2U32 size);
-  void SetView(float fZoom, ezVec2 panCenter);
+  void SetTextureSize(ezVec2U32 vSize);
+  void SetTargetSize(ezVec2U32 vSize);
+  void SetView(float fZoom, ezVec2 vPanCenter);
 
 Q_SIGNALS:
-  void RequestChanged(float fZoom, ezVec2 panCenter, ezVec2I32 pixel, bool bUpdatePixelPosition, bool bHighlightPixel);
+  void RequestChanged(float fZoom, ezVec2 vPanCenter, ezVec2I32 vPixel, bool bUpdatePixelPosition, bool bHighlightPixel);
 
 protected:
   void paintEvent(QPaintEvent*) override;

--- a/Code/Tools/Inspector/RenderGraphPreviewWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphPreviewWidget.moc.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Math/Vec2.h>
+#include <QImage>
+#include <QPoint>
+#include <QWidget>
+
+class QMouseEvent;
+class QPaintEvent;
+class QWheelEvent;
+
+/// Handles viewport interaction for the render graph texture preview.
+class ezQtRenderGraphPreviewWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit ezQtRenderGraphPreviewWidget(QWidget* pParent = nullptr);
+
+  void SetTextureSize(ezVec2U32 size);
+  void SetTargetSize(ezVec2U32 size);
+  void SetView(float fZoom, ezVec2 panCenter);
+
+Q_SIGNALS:
+  void RequestChanged(float fZoom, ezVec2 panCenter, ezVec2I32 pixel, bool bUpdatePixelPosition, bool bHighlightPixel);
+
+protected:
+  void paintEvent(QPaintEvent*) override;
+  void wheelEvent(QWheelEvent* e) override;
+  void mousePressEvent(QMouseEvent* e) override;
+  void mouseMoveEvent(QMouseEvent* e) override;
+  void mouseReleaseEvent(QMouseEvent* e) override;
+
+private:
+  ezVec2 GetUvExtents() const;
+  ezVec2 GetUvAtWidgetPosition(const QPoint& pos) const;
+  QRect GetPreviewRect() const;
+  void EmitChange(const QPoint& pos);
+
+  ezVec2U32 m_vTextureSize = ezVec2U32(0, 0);
+  ezVec2U32 m_vTargetSize = ezVec2U32(0, 0);
+  float m_fZoom = 1.0f;
+  ezVec2 m_vPanCenter = ezVec2(0.5f);
+  bool m_bDragging = false;
+  bool m_bPixelSelectionActive = false;
+  QPoint m_LastMousePos;
+  QImage m_CheckerboardImage;
+};

--- a/Code/Tools/Inspector/RenderGraphWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphWidget.cpp
@@ -1,0 +1,587 @@
+#include <Inspector/InspectorPCH.h>
+
+#include <Foundation/Communication/Telemetry.h>
+#include <Foundation/Math/ColorScheme.h>
+#include <Foundation/Types/Variant.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <GuiFoundation/Widgets/DoubleSpinBox.moc.h>
+#include <Inspector/RenderGraphWidget.moc.h>
+#include <RendererFoundation/RendererReflection.h>
+
+#include <QCheckBox>
+#include <QHideEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPalette>
+#include <QSignalBlocker>
+#include <QShowEvent>
+#include <QSpinBox>
+#include <QSplitter>
+#include <QToolButton>
+
+namespace
+{
+  constexpr ezUInt32 s_uiSystemId = 'RGPH';
+  constexpr ezUInt16 s_uiProtocolVersion = 1;
+
+  enum GraphListItemDataRole
+  {
+    GraphListRole_RenderGraphId = Qt::UserRole,
+    GraphListRole_IsGraphItem = Qt::UserRole + 1,
+  };
+
+  enum SwapChainListItemDataRole
+  {
+    SwapChainListRole_SwapChainId = Qt::UserRole,
+    SwapChainListRole_Width = Qt::UserRole + 1,
+    SwapChainListRole_Height = Qt::UserRole + 2,
+  };
+
+  QString MakeGraphLabel(const ezRenderGraphExecutionSummary& graph)
+  {
+    ezStringBuilder label;
+    if (!graph.m_sUserName.IsEmpty())
+      label.SetFormat("{} ({})", graph.m_sUserName, graph.m_sGraphName);
+    else
+      label = graph.m_sGraphName;
+
+    if (graph.m_uiExecutionOrder >= 0)
+      label.AppendFormat("  [{}]", graph.m_uiExecutionOrder);
+
+    return ezMakeQString(label);
+  }
+
+  QString MakeSwapChainLabel(const ezRenderGraphSwapChainSummary& swapChain)
+  {
+    ezStringBuilder label;
+    label.SetFormat("0x{}  {}x{}", ezArgU(swapChain.m_uiSwapChainId, 8, true, 16), swapChain.m_uiWidth, swapChain.m_uiHeight);
+    return ezMakeQString(label);
+  }
+
+  QString MakePhaseLabel(ezRenderGraphPhase::Enum phase)
+  {
+    switch (phase)
+    {
+      case ezRenderGraphPhase::PreRender:
+        return "PreRender";
+      case ezRenderGraphPhase::Render:
+        return "Render";
+      case ezRenderGraphPhase::PostRender:
+        return "PostRender";
+      default:
+        return "Unknown";
+    }
+  }
+
+  void AddGraphPhaseSeparator(QListWidget* pList, ezRenderGraphPhase::Enum phase)
+  {
+    QListWidgetItem* pItem = new QListWidgetItem(MakePhaseLabel(phase));
+    pItem->setFlags(Qt::NoItemFlags);
+    pItem->setData(GraphListRole_IsGraphItem, false);
+    pItem->setForeground(pList->palette().color(QPalette::Text));
+    pItem->setBackground(pList->palette().color(QPalette::Mid));
+    pList->addItem(pItem);
+  }
+
+} // namespace
+
+ezQtRenderGraphWidget* ezQtRenderGraphWidget::s_pWidget = nullptr;
+
+ezQtRenderGraphWidget::ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QWidget* pParent)
+  : ads::CDockWidget(pDockManager, "Render Graph", pParent)
+{
+  s_pWidget = this;
+
+  setupUi(this);
+  setWidget(HorizontalSplitter);
+
+  QPalette overviewScrollPalette = OverviewScroll->viewport()->palette();
+  overviewScrollPalette.setColor(QPalette::Window, palette().color(QPalette::Dark));
+  OverviewScroll->viewport()->setAutoFillBackground(true);
+  OverviewScroll->viewport()->setPalette(overviewScrollPalette);
+
+  connect(Overview, &ezQtRenderGraphOverviewWidget::AccessSelected, this, &ezQtRenderGraphWidget::SelectAccess);
+  connect(Overview, &ezQtRenderGraphOverviewWidget::AccessDeselected, this, &ezQtRenderGraphWidget::ClearAccessSelection);
+  connect(Preview, &ezQtRenderGraphPreviewWidget::RequestChanged, this, &ezQtRenderGraphWidget::UpdatePreviewRequest);
+
+  auto requestFromControls = [this]() {
+    if (!m_bUpdatingControls)
+    {
+      SetRequestFromControls();
+      if (m_bHasLastHistogram)
+      {
+        Histogram->SetHistogram(m_LastHistogram.GetArrayPtr());
+      }
+      SendObserverRequest();
+    }
+  };
+
+  auto setRange = [this](float fMin, float fMax) {
+    m_bUpdatingControls = true;
+    RangeMinSpin->setValue(fMin);
+    RangeMaxSpin->setValue(fMax);
+    m_bUpdatingControls = false;
+
+    SetRequestFromControls();
+    if (m_bHasLastHistogram)
+    {
+      Histogram->SetHistogram(m_LastHistogram.GetArrayPtr());
+    }
+    SendObserverRequest();
+  };
+
+  connect(GraphList, &QListWidget::currentRowChanged, this, [this](int row) {
+    if (row < 0)
+      return;
+    QListWidgetItem* pItem = GraphList->item(row);
+    if (pItem == nullptr || !pItem->data(GraphListRole_IsGraphItem).toBool())
+      return;
+
+    m_uiSelectedGraphId = pItem->data(GraphListRole_RenderGraphId).toULongLong();
+    m_bInfoValid = false;
+    m_Info.Clear();
+    Overview->Clear();
+    m_Request = ezRenderGraphObserverRequest();
+    m_Request.m_uiRenderGraphId = m_uiSelectedGraphId;
+    Preview->SetView(m_Request.m_fZoom, m_Request.m_vPanCenter);
+    SendInfoRequest();
+    m_bUpdateUi = true;
+  });
+
+  connect(SwapChainList, &QListWidget::currentRowChanged, this, [this](int row) {
+    if (row < 0)
+      return;
+    QListWidgetItem* pItem = SwapChainList->item(row);
+    m_uiSelectedSwapChainId = pItem->data(SwapChainListRole_SwapChainId).toUInt();
+    m_Request.m_uiSwapChainId = m_uiSelectedSwapChainId;
+    Preview->SetTargetSize(ezVec2U32(pItem->data(SwapChainListRole_Width).toUInt(), pItem->data(SwapChainListRole_Height).toUInt()));
+    SendObserverRequest();
+  });
+
+  connect(MipSpin, qOverload<int>(&QSpinBox::valueChanged), this, requestFromControls);
+  connect(SliceSpin, qOverload<int>(&QSpinBox::valueChanged), this, requestFromControls);
+  connect(SampleSpin, qOverload<int>(&QSpinBox::valueChanged), this, requestFromControls);
+  connect(RangeMinSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, requestFromControls);
+  connect(RangeMaxSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, requestFromControls);
+  connect(ChannelR, &QCheckBox::toggled, this, requestFromControls);
+  connect(ChannelG, &QCheckBox::toggled, this, requestFromControls);
+  connect(ChannelB, &QCheckBox::toggled, this, requestFromControls);
+  connect(ChannelA, &QCheckBox::toggled, this, requestFromControls);
+  connect(ResetToolButton, &QToolButton::clicked, this, [setRange]() { setRange(0.0f, 1.0f); });
+  connect(AutoToolButton, &QToolButton::clicked, this, [this, setRange]() { setRange(m_Response.m_fImageMin, m_Response.m_fImageMax); });
+  connect(ResetZoomToolButton, &QToolButton::clicked, this, [this]() {
+    m_Request.m_fZoom = 1.0f;
+    m_Request.m_vPanCenter = ezVec2(0.5f);
+    Preview->SetView(m_Request.m_fZoom, m_Request.m_vPanCenter);
+    SendObserverRequest();
+  });
+
+  ResetStats();
+}
+
+void ezQtRenderGraphWidget::ResetStats()
+{
+  m_Summary.m_AvailableSwapChains.Clear();
+  m_Summary.m_RenderGraphs.Clear();
+  m_Info.Clear();
+  m_Request = ezRenderGraphObserverRequest();
+  m_Response = ezRenderGraphObserverResponse();
+  m_sLastPixelValue.Clear();
+  m_vLastPixelPosition = ezVec2I32(-1, -1);
+  m_LastHistogram.Clear();
+  m_uiSelectedGraphId = 0;
+  m_uiSelectedSwapChainId = 0xFFFFFFFF;
+  m_bHasLastPixelValue = false;
+  m_bHasLastHistogram = false;
+  m_bInfoValid = false;
+  m_bUpdateUi = true;
+  Overview->Clear();
+  Preview->SetTextureSize(ezVec2U32(0, 0));
+  Histogram->Clear();
+  MipSpin->setMaximum(0);
+  MipSpin->setEnabled(false);
+  SliceSpin->setMaximum(0);
+  SliceSpin->setEnabled(false);
+  SampleSpin->setMaximum(-1);
+  SampleSpin->setEnabled(false);
+  SendSummaryRequest();
+}
+
+void ezQtRenderGraphWidget::UpdateStats()
+{
+  UpdateObservationVisibility();
+
+  if (!isVisible())
+    return;
+
+  if (!m_bUpdateUi)
+    return;
+  m_bUpdateUi = false;
+  UpdateGraphList();
+  UpdateSwapChainList();
+  UpdateInfoWidgets();
+}
+
+void ezQtRenderGraphWidget::SendSummaryRequest()
+{
+  ezTelemetryMessage msg;
+  msg.SetMessageID(s_uiSystemId, 'RSUM');
+  msg.GetWriter() << s_uiProtocolVersion;
+  ezTelemetry::SendToServer(msg);
+}
+
+void ezQtRenderGraphWidget::SendInfoRequest()
+{
+  if (m_uiSelectedGraphId == 0)
+    return;
+  ezTelemetryMessage msg;
+  msg.SetMessageID(s_uiSystemId, 'RINF');
+  msg.GetWriter() << s_uiProtocolVersion;
+  msg.GetWriter() << m_uiSelectedGraphId;
+  ezTelemetry::SendToServer(msg);
+}
+
+void ezQtRenderGraphWidget::SendObserverRequest()
+{
+  if (m_bObservationPaused)
+    return;
+
+  SendObserverRequest(m_Request);
+}
+
+void ezQtRenderGraphWidget::SendObserverRequest(const ezRenderGraphObserverRequest& request)
+{
+  if (request.m_uiRenderGraphId == 0)
+    return;
+  ezTelemetryMessage msg;
+  msg.SetMessageID(s_uiSystemId, 'RREQ');
+  msg.GetWriter() << s_uiProtocolVersion;
+  msg.GetWriter() << request;
+  ezTelemetry::SendToServer(msg);
+}
+
+void ezQtRenderGraphWidget::PauseObservation()
+{
+  if (m_bObservationPaused)
+    return;
+
+  m_bObservationPaused = true;
+
+  ezRenderGraphObserverRequest pauseRequest = m_Request;
+  pauseRequest.m_sPassName.Clear();
+  pauseRequest.m_uiAccessIndex = 0;
+  pauseRequest.m_vPixelPosition = ezVec2I32(-1, -1);
+  pauseRequest.m_bHighlightPixel = false;
+  SendObserverRequest(pauseRequest);
+}
+
+void ezQtRenderGraphWidget::ResumeObservation()
+{
+  if (!m_bObservationPaused)
+    return;
+
+  m_bObservationPaused = false;
+
+  if (!m_Request.m_sPassName.IsEmpty())
+  {
+    SendObserverRequest();
+  }
+}
+
+void ezQtRenderGraphWidget::UpdateObservationVisibility()
+{
+  if (isVisible())
+  {
+    ResumeObservation();
+  }
+  else
+  {
+    PauseObservation();
+  }
+}
+
+void ezQtRenderGraphWidget::showEvent(QShowEvent* pEvent)
+{
+  ads::CDockWidget::showEvent(pEvent);
+  UpdateObservationVisibility();
+}
+
+void ezQtRenderGraphWidget::hideEvent(QHideEvent* pEvent)
+{
+  ads::CDockWidget::hideEvent(pEvent);
+  UpdateObservationVisibility();
+}
+
+void ezQtRenderGraphWidget::UpdateGraphList()
+{
+  const QSignalBlocker blocker(GraphList);
+  GraphList->clear();
+  ezInt32 iSelectedRow = -1;
+
+  constexpr ezRenderGraphPhase::Enum phases[] = {ezRenderGraphPhase::PreRender, ezRenderGraphPhase::Render, ezRenderGraphPhase::PostRender};
+  for (ezRenderGraphPhase::Enum phase : phases)
+  {
+    AddGraphPhaseSeparator(GraphList, phase);
+
+    for (ezUInt32 i = 0; i < m_Summary.m_RenderGraphs.GetCount(); ++i)
+    {
+      const auto& graph = m_Summary.m_RenderGraphs[i];
+      if (graph.m_Phase != phase)
+        continue;
+
+      const ezUInt64 uiIdentity = graph.m_uiRenderGraphId;
+      QListWidgetItem* pItem = new QListWidgetItem(MakeGraphLabel(graph));
+        pItem->setData(GraphListRole_RenderGraphId, QVariant::fromValue<qulonglong>(uiIdentity));
+        pItem->setData(GraphListRole_IsGraphItem, true);
+      pItem->setForeground(graph.m_uiExecutionOrder >= 0 ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green)) : GraphList->palette().color(QPalette::Disabled, QPalette::Text));
+      GraphList->addItem(pItem);
+      if (uiIdentity == m_uiSelectedGraphId)
+        iSelectedRow = GraphList->count() - 1;
+    }
+  }
+
+  if (iSelectedRow >= 0)
+    GraphList->setCurrentRow(iSelectedRow);
+}
+
+void ezQtRenderGraphWidget::UpdateSwapChainList()
+{
+  const QSignalBlocker blocker(SwapChainList);
+  SwapChainList->clear();
+  ezInt32 iSelectedRow = -1;
+  for (ezUInt32 i = 0; i < m_Summary.m_AvailableSwapChains.GetCount(); ++i)
+  {
+    const ezRenderGraphSwapChainSummary& swapChain = m_Summary.m_AvailableSwapChains[i];
+    const ezUInt32 uiIdentity = swapChain.m_uiSwapChainId;
+    QListWidgetItem* pItem = new QListWidgetItem(MakeSwapChainLabel(swapChain));
+    pItem->setData(SwapChainListRole_SwapChainId, uiIdentity);
+    pItem->setData(SwapChainListRole_Width, swapChain.m_uiWidth);
+    pItem->setData(SwapChainListRole_Height, swapChain.m_uiHeight);
+    SwapChainList->addItem(pItem);
+    if (uiIdentity == m_uiSelectedSwapChainId)
+      iSelectedRow = (ezInt32)i;
+  }
+
+  // If the previously selected swap chain is no longer available (or none was selected yet), fall back to
+  // the first one so that there is always a target selected as long as at least one swap chain exists.
+  bool bSelectionChanged = false;
+  if (iSelectedRow < 0 && SwapChainList->count() > 0)
+  {
+    iSelectedRow = 0;
+    m_uiSelectedSwapChainId = SwapChainList->item(0)->data(SwapChainListRole_SwapChainId).toUInt();
+    m_Request.m_uiSwapChainId = m_uiSelectedSwapChainId;
+    bSelectionChanged = true;
+  }
+
+  if (iSelectedRow >= 0)
+  {
+    SwapChainList->setCurrentRow(iSelectedRow);
+    Preview->SetTargetSize(ezVec2U32(SwapChainList->item(iSelectedRow)->data(SwapChainListRole_Width).toUInt(), SwapChainList->item(iSelectedRow)->data(SwapChainListRole_Height).toUInt()));
+  }
+
+  if (bSelectionChanged)
+  {
+    SendObserverRequest();
+  }
+}
+
+void ezQtRenderGraphWidget::UpdateInfoWidgets()
+{
+  if (m_bInfoValid)
+  {
+    Overview->SetInfo(m_uiSelectedGraphId, m_Info);
+    Overview->SetRequest(m_Request);
+  }
+
+  if (m_Response.m_PixelValue.IsValid())
+  {
+    m_sLastPixelValue = m_Response.m_PixelValue.ConvertTo<ezString>();
+    m_vLastPixelPosition = m_Request.m_vPixelPosition;
+    m_bHasLastPixelValue = true;
+  }
+
+  if (m_bHasLastPixelValue)
+  {
+    ezStringBuilder text;
+    text.SetFormat("Pixel ({}, {}): {}", m_vLastPixelPosition.x, m_vLastPixelPosition.y, m_sLastPixelValue);
+    PixelLabel->setText(ezMakeQString(text));
+  }
+  else
+  {
+    PixelLabel->setText("Pixel: -");
+  }
+
+  MinValue->setText(QString::number(m_Response.m_fImageMin, 'g', 9));
+  MaxValue->setText(QString::number(m_Response.m_fImageMax, 'g', 9));
+
+  if (m_Response.m_bHistogramValid)
+  {
+    m_LastHistogram = m_Response.m_Histogram;
+    m_bHasLastHistogram = true;
+  }
+
+  if (m_bHasLastHistogram)
+  {
+    Histogram->SetHistogram(m_LastHistogram.GetArrayPtr());
+  }
+}
+
+void ezQtRenderGraphWidget::UpdateRequestControls()
+{
+  m_bUpdatingControls = true;
+  MipSpin->setValue(m_Request.m_uiMipLevel);
+  SliceSpin->setValue(m_Request.m_uiArraySlice);
+  SampleSpin->setValue(m_Request.m_iSampleIndex);
+  RangeMinSpin->setValue(m_Request.m_fRangeMin);
+  RangeMaxSpin->setValue(m_Request.m_fRangeMax);
+  ChannelR->setChecked((m_Request.m_uiChannelMask & EZ_BIT(0)) != 0);
+  ChannelG->setChecked((m_Request.m_uiChannelMask & EZ_BIT(1)) != 0);
+  ChannelB->setChecked((m_Request.m_uiChannelMask & EZ_BIT(2)) != 0);
+  ChannelA->setChecked((m_Request.m_uiChannelMask & EZ_BIT(3)) != 0);
+  m_bUpdatingControls = false;
+}
+
+void ezQtRenderGraphWidget::UpdatePreviewRequest(float fZoom, ezVec2 panCenter, ezVec2I32 pixel, bool bUpdatePixelPosition, bool bHighlightPixel)
+{
+  m_Request.m_fZoom = fZoom;
+  m_Request.m_vPanCenter = panCenter;
+  if (bUpdatePixelPosition)
+  {
+    m_Request.m_vPixelPosition = pixel;
+  }
+  m_Request.m_bHighlightPixel = bHighlightPixel;
+  SendObserverRequest();
+}
+
+void ezQtRenderGraphWidget::SetRequestFromControls()
+{
+  m_Request.m_uiMipLevel = static_cast<ezUInt8>(ezMath::Clamp(MipSpin->value(), 0, 255));
+  m_Request.m_uiArraySlice = static_cast<ezUInt16>(ezMath::Clamp(SliceSpin->value(), 0, 65535));
+  m_Request.m_iSampleIndex = static_cast<ezInt8>(ezMath::Clamp(SampleSpin->value(), -1, 127));
+  m_Request.m_fRangeMin = (float)RangeMinSpin->value();
+  m_Request.m_fRangeMax = (float)RangeMaxSpin->value();
+  m_Request.m_uiChannelMask = 0;
+  m_Request.m_uiChannelMask |= ChannelR->isChecked() ? EZ_BIT(0) : 0;
+  m_Request.m_uiChannelMask |= ChannelG->isChecked() ? EZ_BIT(1) : 0;
+  m_Request.m_uiChannelMask |= ChannelB->isChecked() ? EZ_BIT(2) : 0;
+  m_Request.m_uiChannelMask |= ChannelA->isChecked() ? EZ_BIT(3) : 0;
+  m_Request.m_uiSwapChainId = m_uiSelectedSwapChainId;
+}
+
+void ezQtRenderGraphWidget::SelectAccess(ezUInt16 uiPassIndex, ezUInt16 uiAccessIndex)
+{
+  if (uiPassIndex >= m_Info.m_Passes.GetCount())
+    return;
+  const ezRenderGraphInspectionInfo::AccessInfo* pSelectedAccess = nullptr;
+  for (const auto& access : m_Info.m_Accesses)
+  {
+    if (access.m_bIsTexture && access.m_uiPassIndex == uiPassIndex && access.m_uiAccessIndex == uiAccessIndex)
+    {
+      pSelectedAccess = &access;
+      break;
+    }
+  }
+  if (pSelectedAccess == nullptr || pSelectedAccess->m_uiResourceIndex >= m_Info.m_Textures.GetCount())
+    return;
+
+  const auto& texture = m_Info.m_Textures[pSelectedAccess->m_uiResourceIndex];
+  const ezInt32 iMipMax = ezMath::Max<ezInt32>(0, texture.m_Desc.m_uiMipLevelCount - 1);
+  const ezInt32 iSliceMax = ezMath::Max<ezInt32>(0, texture.m_Desc.GetNumberOfSlices() - 1);
+  const ezInt32 iSampleCount = (ezInt32)texture.m_Desc.m_SampleCount;
+  const bool bHasMsaaSamples = texture.m_Desc.m_SampleCount != ezGALMSAASampleCount::None;
+  MipSpin->setMaximum(iMipMax);
+  MipSpin->setEnabled(iMipMax > 0);
+  SliceSpin->setMaximum(iSliceMax);
+  SliceSpin->setEnabled(iSliceMax > 0);
+  SampleSpin->setMaximum(bHasMsaaSamples ? iSampleCount - 1 : -1);
+  SampleSpin->setEnabled(bHasMsaaSamples);
+  Preview->SetTextureSize(ezVec2U32(texture.m_Desc.m_uiWidth, texture.m_Desc.m_uiHeight));
+  m_Request.m_uiRenderGraphId = m_uiSelectedGraphId;
+  m_Request.m_sPassName = m_Info.m_Passes[uiPassIndex].m_sName;
+  m_Request.m_uiAccessIndex = uiAccessIndex;
+  m_Request.m_uiSwapChainId = m_uiSelectedSwapChainId;
+  SetRequestFromControls();
+  UpdateRequestControls();
+  Overview->SetRequest(m_Request);
+  SendObserverRequest();
+}
+
+void ezQtRenderGraphWidget::ClearAccessSelection()
+{
+  m_Request.m_uiRenderGraphId = m_uiSelectedGraphId;
+  m_Request.m_sPassName.Clear();
+  m_Request.m_uiAccessIndex = 0;
+  m_Request.m_vPixelPosition = ezVec2I32(-1, -1);
+  m_Request.m_bHighlightPixel = false;
+  m_Request.m_uiSwapChainId = m_uiSelectedSwapChainId;
+
+  m_sLastPixelValue.Clear();
+  m_vLastPixelPosition = ezVec2I32(-1, -1);
+  m_LastHistogram.Clear();
+  m_Response = ezRenderGraphObserverResponse();
+  m_bHasLastPixelValue = false;
+  m_bHasLastHistogram = false;
+
+  MipSpin->setMaximum(0);
+  MipSpin->setEnabled(false);
+  SliceSpin->setMaximum(0);
+  SliceSpin->setEnabled(false);
+  SampleSpin->setMaximum(-1);
+  SampleSpin->setEnabled(false);
+  Preview->SetTextureSize(ezVec2U32(0, 0));
+  Overview->SetRequest(m_Request);
+  Histogram->Clear();
+  UpdateInfoWidgets();
+  SendObserverRequest();
+}
+
+void ezQtRenderGraphWidget::ProcessTelemetry(void*)
+{
+  if (s_pWidget == nullptr)
+    return;
+
+  ezTelemetryMessage msg;
+  while (ezTelemetry::RetrieveMessage(s_uiSystemId, msg) == EZ_SUCCESS)
+  {
+    ezUInt16 uiVersion = 0;
+    switch (msg.GetMessageID())
+    {
+      case 'SUMM':
+        msg.GetReader() >> uiVersion;
+        msg.GetReader() >> s_pWidget->m_Summary;
+        s_pWidget->m_bUpdateUi = true;
+        break;
+      case 'INFO':
+      {
+        ezUInt64 uiGraphIdentity = 0;
+        bool bSuccess = false;
+        msg.GetReader() >> uiVersion;
+        msg.GetReader() >> uiGraphIdentity;
+        msg.GetReader() >> bSuccess;
+        if (bSuccess)
+        {
+          msg.GetReader() >> s_pWidget->m_Info;
+          s_pWidget->m_bInfoValid = uiGraphIdentity == s_pWidget->m_uiSelectedGraphId;
+        }
+        else if (uiGraphIdentity == s_pWidget->m_uiSelectedGraphId)
+        {
+          s_pWidget->m_Info = ezRenderGraphInspectionInfo();
+          s_pWidget->m_bInfoValid = false;
+        }
+        s_pWidget->m_bUpdateUi = true;
+      }
+      break;
+      case 'RESP':
+        msg.GetReader() >> uiVersion;
+        msg.GetReader() >> s_pWidget->m_Response;
+        s_pWidget->m_bUpdateUi = true;
+        break;
+      case ' CLR':
+        s_pWidget->ResetStats();
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/Code/Tools/Inspector/RenderGraphWidget.cpp
+++ b/Code/Tools/Inspector/RenderGraphWidget.cpp
@@ -14,8 +14,8 @@
 #include <QLineEdit>
 #include <QListWidget>
 #include <QPalette>
-#include <QSignalBlocker>
 #include <QShowEvent>
+#include <QSignalBlocker>
 #include <QSpinBox>
 #include <QSplitter>
 #include <QToolButton>
@@ -105,7 +105,8 @@ ezQtRenderGraphWidget::ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QW
   connect(Overview, &ezQtRenderGraphOverviewWidget::AccessDeselected, this, &ezQtRenderGraphWidget::ClearAccessSelection);
   connect(Preview, &ezQtRenderGraphPreviewWidget::RequestChanged, this, &ezQtRenderGraphWidget::UpdatePreviewRequest);
 
-  auto requestFromControls = [this]() {
+  auto requestFromControls = [this]()
+  {
     if (!m_bUpdatingControls)
     {
       SetRequestFromControls();
@@ -117,7 +118,8 @@ ezQtRenderGraphWidget::ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QW
     }
   };
 
-  auto setRange = [this](float fMin, float fMax) {
+  auto setRange = [this](float fMin, float fMax)
+  {
     m_bUpdatingControls = true;
     RangeMinSpin->setValue(fMin);
     RangeMaxSpin->setValue(fMax);
@@ -131,7 +133,8 @@ ezQtRenderGraphWidget::ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QW
     SendObserverRequest();
   };
 
-  connect(GraphList, &QListWidget::currentRowChanged, this, [this](int row) {
+  connect(GraphList, &QListWidget::currentRowChanged, this, [this](int row)
+    {
     if (row < 0)
       return;
     QListWidgetItem* pItem = GraphList->item(row);
@@ -146,18 +149,17 @@ ezQtRenderGraphWidget::ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QW
     m_Request.m_uiRenderGraphId = m_uiSelectedGraphId;
     Preview->SetView(m_Request.m_fZoom, m_Request.m_vPanCenter);
     SendInfoRequest();
-    m_bUpdateUi = true;
-  });
+    m_bUpdateUi = true; });
 
-  connect(SwapChainList, &QListWidget::currentRowChanged, this, [this](int row) {
+  connect(SwapChainList, &QListWidget::currentRowChanged, this, [this](int row)
+    {
     if (row < 0)
       return;
     QListWidgetItem* pItem = SwapChainList->item(row);
     m_uiSelectedSwapChainId = pItem->data(SwapChainListRole_SwapChainId).toUInt();
     m_Request.m_uiSwapChainId = m_uiSelectedSwapChainId;
     Preview->SetTargetSize(ezVec2U32(pItem->data(SwapChainListRole_Width).toUInt(), pItem->data(SwapChainListRole_Height).toUInt()));
-    SendObserverRequest();
-  });
+    SendObserverRequest(); });
 
   connect(MipSpin, qOverload<int>(&QSpinBox::valueChanged), this, requestFromControls);
   connect(SliceSpin, qOverload<int>(&QSpinBox::valueChanged), this, requestFromControls);
@@ -168,14 +170,16 @@ ezQtRenderGraphWidget::ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QW
   connect(ChannelG, &QCheckBox::toggled, this, requestFromControls);
   connect(ChannelB, &QCheckBox::toggled, this, requestFromControls);
   connect(ChannelA, &QCheckBox::toggled, this, requestFromControls);
-  connect(ResetToolButton, &QToolButton::clicked, this, [setRange]() { setRange(0.0f, 1.0f); });
-  connect(AutoToolButton, &QToolButton::clicked, this, [this, setRange]() { setRange(m_Response.m_fImageMin, m_Response.m_fImageMax); });
-  connect(ResetZoomToolButton, &QToolButton::clicked, this, [this]() {
+  connect(ResetToolButton, &QToolButton::clicked, this, [setRange]()
+    { setRange(0.0f, 1.0f); });
+  connect(AutoToolButton, &QToolButton::clicked, this, [this, setRange]()
+    { setRange(m_Response.m_fImageMin, m_Response.m_fImageMax); });
+  connect(ResetZoomToolButton, &QToolButton::clicked, this, [this]()
+    {
     m_Request.m_fZoom = 1.0f;
     m_Request.m_vPanCenter = ezVec2(0.5f);
     Preview->SetView(m_Request.m_fZoom, m_Request.m_vPanCenter);
-    SendObserverRequest();
-  });
+    SendObserverRequest(); });
 
   ResetStats();
 }
@@ -332,8 +336,8 @@ void ezQtRenderGraphWidget::UpdateGraphList()
 
       const ezUInt64 uiIdentity = graph.m_uiRenderGraphId;
       QListWidgetItem* pItem = new QListWidgetItem(MakeGraphLabel(graph));
-        pItem->setData(GraphListRole_RenderGraphId, QVariant::fromValue<qulonglong>(uiIdentity));
-        pItem->setData(GraphListRole_IsGraphItem, true);
+      pItem->setData(GraphListRole_RenderGraphId, QVariant::fromValue<qulonglong>(uiIdentity));
+      pItem->setData(GraphListRole_IsGraphItem, true);
       pItem->setForeground(graph.m_uiExecutionOrder >= 0 ? ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green)) : GraphList->palette().color(QPalette::Disabled, QPalette::Text));
       GraphList->addItem(pItem);
       if (uiIdentity == m_uiSelectedGraphId)

--- a/Code/Tools/Inspector/RenderGraphWidget.moc.h
+++ b/Code/Tools/Inspector/RenderGraphWidget.moc.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Containers/StaticArray.h>
+#include <Foundation/Strings/String.h>
+#include <Inspector/RenderGraphHistogramWidget.moc.h>
+#include <Inspector/RenderGraphOverviewWidget.moc.h>
+#include <Inspector/RenderGraphPreviewWidget.moc.h>
+#include <Inspector/ui_RenderGraphWidget.h>
+#include <RendererCore/RenderGraph/RenderGraphInspectionInfo.h>
+#include <RendererCore/RenderGraph/RenderGraphPassObserver.h>
+#include <ads/DockWidget.h>
+
+class QHideEvent;
+class QShowEvent;
+
+/// Dock widget that coordinates render graph inspection telemetry and preview controls.
+class ezQtRenderGraphWidget : public ads::CDockWidget, public Ui_RenderGraphWidget
+{
+  Q_OBJECT
+
+public:
+  ezQtRenderGraphWidget(ads::CDockManager* pDockManager, QWidget* pParent = nullptr);
+
+  static ezQtRenderGraphWidget* s_pWidget;
+  static void ProcessTelemetry(void* pUnused);
+
+  void ResetStats();
+  void UpdateStats();
+
+protected:
+  void showEvent(QShowEvent* pEvent) override;
+  void hideEvent(QHideEvent* pEvent) override;
+
+private:
+  void SendSummaryRequest();
+  void SendInfoRequest();
+  void SendObserverRequest();
+  void SendObserverRequest(const ezRenderGraphObserverRequest& request);
+  void PauseObservation();
+  void ResumeObservation();
+  void UpdateObservationVisibility();
+  void UpdateGraphList();
+  void UpdateSwapChainList();
+  void UpdateInfoWidgets();
+  void UpdateRequestControls();
+  void SelectAccess(ezUInt16 uiPassIndex, ezUInt16 uiAccessIndex);
+  void ClearAccessSelection();
+  void UpdatePreviewRequest(float fZoom, ezVec2 panCenter, ezVec2I32 pixel, bool bUpdatePixelPosition, bool bHighlightPixel);
+  void SetRequestFromControls();
+
+private:
+  ezRenderGraphInspectionSummary m_Summary;
+  ezRenderGraphInspectionInfo m_Info;
+  ezRenderGraphObserverRequest m_Request;
+  ezRenderGraphObserverResponse m_Response;
+  ezString m_sLastPixelValue;
+  ezVec2I32 m_vLastPixelPosition = ezVec2I32(-1, -1);
+  ezStaticArray<ezUInt8, 1024> m_LastHistogram;
+  ezUInt64 m_uiSelectedGraphId = 0;
+  ezUInt32 m_uiSelectedSwapChainId = 0xFFFFFFFF;
+  bool m_bHasLastPixelValue = false;
+  bool m_bHasLastHistogram = false;
+  bool m_bInfoValid = false;
+  bool m_bUpdateUi = true;
+  bool m_bUpdatingControls = false;
+  bool m_bObservationPaused = false;
+};

--- a/Code/Tools/Inspector/RenderGraphWidget.ui
+++ b/Code/Tools/Inspector/RenderGraphWidget.ui
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RenderGraphWidget</class>
+ <widget class="QWidget" name="RenderGraphWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1005</width>
+    <height>748</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Render Graph</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QSplitter" name="HorizontalSplitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="Lists">
+    <layout class="QVBoxLayout" name="ListsLayout" stretch="0,2,0,1">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="GraphListLabel">
+         <property name="text">
+          <string>Render Graphs</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="GraphList"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="SwapChainListLabel">
+         <property name="text">
+          <string>Swap Chains</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="SwapChainList"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QSplitter" name="VerticalSplitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <widget class="QScrollArea" name="OverviewScroll">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="widgetResizable">
+        <bool>false</bool>
+       </property>
+       <widget class="ezQtRenderGraphOverviewWidget" name="Overview">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>600</width>
+          <height>300</height>
+         </rect>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QWidget" name="PreviewAndControlsWidget">
+       <layout class="QVBoxLayout" name="PreviewAndControlsLayout">
+        <item>
+         <layout class="QHBoxLayout" name="ControlsLayout">
+          <item>
+           <widget class="QLabel" name="MipLabel">
+            <property name="text">
+             <string>Mip</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="MipSpin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="SliceLabel">
+            <property name="text">
+             <string>Slice</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="SliceSpin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="SampleLabel">
+            <property name="text">
+             <string>Sample</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="SampleSpin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimum">
+             <number>-1</number>
+            </property>
+            <property name="maximum">
+             <number>8</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ChannelR">
+            <property name="text">
+             <string>R</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ChannelG">
+            <property name="text">
+             <string>G</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ChannelB">
+            <property name="text">
+             <string>B</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ChannelA">
+            <property name="text">
+             <string>A</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="ResetZoomToolButton">
+                        <property name="icon">
+                         <iconset resource="../Libs/GuiFoundation/QtResources/resources.qrc">
+                            <normaloff>:/GuiFoundation/Icons/ZoomReset.svg</normaloff>:/GuiFoundation/Icons/ZoomReset.svg</iconset>
+                        </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="PreviewLayout" stretch="1,0">
+          <item>
+           <widget class="ezQtRenderGraphPreviewWidget" name="Preview" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="autoFillBackground">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="RangeLayout">
+            <item>
+             <layout class="QHBoxLayout" name="RangeControlsLayout" stretch="0,0">
+              <item>
+               <layout class="QGridLayout" name="HistogramGridLayout">
+                <item row="0" column="0" rowspan="2">
+                 <widget class="ezQtRenderGraphHistogramWidget" name="Histogram" native="true">
+                  <property name="minimumSize">
+                   <size>
+                    <width>256</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="autoFillBackground">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
+                 <widget class="ezQtDoubleSpinBox" name="RangeMinSpin">
+                  <property name="decimals">
+                   <number>4</number>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="minimum">
+                   <double>-100000.000000000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>100000.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="2">
+                 <widget class="ezQtDoubleSpinBox" name="RangeMaxSpin">
+                  <property name="decimals">
+                   <number>4</number>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="minimum">
+                   <double>-100000.000000000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>100000.000000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>1.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QLabel" name="RangeMaxLabel">
+                  <property name="text">
+                   <string>Max</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="4">
+                 <widget class="QToolButton" name="AutoToolButton">
+                  <property name="text">
+                   <string>[m,M]</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QLabel" name="RangeMinLabel">
+                  <property name="text">
+                   <string>Min</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="4">
+                 <widget class="QToolButton" name="ResetToolButton">
+                  <property name="text">
+                   <string>[0,1]</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <widget class="QLineEdit" name="MinValue">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>100</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="readOnly">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="3">
+                 <widget class="QLineEdit" name="MaxValue">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>100</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="readOnly">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="HistogramSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="PixelLabel">
+              <property name="text">
+               <string>Pixel: -</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ezQtRenderGraphOverviewWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">Inspector/RenderGraphOverviewWidget.moc.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ezQtRenderGraphPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">Inspector/RenderGraphPreviewWidget.moc.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ezQtRenderGraphHistogramWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">Inspector/RenderGraphHistogramWidget.moc.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ezQtDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">GuiFoundation/Widgets/DoubleSpinBox.moc.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../Libs/GuiFoundation/QtResources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Data/Base/Shaders/RenderGraph/RenderGraphBuildHistogram.ezShader
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphBuildHistogram.ezShader
@@ -1,0 +1,48 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+MSAA
+
+[COMPUTESHADER]
+
+#include <Shaders/RenderGraph/RenderGraphHistogramConstants.h>
+#include <Shaders/RenderGraph/RenderGraphReadTexel.h>
+
+RWStructuredBuffer<uint> HistogramOutput BIND_GROUP(BG_DRAW_CALL);
+
+#define NUM_BINS 256u
+#define THREADS_X 8u
+#define THREADS_Y 8u
+
+void AddChannel(uint channelIndex, float normalizedValue)
+{
+  uint channelMask = GET_PUSH_CONSTANT(ezRenderGraphHistogramConstants, ChannelMask);
+  if ((channelMask & (1u << channelIndex)) == 0u)
+    return;
+
+  uint bucket = uint(floor(normalizedValue * float(NUM_BINS)));
+  if (bucket >= NUM_BINS)
+    return;
+
+  uint previousValue;
+  InterlockedAdd(HistogramOutput[channelIndex * NUM_BINS + bucket], 1u, previousValue);
+}
+
+[numthreads(THREADS_X, THREADS_Y, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+  uint2 textureSize = GET_PUSH_CONSTANT(ezRenderGraphHistogramConstants, TextureSize);
+  if (dispatchThreadId.x >= textureSize.x || dispatchThreadId.y >= textureSize.y)
+    return;
+
+  float rangeMin = GET_PUSH_CONSTANT(ezRenderGraphHistogramConstants, RangeMin);
+  float rangeMax = GET_PUSH_CONSTANT(ezRenderGraphHistogramConstants, RangeMax);
+  float4 texel = ReadTexel(int2(dispatchThreadId.xy), GET_PUSH_CONSTANT(ezRenderGraphHistogramConstants, SampleIndex), GET_PUSH_CONSTANT(ezRenderGraphHistogramConstants, SampleCount));
+  float4 normalized = ApplyValueRange(texel, rangeMin, rangeMax);
+
+  AddChannel(0u, normalized.r);
+  AddChannel(1u, normalized.g);
+  AddChannel(2u, normalized.b);
+  AddChannel(3u, normalized.a);
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphBuildMinMax.ezShader
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphBuildMinMax.ezShader
@@ -1,0 +1,50 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+MSAA
+
+[COMPUTESHADER]
+
+#include <Shaders/RenderGraph/RenderGraphMinMaxConstants.h>
+#include <Shaders/RenderGraph/RenderGraphReadTexel.h>
+
+RWStructuredBuffer<uint> MinMaxOutput BIND_GROUP(BG_DRAW_CALL);
+
+#define THREADS_X 8u
+#define THREADS_Y 8u
+
+uint FloatToOrderedUint(float value)
+{
+  // InterlockedMin/Max operate on integers. Positive IEEE floats already increase with their bit pattern once the sign bit is set.
+  // Negative floats sort in the opposite direction, so invert all their bits. This maps the full float range to unsigned integers
+  // where smaller floats have smaller integer values and larger floats have larger integer values.
+  uint rawValue = asuint(value);
+  return (rawValue & 0x80000000u) != 0u ? ~rawValue : (rawValue ^ 0x80000000u);
+}
+
+void AddChannel(uint channelIndex, float value)
+{
+  uint channelMask = GET_PUSH_CONSTANT(ezRenderGraphMinMaxConstants, ChannelMask);
+  if ((channelMask & (1u << channelIndex)) == 0u || value != value)
+    return;
+
+  uint orderedValue = FloatToOrderedUint(value);
+  uint previousValue;
+  InterlockedMin(MinMaxOutput[0], orderedValue, previousValue);
+  InterlockedMax(MinMaxOutput[1], orderedValue, previousValue);
+}
+
+[numthreads(THREADS_X, THREADS_Y, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+  uint2 textureSize = GET_PUSH_CONSTANT(ezRenderGraphMinMaxConstants, TextureSize);
+  if (dispatchThreadId.x >= textureSize.x || dispatchThreadId.y >= textureSize.y)
+    return;
+
+  float4 texel = ReadTexel(int2(dispatchThreadId.xy), GET_PUSH_CONSTANT(ezRenderGraphMinMaxConstants, SampleIndex), GET_PUSH_CONSTANT(ezRenderGraphMinMaxConstants, SampleCount));
+  AddChannel(0u, texel.r);
+  AddChannel(1u, texel.g);
+  AddChannel(2u, texel.b);
+  AddChannel(3u, texel.a);
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphClearHistogram.ezShader
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphClearHistogram.ezShader
@@ -1,0 +1,22 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+
+[COMPUTESHADER]
+
+#include <Shaders/Common/Common.h>
+RWStructuredBuffer<uint> HistogramOutput BIND_GROUP(BG_DRAW_CALL);
+
+[numthreads(256, 1, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+  uint bucket = dispatchThreadId.x;
+  if (bucket >= 256u)
+    return;
+
+  HistogramOutput[bucket] = 0u;
+  HistogramOutput[256u + bucket] = 0u;
+  HistogramOutput[512u + bucket] = 0u;
+  HistogramOutput[768u + bucket] = 0u;
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphClearMinMax.ezShader
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphClearMinMax.ezShader
@@ -1,0 +1,16 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+
+[COMPUTESHADER]
+
+#include <Shaders/Common/Common.h>
+RWStructuredBuffer<uint> MinMaxOutput BIND_GROUP(BG_DRAW_CALL);
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+  MinMaxOutput[0] = 0xFFFFFFFFu;
+  MinMaxOutput[1] = 0u;
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphHistogramConstants.h
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphHistogramConstants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Shaders/Common/ConstantBufferMacros.h>
+
+BEGIN_PUSH_CONSTANTS(ezRenderGraphHistogramConstants)
+{
+  UINT2(TextureSize);
+  INT1(SampleIndex);
+  UINT1(SampleCount);
+  UINT1(ChannelMask);
+  FLOAT1(RangeMin);
+  FLOAT1(RangeMax);
+}
+END_PUSH_CONSTANTS(ezRenderGraphHistogramConstants)

--- a/Data/Base/Shaders/RenderGraph/RenderGraphMinMaxConstants.h
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphMinMaxConstants.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Shaders/Common/ConstantBufferMacros.h>
+
+BEGIN_PUSH_CONSTANTS(ezRenderGraphMinMaxConstants)
+{
+  UINT2(TextureSize);
+  INT1(SampleIndex);
+  UINT1(SampleCount);
+  UINT1(ChannelMask);
+}
+END_PUSH_CONSTANTS(ezRenderGraphMinMaxConstants)

--- a/Data/Base/Shaders/RenderGraph/RenderGraphPreview.ezShader
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphPreview.ezShader
@@ -1,0 +1,114 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+
+CAMERA_MODE = CAMERA_MODE_ORTHO
+MSAA
+
+[RENDERSTATE]
+
+DepthTest = false
+DepthWrite = false
+CullMode = CullMode_None
+
+[VERTEXSHADER]
+
+#include <Shaders/Pipeline/FullscreenTriangleVertexShader.h>
+
+[PIXELSHADER]
+
+#include <Shaders/Pipeline/FullscreenTriangleInterpolator.h>
+#include <Shaders/Common/Common.h>
+#include <Shaders/RenderGraph/RenderGraphPreviewConstants.h>
+#include <Shaders/RenderGraph/RenderGraphReadTexel.h>
+
+float4 SampleTexture(float2 uv)
+{
+  uint width;
+  uint height;
+#if MSAA
+  uint sampleCount;
+  SourceTexture.GetDimensions(width, height, sampleCount);
+#else
+  uint sampleCount = 1;
+  SourceTexture.GetDimensions(width, height);
+#endif
+
+  int2 pixelPosition = int2(uv * float2(width, height));
+  int sampleIndex = GET_PUSH_CONSTANT(ezRenderGraphPreviewConstants, SampleIndex);
+  return ReadTexel(pixelPosition, sampleIndex, sampleCount);
+}
+
+uint2 GetTextureSize()
+{
+  uint width;
+  uint height;
+#if MSAA
+  uint sampleCount;
+  SourceTexture.GetDimensions(width, height, sampleCount);
+#else
+  SourceTexture.GetDimensions(width, height);
+#endif
+  return uint2(width, height);
+}
+
+float3 ApplyChannels(float4 texel, float2 uv)
+{
+  uint channelMask = GET_PUSH_CONSTANT(ezRenderGraphPreviewConstants, ChannelMask);
+  bool showR = (channelMask & 1u) != 0u;
+  bool showG = (channelMask & 2u) != 0u;
+  bool showB = (channelMask & 4u) != 0u;
+  bool showA = (channelMask & 8u) != 0u;
+  uint colorChannelCount = (showR ? 1u : 0u) + (showG ? 1u : 0u) + (showB ? 1u : 0u);
+
+  if (colorChannelCount == 0u && showA)
+  {
+    return texel.a.xxx;
+  }
+
+  if (colorChannelCount == 1u)
+  {
+    float value = showR ? texel.r : (showG ? texel.g : texel.b);
+    return value.xxx;
+  }
+
+  float3 color = float3(showR ? texel.r : 0.0f, showG ? texel.g : 0.0f, showB ? texel.b : 0.0f);
+  if (showR && showG && showB && showA)
+  {
+    float3 bg0 = float3(0.3f, 0.3f, 0.3f);
+    float3 bg1 = float3(0.5f, 0.5f, 0.5f);
+    int bgIdx = (int)(floor(uv.x * 32.0f) + floor(uv.y * 32.0f)) & 1;
+    color = lerp(bgIdx != 0 ? bg1 : bg0, color, texel.a);
+  }
+
+  return color;
+}
+
+float4 main(PS_IN input) : SV_Target
+{
+  float4 uvTransform = GET_PUSH_CONSTANT(ezRenderGraphPreviewConstants, UVTransform);
+  float2 uv = input.TexCoord0.xy * uvTransform.xy + uvTransform.zw;
+
+  if (uv.x < 0.0f || uv.x > 1.0f || uv.y < 0.0f || uv.y > 1.0f)
+  {
+    return float4(0.2f, 0.2f, 0.2f, 1.0f);
+  }
+
+  float2 valueRange = GET_PUSH_CONSTANT(ezRenderGraphPreviewConstants, ValueRange);
+  float4 texel = ApplyValueRange(SampleTexture(uv), valueRange.x, valueRange.y);
+  float3 color = saturate(ApplyChannels(texel, uv));
+
+  if (GET_PUSH_CONSTANT(ezRenderGraphPreviewConstants, HighlightPixel) != 0)
+  {
+    int2 selectedPixel = GET_PUSH_CONSTANT(ezRenderGraphPreviewConstants, PixelPosition);
+    uint2 textureSize = GetTextureSize();
+    int2 pixelPosition = min(int2(uv * float2(textureSize)), int2(textureSize) - 1);
+    if (selectedPixel.x >= 0 && selectedPixel.y >= 0 && (pixelPosition.x == selectedPixel.x || pixelPosition.y == selectedPixel.y))
+    {
+      color = 1.0f - color;
+    }
+  }
+
+  return float4(color, 1.0f);
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphPreviewConstants.h
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphPreviewConstants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Shaders/Common/ConstantBufferMacros.h>
+
+BEGIN_PUSH_CONSTANTS(ezRenderGraphPreviewConstants)
+{
+  FLOAT4(UVTransform);
+  FLOAT2(ValueRange);
+  UINT1(ChannelMask);
+  INT1(SampleIndex);
+  INT2(PixelPosition);
+  INT1(HighlightPixel);
+}
+END_PUSH_CONSTANTS(ezRenderGraphPreviewConstants)

--- a/Data/Base/Shaders/RenderGraph/RenderGraphReadTexel.h
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphReadTexel.h
@@ -1,7 +1,7 @@
 #if MSAA
-  Texture2DMS<float4> SourceTexture BIND_GROUP(BG_DRAW_CALL);
+Texture2DMS<float4> SourceTexture BIND_GROUP(BG_DRAW_CALL);
 #else
-  Texture2D SourceTexture BIND_GROUP(BG_DRAW_CALL);
+Texture2D SourceTexture BIND_GROUP(BG_DRAW_CALL);
 #endif
 
 float4 ReadTexel(int2 pixelPosition, int sampleIndex, uint sampleCount)

--- a/Data/Base/Shaders/RenderGraph/RenderGraphReadTexel.h
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphReadTexel.h
@@ -1,0 +1,30 @@
+#if MSAA
+  Texture2DMS<float4> SourceTexture BIND_GROUP(BG_DRAW_CALL);
+#else
+  Texture2D SourceTexture BIND_GROUP(BG_DRAW_CALL);
+#endif
+
+float4 ReadTexel(int2 pixelPosition, int sampleIndex, uint sampleCount)
+{
+#if MSAA
+  if (sampleIndex >= 0)
+  {
+    return SourceTexture.Load(pixelPosition, sampleIndex);
+  }
+
+  float4 result = 0.0f;
+  for (uint sample = 0; sample < sampleCount; ++sample)
+  {
+    result += SourceTexture.Load(pixelPosition, int(sample));
+  }
+  return result / float(sampleCount);
+#else
+  return SourceTexture.Load(int3(pixelPosition, 0));
+#endif
+}
+
+float4 ApplyValueRange(float4 value, float rangeMin, float rangeMax)
+{
+  float invRange = 1.0f / max(rangeMax - rangeMin, 0.0000001f);
+  return (value - rangeMin) * invRange;
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphReadbackPixel.ezShader
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphReadbackPixel.ezShader
@@ -1,0 +1,27 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+MSAA
+
+[COMPUTESHADER]
+
+#include <Shaders/RenderGraph/RenderGraphReadbackPixelConstants.h>
+#include <Shaders/RenderGraph/RenderGraphReadTexel.h>
+
+RWStructuredBuffer<float4> PixelOutput BIND_GROUP(BG_DRAW_CALL);
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+  int2 pixelPosition = GET_PUSH_CONSTANT(ezRenderGraphReadbackPixelConstants, PixelPosition);
+  uint2 textureSize = GET_PUSH_CONSTANT(ezRenderGraphReadbackPixelConstants, TextureSize);
+
+  if (pixelPosition.x < 0 || pixelPosition.y < 0 || pixelPosition.x >= int(textureSize.x) || pixelPosition.y >= int(textureSize.y))
+  {
+    PixelOutput[0] = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    return;
+  }
+
+  PixelOutput[0] = ReadTexel(pixelPosition, GET_PUSH_CONSTANT(ezRenderGraphReadbackPixelConstants, SampleIndex), GET_PUSH_CONSTANT(ezRenderGraphReadbackPixelConstants, SampleCount));
+}

--- a/Data/Base/Shaders/RenderGraph/RenderGraphReadbackPixelConstants.h
+++ b/Data/Base/Shaders/RenderGraph/RenderGraphReadbackPixelConstants.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Shaders/Common/ConstantBufferMacros.h>
+
+BEGIN_PUSH_CONSTANTS(ezRenderGraphReadbackPixelConstants)
+{
+  INT2(PixelPosition);
+  INT1(SampleIndex);
+  UINT1(SampleCount);
+  UINT2(TextureSize);
+}
+END_PUSH_CONSTANTS(ezRenderGraphReadbackPixelConstants)


### PR DESCRIPTION
Introduces a live render graph inspection and texture preview system that sends compiled render graph data from a running application to the Inspector tool over telemetry, including per-pass resource access visualization and interactive texture previews with histogram, min/max and per-pixel readback. 
The render graph overview shows passes as rows and resources as columns. Reads are cold colored and writes are warm colored.
Reads  / writes in a pass can be selected and are then previewed on top of the selected swap-chain of the running application.


<img width="1071" height="762" alt="image" src="https://github.com/user-attachments/assets/0dd2d97e-a3fb-4cf5-a1b9-60c424e8f4ad" />


## RendererCore / RenderGraph

- Add `ezRenderGraphInspectionInfo`, `ezRenderGraphExecutionSummary`, `ezRenderGraphSwapChainSummary` and `ezRenderGraphInspectionSummary` as read-only snapshots of a compiled graph (passes, textures, buffers and flattened resource accesses), plus stream serialization operators (`RenderGraphInspectionInfo.h`, `RenderGraphSerialization.cpp`).
- Add `ezRenderGraphPassObserver`: observes a specific texture access within a pass by copying it into a persistent texture after the pass executes. Supports preview blit to a swap chain, sub-resource/channel/sample selection, value range clamping, zoom/pan, GPU histogram and min/max computation, and per-pixel readback.
- Extend `ezRenderGraphManager` with observer management and inspection queries: `GetExecutionSummary`, `GetRenderGraphInspectionInfo`, `CreateObserver`.

## InspectorPlugin

- Add `RenderGraphObserver.cpp` to broadcast execution summaries, inspection info and observer responses over telemetry, and to apply observer requests received from the Inspector tool.

## Inspector tool

- Add render graph UI: `RenderGraphWidget`, `RenderGraphOverviewWidget`, `RenderGraphPreviewWidget` and `RenderGraphHistogramWidget`, wired into the main window, actions and menus.

## Shaders

- Add compute/preview shaders for the observer: histogram clear/build, min/max clear/build, pixel readback and texture preview, with associated constant buffer and helper headers.

## RendererFoundation

- Add `ezGALTextureCreationDescription::GetNumberOfSlices` and `GetMipMapSize`. Reuse the latter from `ezGALTexture::GetMipMapSize`.
- Add `ezGALDevice::GetAllSwapChains` and make `GetBackBufferTextureFromSwapChain` const.
