### PR TITLE
Simple console actions and generalized ImGui resources

### DIFF
--- a/Code/Engine/GameEngine/Console/ConsoleActions.h
+++ b/Code/Engine/GameEngine/Console/ConsoleActions.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Strings/String.h>
+#include <Foundation/Types/Delegate.h>
+#include <GameEngine/GameEngineDLL.h>
+
+// Allows to add a simple action that is shown in the console menu.
+// To execute shortcuts, call `HandleInput` during your application's 'Run_ProcessApplicationInput' function.
+class EZ_GAMEENGINE_DLL ezConsoleActions
+{
+public:
+  using Action = ezDelegate<void()>;
+
+  struct ezConsoleActionsDesc
+  {
+    ezString m_sInputSet;
+    ezString m_sAction;
+    ezString m_sMenu;
+    Action m_Action;
+  };
+
+  // Adds an action. sInputSet and sAction should match what was passed into 'ezInputManager::SetInputActionConfig' and uniquely identifies the action. Actions are sorted by their menu and action name.
+  static void AddAction(ezStringView sInputSet, ezStringView sAction, ezStringView sMenu, Action action);
+  // Removes an action.
+  static void RemoveAction(ezStringView sInputSet, ezStringView sAction);
+
+  // Executes any action who's shortcut is 'ezKeyState::Pressed'.
+  static void HandleInput();
+  // Returns all actions sorted by menu first, then by action.
+  static ezArrayPtr<const ezConsoleActionsDesc> GetActions();
+  static void ClearActions();
+
+private:
+  static ezDynamicArray<ezConsoleActionsDesc> s_ConsoleActions;
+};

--- a/Code/Engine/GameEngine/Console/ImGuiConsole.h
+++ b/Code/Engine/GameEngine/Console/ImGuiConsole.h
@@ -116,7 +116,7 @@ protected:
   void UpdateFrameTimes();
   void UpdateMemoryUsage();
 
-  static ezIdTable<ezImGuiRegisteredWndHandleData, ezUniquePtr<CustomConsoleWindow>> m_CustomWindows;
+  static ezIdTable<ezImGuiRegisteredWndHandleData, ezUniquePtr<CustomConsoleWindow>> s_CustomWindows;
 
   ezDeque<ezConsoleString> m_LogStrings;           // For log messages (used by log window)
   ezDeque<ezConsoleString> m_CommandOutputStrings; // For command input/output (used by console window)

--- a/Code/Engine/GameEngine/Console/ImGuiConsole.h
+++ b/Code/Engine/GameEngine/Console/ImGuiConsole.h
@@ -4,10 +4,21 @@
 
 #  include <Core/Console/Console.h>
 #  include <Core/Input/DeviceTypes/MouseKeyboard.h>
+#  include <Foundation/Containers/IdTable.h>
 #  include <Foundation/Logging/Log.h>
+#  include <Foundation/Types/Delegate.h>
 #  include <GameEngine/GameEngineDLL.h>
 
 struct ezLoggingEventData;
+
+/// Callback signature for registered ImGui windows. The bool ref controls the window's open state.
+using ezImGuiWindowCallback = ezDelegate<void(bool&)>;
+using ezImGuiRegisteredWndHandleData = ezGenericId<16, 16>;
+class ezImGuiRegisteredWndHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezImGuiRegisteredWndHandle, ezImGuiRegisteredWndHandleData);
+};
+
 
 /// \brief An ImGui-based console for in-game display of logs, configuration of ezCVars, and more.
 ///
@@ -57,6 +68,17 @@ public:
   virtual void HandleInput(bool bIsOpen) override;
 
   /// @}
+  /// \name Custom Windows
+  /// @{
+
+  /// Register an additional ImGui window that will be rendered when the console is open.
+  /// The window appears in the Commands menu bar under "Windows".
+  static ezImGuiRegisteredWndHandle RegisterWindow(ezStringView sName, ezImGuiWindowCallback callback);
+
+  /// Unregister a previously registered window by name.
+  static void UnregisterWindow(ezImGuiRegisteredWndHandle hWindow);
+
+  /// @}
 
 protected:
   struct CVarTreeNode
@@ -67,8 +89,16 @@ protected:
     bool m_bExpanded = false;
   };
 
+  struct CustomConsoleWindow
+  {
+    ezString m_sName;
+    ezImGuiWindowCallback m_Callback;
+    bool m_bOpen = false;
+  };
+
   void LogHandler(const ezLoggingEventData& data);
   void ClearLogStrings();
+  void RenderMenuBar();
   void RenderCommandWindow(bool bSetFocus);
   void RenderCVarWindow();
   void RenderStatsWindow(bool bFull);
@@ -85,6 +115,8 @@ protected:
   ezUInt64 CalculateTotalMemoryUsage();
   void UpdateFrameTimes();
   void UpdateMemoryUsage();
+
+  static ezIdTable<ezImGuiRegisteredWndHandleData, ezUniquePtr<CustomConsoleWindow>> m_CustomWindows;
 
   ezDeque<ezConsoleString> m_LogStrings;           // For log messages (used by log window)
   ezDeque<ezConsoleString> m_CommandOutputStrings; // For command input/output (used by console window)

--- a/Code/Engine/GameEngine/Console/Implementation/ConsoleActions.cpp
+++ b/Code/Engine/GameEngine/Console/Implementation/ConsoleActions.cpp
@@ -1,0 +1,86 @@
+#include <GameEngine/GameEnginePCH.h>
+
+#include <Core/Input/InputManager.h>
+#include <Foundation/Configuration/Startup.h>
+#include <GameEngine/Console/ConsoleActions.h>
+
+ezDynamicArray<ezConsoleActions::ezConsoleActionsDesc> ezConsoleActions::s_ConsoleActions;
+
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(GameEngine, ConsoleActions)
+
+  BEGIN_SUBSYSTEM_DEPENDENCIES
+    "Foundation"
+  END_SUBSYSTEM_DEPENDENCIES
+
+  ON_CORESYSTEMS_SHUTDOWN
+  {
+    ezConsoleActions::ClearActions();
+  }
+
+EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
+
+namespace
+{
+  ezInt32 CompareConsoleActions(const ezConsoleActions::ezConsoleActionsDesc& lhs, const ezConsoleActions::ezConsoleActionsDesc& rhs)
+  {
+    const ezInt32 iMenuCompare = lhs.m_sMenu.Compare(rhs.m_sMenu);
+    if (iMenuCompare != 0)
+      return iMenuCompare;
+
+    return lhs.m_sAction.Compare(rhs.m_sAction);
+  }
+}
+
+void ezConsoleActions::AddAction(ezStringView sInputSet, ezStringView sAction, ezStringView sMenu, Action action)
+{
+  ezConsoleActionsDesc desc;
+  desc.m_sInputSet = sInputSet;
+  desc.m_sAction = sAction;
+  desc.m_sMenu = sMenu;
+  desc.m_Action = std::move(action);
+
+  RemoveAction(sInputSet, sAction);
+
+  ezUInt32 uiInsertIndex = 0;
+  while (uiInsertIndex < s_ConsoleActions.GetCount() && CompareConsoleActions(s_ConsoleActions[uiInsertIndex], desc) <= 0)
+  {
+    ++uiInsertIndex;
+  }
+
+  s_ConsoleActions.InsertAt(uiInsertIndex, std::move(desc));
+}
+
+void ezConsoleActions::RemoveAction(ezStringView sInputSet, ezStringView sAction)
+{
+  for (ezUInt32 uiActionIndex = 0; uiActionIndex < s_ConsoleActions.GetCount(); ++uiActionIndex)
+  {
+    if (s_ConsoleActions[uiActionIndex].m_sInputSet.IsEqual(sInputSet) && s_ConsoleActions[uiActionIndex].m_sAction.IsEqual(sAction))
+    {
+      s_ConsoleActions.RemoveAtAndCopy(uiActionIndex);
+      return;
+    }
+  }
+}
+
+void ezConsoleActions::HandleInput()
+{
+  for (auto& desc : s_ConsoleActions)
+  {
+    if (ezInputManager::GetInputActionState(desc.m_sInputSet, desc.m_sAction) == ezKeyState::Pressed && desc.m_Action.IsValid())
+    {
+      desc.m_Action();
+    }
+  }
+}
+
+ezArrayPtr<const ezConsoleActions::ezConsoleActionsDesc> ezConsoleActions::GetActions()
+{
+  return s_ConsoleActions;
+}
+
+void ezConsoleActions::ClearActions()
+{
+  s_ConsoleActions.Clear();
+}

--- a/Code/Engine/GameEngine/Console/Implementation/ConsoleActions.cpp
+++ b/Code/Engine/GameEngine/Console/Implementation/ConsoleActions.cpp
@@ -31,7 +31,7 @@ namespace
 
     return lhs.m_sAction.Compare(rhs.m_sAction);
   }
-}
+} // namespace
 
 void ezConsoleActions::AddAction(ezStringView sInputSet, ezStringView sAction, ezStringView sMenu, Action action)
 {

--- a/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
+++ b/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
@@ -469,8 +469,8 @@ void ezImGuiConsole::RenderStatsWindow(bool bFull)
 
   // Stats window: top left, 1/4 width, auto height
   const float statsWidth = screenWidth * 0.25f;
-  const float statsPosX = 10.0f;                                 // Left side with padding
-  const float statsPosY = ImGui::GetFrameHeight() + 10.0f;        // Below the menu bar
+  const float statsPosX = 10.0f;                           // Left side with padding
+  const float statsPosY = ImGui::GetFrameHeight() + 10.0f; // Below the menu bar
 
   // Set initial size with width preference, allow manual resizing
   if (m_uiResetLayout > 0)

--- a/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
+++ b/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
@@ -14,6 +14,7 @@
 #  include <Foundation/Strings/StringBuilder.h>
 #  include <Foundation/Time/Clock.h>
 #  include <Foundation/Time/Time.h>
+#  include <GameEngine/Console/ConsoleActions.h>
 #  include <GameEngine/Console/LuaInterpreter.h>
 #  include <GameEngine/DearImgui/DearImgui.h>
 #  include <RendererCore/Pipeline/View.h>
@@ -36,9 +37,33 @@ ezImGuiConsole::ezImGuiConsole()
   EnableLogOutput(true);
 }
 
+ezIdTable<ezImGuiRegisteredWndHandleData, ezUniquePtr<ezImGuiConsole::CustomConsoleWindow>> ezImGuiConsole::m_CustomWindows;
+
 ezImGuiConsole::~ezImGuiConsole()
 {
   EnableLogOutput(false);
+}
+
+ezImGuiRegisteredWndHandle ezImGuiConsole::RegisterWindow(ezStringView sName, ezImGuiWindowCallback callback)
+{
+  ezUniquePtr<CustomConsoleWindow> pData = EZ_DEFAULT_NEW(CustomConsoleWindow);
+  pData->m_sName = sName;
+  pData->m_Callback = callback;
+  pData->m_bOpen = false;
+
+  return ezImGuiRegisteredWndHandle(m_CustomWindows.Insert(std::move(pData)));
+}
+
+void ezImGuiConsole::UnregisterWindow(ezImGuiRegisteredWndHandle hWindow)
+{
+  ezUniquePtr<CustomConsoleWindow>* pDataPtr = nullptr;
+  if (!m_CustomWindows.TryGetValue(hWindow.GetInternalID(), pDataPtr))
+    return;
+
+  CustomConsoleWindow* pData = pDataPtr->Borrow();
+  EZ_ASSERT_DEV(pData != nullptr, "Invalid window data");
+
+  m_CustomWindows.Remove(hWindow.GetInternalID());
 }
 
 void ezImGuiConsole::EnableLogOutput(bool bEnable)
@@ -198,6 +223,87 @@ void ezImGuiConsole::LogHandler(const ezLoggingEventData& data)
   }
 }
 
+void ezImGuiConsole::RenderMenuBar()
+{
+  if (!ImGui::BeginMainMenuBar())
+    return;
+
+  if (ImGui::BeginMenu("Windows"))
+  {
+    ImGui::MenuItem("Stats", nullptr, &m_bStatsWindowOpen);
+    ImGui::MenuItem("Log", nullptr, &m_bLogWindowOpen);
+    ImGui::MenuItem("CVars", nullptr, &m_bCVarWindowOpen);
+
+    if (!m_CustomWindows.IsEmpty())
+    {
+      for (auto it = m_CustomWindows.GetIterator(); it.IsValid(); ++it)
+      {
+        ImGui::MenuItem(it.Value()->m_sName.GetData(), nullptr, &it.Value()->m_bOpen);
+      }
+    }
+
+    ImGui::EndMenu();
+  }
+
+  if (ImGui::BeginMenu("Layout"))
+  {
+    if (ImGui::MenuItem("Reset Layout"))
+    {
+      m_uiResetLayout = 3;
+      m_bStatsWindowOpen = true;
+      m_bLogWindowOpen = true;
+      m_bCVarWindowOpen = true;
+    }
+
+    ImGui::EndMenu();
+  }
+
+  auto actions = ezConsoleActions::GetActions();
+  ezStringView sCurrentMenu;
+  bool bHasCurrentMenu = false;
+  bool bCurrentMenuOpen = false;
+
+  for (const auto& desc : actions)
+  {
+    const ezStringView sMenu = desc.m_sMenu;
+
+    if (!bHasCurrentMenu || !sCurrentMenu.IsEqual(sMenu))
+    {
+      if (bCurrentMenuOpen)
+      {
+        ImGui::EndMenu();
+      }
+
+      sCurrentMenu = sMenu;
+      bHasCurrentMenu = true;
+      bCurrentMenuOpen = ImGui::BeginMenu(ezStringBuilder(sMenu).GetData());
+    }
+
+    ezStringBuilder sShortcut;
+    const ezInputActionConfig config = ezInputManager::GetInputActionConfig(desc.m_sInputSet, desc.m_sAction);
+    for (const ezString& sTrigger : config.m_sInputSlotTrigger)
+    {
+      if (sTrigger.IsEmpty())
+        continue;
+
+      sShortcut.Append(ezInputManager::GetInputSlotDisplayName(sTrigger));
+      break;
+    }
+
+    if (bCurrentMenuOpen && ImGui::MenuItem(desc.m_sAction.GetData(), sShortcut.IsEmpty() ? nullptr : sShortcut.GetData()) && desc.m_Action.IsValid())
+    {
+      desc.m_Action();
+    }
+  }
+
+  if (bCurrentMenuOpen)
+  {
+    ImGui::EndMenu();
+  }
+
+  ImGui::EndMainMenuBar();
+}
+
 void ezImGuiConsole::RenderCommandWindow(bool bSetFocus)
 {
   // Get available screen space
@@ -211,40 +317,15 @@ void ezImGuiConsole::RenderCommandWindow(bool bSetFocus)
   const float commandWidth = screenWidth - statsWidth - logWidth - 20.0f; // Remaining width with some padding
   const float commandHeight = screenHeight * 0.2f;                        // 1/5th of screen height
   const float commandPosX = statsWidth + 10.0f;                           // Position after stats with padding
-  const float commandPosY = 10.0f;                                        // Top of screen
+  const float commandPosY = ImGui::GetFrameHeight() + 10.0f;              // Below the menu bar
 
   ImGui::SetNextWindowSize(ImVec2(commandWidth, commandHeight), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowPos(ImVec2(commandPosX, commandPosY), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
 
-  if (!ImGui::Begin("Commands", nullptr, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoSavedSettings))
+  if (!ImGui::Begin("Commands", nullptr, ImGuiWindowFlags_NoSavedSettings))
   {
     ImGui::End();
     return;
-  }
-
-  // Menu bar with Reset Layout button
-  if (ImGui::BeginMenuBar())
-  {
-    if (ImGui::BeginMenu("Windows"))
-    {
-      ImGui::MenuItem("Stats", nullptr, &m_bStatsWindowOpen);
-      ImGui::MenuItem("Log", nullptr, &m_bLogWindowOpen);
-      ImGui::MenuItem("CVars", nullptr, &m_bCVarWindowOpen);
-      ImGui::EndMenu();
-    }
-
-    if (ImGui::BeginMenu("Layout"))
-    {
-      if (ImGui::MenuItem("Reset Layout"))
-      {
-        m_uiResetLayout = 3;
-        m_bStatsWindowOpen = true;
-        m_bLogWindowOpen = true;
-        m_bCVarWindowOpen = true;
-      }
-      ImGui::EndMenu();
-    }
-    ImGui::EndMenuBar();
   }
 
   // Reserve space for input at the bottom
@@ -388,8 +469,8 @@ void ezImGuiConsole::RenderStatsWindow(bool bFull)
 
   // Stats window: top left, 1/4 width, auto height
   const float statsWidth = screenWidth * 0.25f;
-  const float statsPosX = 10.0f; // Left side with padding
-  const float statsPosY = 10.0f; // Top with padding
+  const float statsPosX = 10.0f;                                 // Left side with padding
+  const float statsPosY = ImGui::GetFrameHeight() + 10.0f;        // Below the menu bar
 
   // Set initial size with width preference, allow manual resizing
   if (m_uiResetLayout > 0)
@@ -944,7 +1025,7 @@ void ezImGuiConsole::RenderLogWindow(bool bFull)
   const float buttonHeight = ImGui::GetFrameHeightWithSpacing();
   const float logHeight = screenHeight * 0.5f - buttonHeight; // Reduced height to account for command window
   const float logPosX = screenWidth - logWidth - 10.0f;       // Right side with padding
-  const float logPosY = 10.0f;                                // Top with padding (original position)
+  const float logPosY = ImGui::GetFrameHeight() + 10.0f;      // Below the menu bar
 
   ImGui::SetNextWindowSize(ImVec2(logWidth, logHeight), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowPos(ImVec2(logPosX, logPosY), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
@@ -1145,6 +1226,7 @@ void ezImGuiConsole::RenderConsole(bool bIsOpen)
   {
     ezImgui::GetSingleton()->SetPassInputToImgui(true);
 
+    RenderMenuBar();
     RenderCommandWindow(m_uiForceFocus > 0);
     if (m_uiForceFocus > 0)
     {
@@ -1165,6 +1247,18 @@ void ezImGuiConsole::RenderConsole(bool bIsOpen)
   if (m_bLogWindowOpen && (bIsOpen || m_bPinLogWindow))
   {
     RenderLogWindow(bIsOpen);
+  }
+
+  // Render registered custom windows
+  if (bIsOpen)
+  {
+    for (auto it = m_CustomWindows.GetIterator(); it.IsValid(); ++it)
+    {
+      if (it.Value()->m_bOpen)
+      {
+        it.Value()->m_Callback(it.Value()->m_bOpen);
+      }
+    }
   }
 
   // Reset layout flag after all windows have been rendered

--- a/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
+++ b/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
@@ -37,7 +37,7 @@ ezImGuiConsole::ezImGuiConsole()
   EnableLogOutput(true);
 }
 
-ezIdTable<ezImGuiRegisteredWndHandleData, ezUniquePtr<ezImGuiConsole::CustomConsoleWindow>> ezImGuiConsole::m_CustomWindows;
+ezIdTable<ezImGuiRegisteredWndHandleData, ezUniquePtr<ezImGuiConsole::CustomConsoleWindow>> ezImGuiConsole::s_CustomWindows;
 
 ezImGuiConsole::~ezImGuiConsole()
 {
@@ -51,19 +51,19 @@ ezImGuiRegisteredWndHandle ezImGuiConsole::RegisterWindow(ezStringView sName, ez
   pData->m_Callback = callback;
   pData->m_bOpen = false;
 
-  return ezImGuiRegisteredWndHandle(m_CustomWindows.Insert(std::move(pData)));
+  return ezImGuiRegisteredWndHandle(s_CustomWindows.Insert(std::move(pData)));
 }
 
 void ezImGuiConsole::UnregisterWindow(ezImGuiRegisteredWndHandle hWindow)
 {
   ezUniquePtr<CustomConsoleWindow>* pDataPtr = nullptr;
-  if (!m_CustomWindows.TryGetValue(hWindow.GetInternalID(), pDataPtr))
+  if (!s_CustomWindows.TryGetValue(hWindow.GetInternalID(), pDataPtr))
     return;
 
   CustomConsoleWindow* pData = pDataPtr->Borrow();
   EZ_ASSERT_DEV(pData != nullptr, "Invalid window data");
 
-  m_CustomWindows.Remove(hWindow.GetInternalID());
+  s_CustomWindows.Remove(hWindow.GetInternalID());
 }
 
 void ezImGuiConsole::EnableLogOutput(bool bEnable)
@@ -234,9 +234,9 @@ void ezImGuiConsole::RenderMenuBar()
     ImGui::MenuItem("Log", nullptr, &m_bLogWindowOpen);
     ImGui::MenuItem("CVars", nullptr, &m_bCVarWindowOpen);
 
-    if (!m_CustomWindows.IsEmpty())
+    if (!s_CustomWindows.IsEmpty())
     {
-      for (auto it = m_CustomWindows.GetIterator(); it.IsValid(); ++it)
+      for (auto it = s_CustomWindows.GetIterator(); it.IsValid(); ++it)
       {
         ImGui::MenuItem(it.Value()->m_sName.GetData(), nullptr, &it.Value()->m_bOpen);
       }
@@ -1252,7 +1252,7 @@ void ezImGuiConsole::RenderConsole(bool bIsOpen)
   // Render registered custom windows
   if (bIsOpen)
   {
-    for (auto it = m_CustomWindows.GetIterator(); it.IsValid(); ++it)
+    for (auto it = s_CustomWindows.GetIterator(); it.IsValid(); ++it)
     {
       if (it.Value()->m_bOpen)
       {

--- a/Code/Engine/GameEngine/DearImgui/DearImgui.h
+++ b/Code/Engine/GameEngine/DearImgui/DearImgui.h
@@ -5,6 +5,7 @@
 #  include <Core/ResourceManager/ResourceHandle.h>
 #  include <Foundation/Configuration/CVar.h>
 #  include <Foundation/Configuration/Singleton.h>
+#  include <Foundation/Containers/IdTable.h>
 #  include <Foundation/Math/Size.h>
 #  include <Foundation/Memory/CommonAllocators.h>
 #  include <Foundation/Types/UniquePtr.h>
@@ -13,6 +14,7 @@
 #  include <RendererCore/Pipeline/Declarations.h>
 
 using ezTexture2DResourceHandle = ezTypedResourceHandle<class ezTexture2DResource>;
+using ezMaterialResourceHandle = ezTypedResourceHandle<class ezMaterialResource>;
 
 struct ImGuiContext;
 struct ezGameApplicationExecutionEvent;
@@ -61,7 +63,17 @@ public:
   /// \brief Returns the shared font atlas
   ImFontAtlas& GetFontAtlas() { return *m_pSharedFontAtlas; }
 
+  /// Registers a texture resource and returns an ImTextureID that can be used with raw ImGui image calls or passed to RegisterImage(). The texture stays registered until UnregisterResource() is called.
   ImTextureID RegisterTexture(const ezTexture2DResourceHandle& hTexture);
+
+  /// \copydoc RegisterTexture(const ezTexture2DResourceHandle&)
+  ImTextureID RegisterTexture(ezGALTextureHandle hTexture);
+
+  /// Registers a material resource and returns an ImTextureID. Works like RegisterTexture() but renders using the full material rather than just a texture.
+  ImTextureID RegisterMaterial(const ezMaterialResourceHandle& hMaterial);
+
+  /// Removes a previously registered texture or material. The ImTextureID must not be used afterwards.
+  void UnregisterResource(ImTextureID id);
 
   struct Image
   {
@@ -70,19 +82,41 @@ public:
     ezVec2 m_UV1;
   };
 
+  /// Associates a named image with a registered texture and UV coordinates. This allows the AddImage() and AddImageButton() convenience functions to look up the image by name instead of requiring the caller to pass the ImTextureID and UVs every time. Call RegisterTexture() first to obtain the texture ID.
   void RegisterImage(ezTempHashedString sImgId, ImTextureID pTexId, const ezVec2& vUv0, const ezVec2& vUv1);
 
+  /// Renders a clickable image button using a previously registered image name.
   bool AddImageButton(ezTempHashedString sImgId, const char* szImguiID, const ezVec2& vImageSize, const ezColor& backgroundColor = ezColor::MakeZero(), const ezColor& tintColor = ezColor::White) const;
 
+  /// Renders an image using a previously registered image name.
   void AddImage(ezTempHashedString sImgId, const ezVec2& vImageSize, const ezColor& tintColor = ezColor::White, const ezColor& borderColor = ezColor::MakeZero()) const;
 
+  /// Like AddImageButton(), but draws a colored overlay from \a fProgress (0 to 1) to the right edge, which can be used to indicate a loading progress.
   bool AddImageButtonWithProgress(ezTempHashedString sImgId, const char* szImguiID, const ezVec2& vImageSize, float fProgress, const ezColor& overlayColor, const ezColor& tintColor = ezColor::White) const;
 
+  /// Like AddImage(), but draws a colored overlay from \a fProgress (0 to 1) to the right edge, which can be used to indicate a loading progress.
   void AddImageWithProgress(ezTempHashedString sImgId, const char* szImguiID, const ezVec2& vImageSize, float fProgress, const ezColor& overlayColor, const ezColor& tintColor = ezColor::White) const;
 
 private:
   friend class ezImguiExtractor;
   friend class ezImguiRenderer;
+
+  using ezImGuiTextureIdData = ezGenericId<16, 16>;
+
+  struct ezImGuiTextureRegistration
+  {
+    enum class Type : ezUInt8
+    {
+      Texture2D,
+      GALTexture,
+      Material,
+    };
+
+    Type m_Type = Type::Texture2D;
+    ezTexture2DResourceHandle m_hTexture2D;
+    ezGALTextureHandle m_hGALTexture;
+    ezMaterialResourceHandle m_hMaterial;
+  };
 
   void Startup(ezImguiConfigFontCallback configFontCallback);
   void Shutdown();
@@ -96,7 +130,7 @@ private:
   bool m_bPassInputToImgui = true;
   bool m_bImguiWantsInput = false;
   ezSizeU32 m_CurrentWindowResolution;
-  ezHybridArray<ezTexture2DResourceHandle, 4> m_Textures;
+  ezIdTable<ezImGuiTextureIdData, ezImGuiTextureRegistration> m_RegisteredTextures;
 
   ezImguiConfigStyleCallback m_ConfigStyleCallback;
 

--- a/Code/Engine/GameEngine/DearImgui/DearImgui.h
+++ b/Code/Engine/GameEngine/DearImgui/DearImgui.h
@@ -83,7 +83,7 @@ public:
   };
 
   /// Associates a named image with a registered texture and UV coordinates. This allows the AddImage() and AddImageButton() convenience functions to look up the image by name instead of requiring the caller to pass the ImTextureID and UVs every time. Call RegisterTexture() first to obtain the texture ID.
-  void RegisterImage(ezTempHashedString sImgId, ImTextureID pTexId, const ezVec2& vUv0, const ezVec2& vUv1);
+  void RegisterImage(ezTempHashedString sImgId, ImTextureID texId, const ezVec2& vUv0, const ezVec2& vUv1);
 
   /// Renders a clickable image button using a previously registered image name.
   bool AddImageButton(ezTempHashedString sImgId, const char* szImguiID, const ezVec2& vImageSize, const ezColor& backgroundColor = ezColor::MakeZero(), const ezColor& tintColor = ezColor::White) const;

--- a/Code/Engine/GameEngine/DearImgui/DearImguiRenderer.h
+++ b/Code/Engine/GameEngine/DearImgui/DearImguiRenderer.h
@@ -4,6 +4,7 @@
 
 #  include <Core/ResourceManager/ResourceHandle.h>
 #  include <Foundation/Math/Rect.h>
+#  include <GameEngine/DearImgui/DearImgui.h>
 #  include <GameEngine/GameEngineDLL.h>
 #  include <Imgui/imgui.h>
 #  include <RendererCore/Meshes/MeshBufferResource.h>
@@ -29,7 +30,7 @@ struct ezImguiBatch
   EZ_DECLARE_POD_TYPE();
 
   ezRectU32 m_ScissorRect;
-  ezUInt16 m_uiTextureID;
+  ImTextureID m_TextureId;
   ezUInt16 m_uiVertexCount;
 };
 

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
@@ -133,10 +133,10 @@ void ezImgui::UnregisterResource(ImTextureID id)
   m_RegisteredTextures.Remove(handle);
 }
 
-void ezImgui::RegisterImage(ezTempHashedString sName, ImTextureID pTexId, const ezVec2& vUv0, const ezVec2& vUv1)
+void ezImgui::RegisterImage(ezTempHashedString sName, ImTextureID texId, const ezVec2& vUv0, const ezVec2& vUv1)
 {
   auto& img = m_Images[sName];
-  img.m_Id = pTexId;
+  img.m_Id = texId;
   img.m_UV0 = vUv0;
   img.m_UV1 = vUv1;
 }

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
@@ -99,14 +99,38 @@ void ezImgui::SetCurrentContextForView(const ezViewHandle& hView)
 
 ImTextureID ezImgui::RegisterTexture(const ezTexture2DResourceHandle& hTexture)
 {
-  ezUInt32 idx = m_Textures.IndexOf(hTexture);
-  if (idx == ezInvalidIndex)
-  {
-    idx = m_Textures.GetCount();
-    m_Textures.PushBack(hTexture);
-  }
+  ezImGuiTextureRegistration reg;
+  reg.m_Type = ezImGuiTextureRegistration::Type::Texture2D;
+  reg.m_hTexture2D = hTexture;
+  ezImGuiTextureIdData handle = m_RegisteredTextures.Insert(reg);
+  return *reinterpret_cast<ImTextureID*>(&handle);
+}
 
-  return reinterpret_cast<ImTextureID>(static_cast<intptr_t>(idx));
+ImTextureID ezImgui::RegisterTexture(ezGALTextureHandle hTexture)
+{
+  ezImGuiTextureRegistration reg;
+  reg.m_Type = ezImGuiTextureRegistration::Type::GALTexture;
+  reg.m_hGALTexture = hTexture;
+  ezImGuiTextureIdData handle = m_RegisteredTextures.Insert(reg);
+  return *reinterpret_cast<ImTextureID*>(&handle);
+}
+
+ImTextureID ezImgui::RegisterMaterial(const ezMaterialResourceHandle& hMaterial)
+{
+  ezImGuiTextureRegistration reg;
+  reg.m_Type = ezImGuiTextureRegistration::Type::Material;
+  reg.m_hMaterial = hMaterial;
+  ezImGuiTextureIdData handle = m_RegisteredTextures.Insert(reg);
+  return *reinterpret_cast<ImTextureID*>(&handle);
+}
+
+void ezImgui::UnregisterResource(ImTextureID id)
+{
+  ezImGuiTextureIdData handle = *reinterpret_cast<ezImGuiTextureIdData*>(&id);
+  if (!m_RegisteredTextures.Contains(handle))
+    return;
+
+  m_RegisteredTextures.Remove(handle);
 }
 
 void ezImgui::RegisterImage(ezTempHashedString sName, ImTextureID pTexId, const ezVec2& vUv0, const ezVec2& vUv1)
@@ -276,20 +300,24 @@ void ezImgui::Startup(ezImguiConfigFontCallback configFontCallback)
     hFont = ezResourceManager::GetOrCreateResource<ezTexture2DResource>("ImguiFont", std::move(desc));
   }
 
-  m_Textures.PushBack(hFont);
-
-  const size_t id = (size_t)m_Textures.GetCount() - 1;
-  m_pSharedFontAtlas->TexID = reinterpret_cast<void*>(id);
+  m_pSharedFontAtlas->TexID = RegisterTexture(hFont);
 
   ezGameApplicationBase::GetGameApplicationBaseInstance()->m_ExecutionEvents.AddEventHandler(ezMakeDelegate(&ezImgui::GameApplicationEventHandler, this));
 }
 
 void ezImgui::Shutdown()
 {
-  ezGameApplicationBase::GetGameApplicationBaseInstance()->m_ExecutionEvents.RemoveEventHandler(ezMakeDelegate(&ezImgui::GameApplicationEventHandler, this));
-  m_Textures.Clear();
-
+  if (m_pSharedFontAtlas)
+  {
+    UnregisterResource(m_pSharedFontAtlas->TexID);
+  }
   m_pSharedFontAtlas = nullptr;
+
+  ezGameApplicationBase::GetGameApplicationBaseInstance()->m_ExecutionEvents.RemoveEventHandler(ezMakeDelegate(&ezImgui::GameApplicationEventHandler, this));
+  EZ_ASSERT_DEV(m_RegisteredTextures.IsEmpty(), "Not all registered textures were unregistered. You need to call 'UnregisterResource' before shutdown.");
+  m_RegisteredTextures.Clear();
+
+
 
   for (auto it = m_ViewToContextTable.GetIterator(); it.IsValid(); ++it)
   {

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
@@ -107,11 +107,10 @@ void ezImguiExtractor::Extract(const ezView& view, const ezDynamicArray<const ez
         for (int cmdIdx = 0; cmdIdx < pCommands->CmdBuffer.Size; cmdIdx++)
         {
           const ImDrawCmd* pCmd = &pCommands->CmdBuffer[cmdIdx];
-          const size_t iTextureID = reinterpret_cast<size_t>(pCmd->TextureId);
 
           ezImguiBatch& batch = pRenderData->m_Batches[cmdIdx];
           batch.m_uiVertexCount = static_cast<ezUInt16>(pCmd->ElemCount);
-          batch.m_uiTextureID = (ezUInt16)iTextureID;
+          batch.m_TextureId = pCmd->TextureId;
           batch.m_ScissorRect = ezRectU32((ezUInt32)pCmd->ClipRect.x, (ezUInt32)pCmd->ClipRect.y, (ezUInt32)(pCmd->ClipRect.z - pCmd->ClipRect.x), (ezUInt32)(pCmd->ClipRect.w - pCmd->ClipRect.y));
         }
       }
@@ -161,9 +160,9 @@ void ezImguiRenderer::RenderBatch(const ezRenderViewContext& renderContext, cons
   ezGALCommandEncoder* pCommandEncoder = pRenderContext->GetCommandEncoder();
 
   pRenderContext->BindShader(m_hShader);
-  const auto& textures = ezImgui::GetSingleton()->m_Textures;
-  const ezUInt32 numTextures = textures.GetCount();
+  const auto& registeredTextures = ezImgui::GetSingleton()->m_RegisteredTextures;
   ezBindGroupBuilder& bindGroup = pRenderContext->GetBindGroup();
+
   for (auto it = batch.GetIterator<ezImguiRenderData>(); it.IsValid(); ++it)
   {
     const ezImguiRenderData* pRenderData = it;
@@ -185,10 +184,33 @@ void ezImguiRenderer::RenderBatch(const ezRenderViewContext& renderContext, cons
     {
       const ezImguiBatch& imGuiBatch = pRenderData->m_Batches[batchIdx];
 
-      if (imGuiBatch.m_uiVertexCount > 0 && imGuiBatch.m_uiTextureID < numTextures)
+      ezImgui::ezImGuiTextureRegistration reg;
+      ezImgui::ezImGuiTextureIdData handle = *reinterpret_cast<const ezImgui::ezImGuiTextureIdData*>(&imGuiBatch.m_TextureId);
+      if (imGuiBatch.m_uiVertexCount > 0 && registeredTextures.TryGetValue(handle, reg))
       {
         pCommandEncoder->SetScissorRect(imGuiBatch.m_ScissorRect);
-        bindGroup.BindTexture("BaseTexture", textures[imGuiBatch.m_uiTextureID]);
+
+        switch (reg.m_Type)
+        {
+          case ezImgui::ezImGuiTextureRegistration::Type::Texture2D:
+          {
+            pRenderContext->BindShader(m_hShader);
+            bindGroup.BindTexture("BaseTexture", reg.m_hTexture2D);
+            break;
+          }
+          case ezImgui::ezImGuiTextureRegistration::Type::GALTexture:
+          {
+            pRenderContext->BindShader(m_hShader);
+            bindGroup.BindTexture("BaseTexture", reg.m_hGALTexture);
+            break;
+          }
+          case ezImgui::ezImGuiTextureRegistration::Type::Material:
+          {
+            pRenderContext->BindMaterial(reg.m_hMaterial);
+            break;
+          }
+        }
+
         pRenderContext->DrawMeshBuffer(imGuiBatch.m_uiVertexCount / 3, uiFirstIndex / 3).IgnoreResult();
       }
 

--- a/Code/Engine/GameEngine/GameApplication/GameApplication.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplication.h
@@ -29,6 +29,7 @@ struct ezGameApplicationInputFlags
     Dev_CaptureProfilingInfo = EZ_BIT(12), ///< Register the F8 key to write a profiling capture to disk
     Dev_CaptureFrame = EZ_BIT(13),         ///< Register the F11 key to make a render frame capture (if capture plugin is available)
     Dev_Screenshot = EZ_BIT(14),           ///< Register the F12 key to save a screenshot to disk
+    Dev_OpenInspector = EZ_BIT(15),        ///< Register the F10 key to open the ezInspector application
 
     Dev_All = 0xFFFFFF00,
 
@@ -47,6 +48,7 @@ struct ezGameApplicationInputFlags
     StorageType Dev_CaptureProfilingInfo : 1;
     StorageType Dev_CaptureFrame : 1;
     StorageType Dev_Screenshot : 1;
+    StorageType Dev_OpenInspector : 1;
   };
 };
 
@@ -139,6 +141,7 @@ protected:
   void RenderWorldDebugInfos(const ezWorld& world);
   void RenderFps();
   void RenderConsole();
+  void OpenInspector();
 
   void UpdateWorldsAndExtractViews();
   ezSharedPtr<ezDelegateTask<void>> m_pUpdateTask;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -219,7 +219,7 @@ void ezGameApplication::OpenInspector()
   sInspectorPath.AppendPath("ezInspector");
 #  endif
 
-  opt.m_sProcess = ezOSFile::ExistsFile(sInspectorPath) ? sInspectorPath : "ezInspector";
+  opt.m_sProcess = sInspectorPath;
 
   ezProcess process;
   if (process.Launch(opt, ezProcessLaunchFlags::Detached).Failed())

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -115,44 +115,50 @@ void ezGameApplication::RegisterGameApplicationInputActions(ezBitflags<ezGameApp
     // so we use F4 there, and it should be consistent here
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF4;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szReloadResourcesAction, config, true);
-    ezConsoleActions::AddAction(s_szInputSet, s_szReloadResourcesAction, "Engine", []() { ezResourceManager::ReloadAllResources(false); });
+    ezConsoleActions::AddAction(s_szInputSet, s_szReloadResourcesAction, "Engine", []()
+      { ezResourceManager::ReloadAllResources(false); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_ShowStats))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF5;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szShowFpsAction, config, true);
-    ezConsoleActions::AddAction(s_szInputSet, s_szShowFpsAction, "Engine", []() { cvar_AppShowFPS = !cvar_AppShowFPS; });
+    ezConsoleActions::AddAction(s_szInputSet, s_szShowFpsAction, "Engine", []()
+      { cvar_AppShowFPS = !cvar_AppShowFPS; });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_CaptureProfilingInfo))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF8;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szCaptureProfilingAction, config, true);
-    ezConsoleActions::AddAction(s_szInputSet, s_szCaptureProfilingAction, "Engine", [this]() { TakeProfilingCapture(); });
+    ezConsoleActions::AddAction(s_szInputSet, s_szCaptureProfilingAction, "Engine", [this]()
+      { TakeProfilingCapture(); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_CaptureFrame))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF11;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szCaptureFrame, config, true);
-    ezConsoleActions::AddAction(s_szInputSet, s_szCaptureFrame, "Engine", [this]() { CaptureFrame(); });
+    ezConsoleActions::AddAction(s_szInputSet, s_szCaptureFrame, "Engine", [this]()
+      { CaptureFrame(); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_Screenshot))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF12;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szTakeScreenshot, config, true);
-    ezConsoleActions::AddAction(s_szInputSet, s_szTakeScreenshot, "Engine", [this]() { TakeScreenshot(); });
+    ezConsoleActions::AddAction(s_szInputSet, s_szTakeScreenshot, "Engine", [this]()
+      { TakeScreenshot(); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_OpenInspector))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF10;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szOpenInspector, config, true);
-    ezConsoleActions::AddAction(s_szInputSet, s_szOpenInspector, "Engine", [this]() { OpenInspector(); });
+    ezConsoleActions::AddAction(s_szInputSet, s_szOpenInspector, "Engine", [this]()
+      { OpenInspector(); });
   }
-  
+
   if (flags.IsSet(ezGameApplicationInputFlags::LoadInputConfig))
   {
     ezStringView sConfigFile = ezGameAppInputConfig::s_sConfigFile;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -12,8 +12,10 @@
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Memory/FrameAllocator.h>
 #include <Foundation/Profiling/Profiling.h>
+#include <Foundation/System/Process.h>
 #include <Foundation/Time/DefaultTimeStepSmoothing.h>
 #include <GameEngine/Configuration/InputConfig.h>
+#include <GameEngine/Console/ConsoleActions.h>
 #include <GameEngine/Console/QuakeConsole.h>
 #include <GameEngine/GameApplication/GameApplication.h>
 #include <GameEngine/GameApplication/WindowOutputTarget.h>
@@ -81,6 +83,7 @@ namespace
   const char* s_szCaptureProfilingAction = "CaptureProfiling";
   const char* s_szCaptureFrame = "CaptureFrame";
   const char* s_szTakeScreenshot = "TakeScreenshot";
+  const char* s_szOpenInspector = "OpenInspector";
 } // namespace
 
 
@@ -112,32 +115,44 @@ void ezGameApplication::RegisterGameApplicationInputActions(ezBitflags<ezGameApp
     // so we use F4 there, and it should be consistent here
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF4;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szReloadResourcesAction, config, true);
+    ezConsoleActions::AddAction(s_szInputSet, s_szReloadResourcesAction, "Engine", []() { ezResourceManager::ReloadAllResources(false); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_ShowStats))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF5;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szShowFpsAction, config, true);
+    ezConsoleActions::AddAction(s_szInputSet, s_szShowFpsAction, "Engine", []() { cvar_AppShowFPS = !cvar_AppShowFPS; });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_CaptureProfilingInfo))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF8;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szCaptureProfilingAction, config, true);
+    ezConsoleActions::AddAction(s_szInputSet, s_szCaptureProfilingAction, "Engine", [this]() { TakeProfilingCapture(); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_CaptureFrame))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF11;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szCaptureFrame, config, true);
+    ezConsoleActions::AddAction(s_szInputSet, s_szCaptureFrame, "Engine", [this]() { CaptureFrame(); });
   }
 
   if (flags.IsSet(ezGameApplicationInputFlags::Dev_Screenshot))
   {
     config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF12;
     ezInputManager::SetInputActionConfig(s_szInputSet, s_szTakeScreenshot, config, true);
+    ezConsoleActions::AddAction(s_szInputSet, s_szTakeScreenshot, "Engine", [this]() { TakeScreenshot(); });
   }
 
+  if (flags.IsSet(ezGameApplicationInputFlags::Dev_OpenInspector))
+  {
+    config.m_sInputSlotTrigger[0] = ezInputSlot_KeyF10;
+    ezInputManager::SetInputActionConfig(s_szInputSet, s_szOpenInspector, config, true);
+    ezConsoleActions::AddAction(s_szInputSet, s_szOpenInspector, "Engine", [this]() { OpenInspector(); });
+  }
+  
   if (flags.IsSet(ezGameApplicationInputFlags::LoadInputConfig))
   {
     ezStringView sConfigFile = ezGameAppInputConfig::s_sConfigFile;
@@ -184,6 +199,28 @@ ezString ezGameApplication::FindProjectDirectory() const
   }
 
   return result;
+}
+
+void ezGameApplication::OpenInspector()
+{
+#if EZ_ENABLED(EZ_SUPPORTS_PROCESSES)
+  ezProcessOptions opt;
+
+  ezStringBuilder sInspectorPath = ezOSFile::GetApplicationDirectory();
+#  if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+  sInspectorPath.AppendPath("ezInspector.exe");
+#  else
+  sInspectorPath.AppendPath("ezInspector");
+#  endif
+
+  opt.m_sProcess = ezOSFile::ExistsFile(sInspectorPath) ? sInspectorPath : "ezInspector";
+
+  ezProcess process;
+  if (process.Launch(opt, ezProcessLaunchFlags::Detached).Failed())
+  {
+    ezLog::Warning("Failed to launch ezInspector.");
+  }
+#endif
 }
 
 ezGameUpdateMode ezGameApplication::GetGameUpdateMode() const
@@ -444,30 +481,7 @@ bool ezGameApplication::Run_ProcessApplicationInput()
     }
   }
 
-  if (ezInputManager::GetInputActionState(s_szInputSet, s_szShowFpsAction) == ezKeyState::Pressed)
-  {
-    cvar_AppShowFPS = !cvar_AppShowFPS;
-  }
-
-  if (ezInputManager::GetInputActionState(s_szInputSet, s_szReloadResourcesAction) == ezKeyState::Pressed)
-  {
-    ezResourceManager::ReloadAllResources(false);
-  }
-
-  if (ezInputManager::GetInputActionState(s_szInputSet, s_szTakeScreenshot) == ezKeyState::Pressed)
-  {
-    TakeScreenshot();
-  }
-
-  if (ezInputManager::GetInputActionState(s_szInputSet, s_szCaptureProfilingAction) == ezKeyState::Pressed)
-  {
-    TakeProfilingCapture();
-  }
-
-  if (ezInputManager::GetInputActionState(s_szInputSet, s_szCaptureFrame) == ezKeyState::Pressed)
-  {
-    CaptureFrame();
-  }
+  ezConsoleActions::HandleInput();
 
   if (m_pConsole)
   {

--- a/Code/ThirdParty/Imgui/imconfig.h
+++ b/Code/ThirdParty/Imgui/imconfig.h
@@ -39,6 +39,9 @@
 
 extern thread_local struct ImGuiContext* g_ThreadLocalContext;
 #define GImGui g_ThreadLocalContext
+
+#include <cstdint>
+#define ImTextureID uint32_t
 // End ezEngine edit
 //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
- Added `ezConsoleActions`, a central registry for input-backed console actions that keeps actions sorted by menu and action name, executes pressed shortcuts, and clears registered actions during shutdown.
    - Wired the default game application developer actions into `ezConsoleActions`, replacing the hard-coded per-action input handling path with a shared `HandleInput()` call.
    - Moved the ImGui console controls into a main menu bar with window toggles, layout reset, shortcut labels, and menu entries for registered console actions.
    - Added a new action to open the ezInspector with F10 key.  
    <img width="311" height="165" alt="image" src="https://github.com/user-attachments/assets/c0388b65-87ed-4a65-af78-f0113afa159b" />
- Added support for registering custom ImGui console windows that can be toggled from the console menu and rendered while the console is open.
- Reworked Dear ImGui resource registration to use stable handle IDs backed by an ID table, with support for texture resources, raw GAL textures, and material resources. For this `ImTextureID` was changed to the handle size (uint32).