### PR TITLE
Fixed #1971: Export asset package dependencies

### DIFF
--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -7,6 +7,7 @@
 #include <Foundation/IO/FileSystem/FileSystem.h>
 #include <Foundation/IO/FileSystem/FileWriter.h>
 #include <Foundation/IO/OSFile.h>
+#include <Foundation/Utilities/ConversionUtils.h>
 #include <Foundation/Utilities/Progress.h>
 #include <ToolsFoundation/Utilities/PathPatternFilter.h>
 
@@ -406,6 +407,44 @@ ezResult ezProjectExport::GatherGeneratedAssetFiles(ezSet<ezString>& out_Files, 
   return EZ_SUCCESS;
 }
 
+void ezProjectExport::AddPackageDependenciesToFileList(DirectoryMapping& ref_fileList)
+{
+  auto knownAssets = ezAssetCurator::GetSingleton()->GetKnownAssets();
+
+  ezStringBuilder sAbsPath, sRelPath;
+
+  for (auto it = knownAssets->GetIterator(); it.IsValid(); ++it)
+  {
+    const ezAssetInfo* pAssetInfo = it.Value();
+    if (pAssetInfo->m_Info == nullptr)
+      continue;
+
+    for (const ezString& dep : pAssetInfo->m_Info->m_PackageDependencies)
+    {
+      // GUIDs reference other assets which ScanFolder already handles via the asset curator
+      if (ezConversionUtils::IsStringUuid(dep))
+        continue;
+
+      if (ezFileSystem::ResolvePath(dep, &sAbsPath, nullptr).Failed())
+        continue;
+
+      sAbsPath.MakeCleanPath();
+
+      // Find which data directory this file belongs to and add it directly to that directory's file list
+      for (auto itDir = ref_fileList.GetIterator(); itDir.IsValid(); ++itDir)
+      {
+        if (sAbsPath.StartsWith_NoCase(itDir.Key()))
+        {
+          sRelPath = sAbsPath;
+          sRelPath.Shrink(itDir.Key().GetElementCount(), 0); // keeps the leading slash
+          itDir.Value().m_Files.Insert(sRelPath);
+          break;
+        }
+      }
+    }
+  }
+}
+
 ezResult ezProjectExport::ExportProject(const char* szTargetDirectory, const ezPlatformProfile* pPlatformProfile, const ezApplicationFileSystemConfig& dataDirs)
 {
   ezProgressRange mainProgress("Export Project", 7, true);
@@ -450,6 +489,7 @@ ezResult ezProjectExport::ExportProject(const char* szTargetDirectory, const ezP
   {
     mainProgress.BeginNextStep("Scanning data directories");
     EZ_SUCCEED_OR_RETURN(ezProjectExport::ScanDataDirectories(fileList, dataDirs, dataFilter, &sceneFiles, pPlatformProfile));
+    ezProjectExport::AddPackageDependenciesToFileList(fileList);
   }
 
   // 3

--- a/Code/Editor/EditorFramework/Project/ProjectExport.h
+++ b/Code/Editor/EditorFramework/Project/ProjectExport.h
@@ -41,4 +41,5 @@ private:
   static ezResult GatherBinaries(DirectoryMapping& mapping, const ezPathPatternFilter& filter);
   static ezResult CreateLaunchConfig(const ezDynamicArray<ezString>& sceneFiles, const char* szTargetDirectory);
   static ezResult GatherGeneratedAssetFiles(ezSet<ezString>& out_Files, const char* szProjectDirectory);
+  static void AddPackageDependenciesToFileList(DirectoryMapping& ref_fileList);
 };

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
@@ -6,46 +6,102 @@
 
 ezStringView FindNextHREF(ezStringView& ref_sRml)
 {
-  const char* szCurrent = ref_sRml.FindSubString("href");
-  if (szCurrent == nullptr)
-    return ezStringView();
-
-  const char* szStart = nullptr;
-  const char* szEnd = nullptr;
-  while (*szCurrent != '\0')
+  while (true)
   {
-    if (*szCurrent == '\"')
+    const char* szCurrent = ref_sRml.FindSubString("href");
+    if (szCurrent == nullptr)
+      return ezStringView();
+
+    szCurrent += 4; // skip "href"
+
+    const char* szStart = nullptr;
+    const char* szEnd = nullptr;
+    while (*szCurrent != '\0')
     {
-      if (szStart == nullptr)
+      if (*szCurrent == '\"')
       {
-        szStart = szCurrent + 1;
+        if (szStart == nullptr)
+          szStart = szCurrent + 1;
+        else
+        {
+          szEnd = szCurrent;
+          break;
+        }
       }
-      else
-      {
-        szEnd = szCurrent;
-        break;
-      }
+      ++szCurrent;
     }
 
-    ++szCurrent;
-  }
+    if (szStart == nullptr || szEnd == nullptr)
+    {
+      // malformed or reached end of string
+      ref_sRml.SetStartPosition(szCurrent);
+      return ezStringView();
+    }
 
-  if (szStart != nullptr && szEnd != nullptr)
+    ref_sRml.SetStartPosition(szEnd + 1);
+
+    const ezStringView href = ezStringView(szStart, szEnd);
+    if (href.HasExtension(".rcss") || href.HasExtension(".rml"))
+      return href;
+
+    // non-matching extension; continue searching
+  }
+}
+
+ezStringView FindNextSrcValue(ezStringView& ref_sContent)
+{
+  while (true)
   {
-    ref_sRml.SetStartPosition(szEnd);
+    const char* szCurrent = ref_sContent.FindSubString("src");
+    if (szCurrent == nullptr)
+      return ezStringView();
 
-    ezStringView href = ezStringView(szStart, szEnd);
-    if (href.HasExtension(".rcss"))
+    szCurrent += 3;
+
+    szCurrent = ezStringUtils::SkipCharacters(szCurrent, ezStringUtils::IsWhiteSpace);
+
+    if (*szCurrent == '=')
     {
-      return href;
+      // HTML attribute: src="value" or src='value'
+      ++szCurrent;
+      const char cQuote = *szCurrent;
+      if (cQuote == '"' || cQuote == '\'')
+      {
+        ++szCurrent;
+        const char* szStart = szCurrent;
+        while (*szCurrent != '\0' && *szCurrent != cQuote)
+          ++szCurrent;
+        if (*szCurrent == cQuote)
+        {
+          ref_sContent.SetStartPosition(szCurrent + 1);
+          return ezStringView(szStart, szCurrent);
+        }
+      }
+      ref_sContent.SetStartPosition(szCurrent);
+      continue;
     }
-    if (href.HasExtension(".rml"))
+    else if (*szCurrent == ':')
     {
-      return href;
+      // CSS property: src: value;
+      ++szCurrent;
+      szCurrent = ezStringUtils::SkipCharacters(szCurrent, ezStringUtils::IsWhiteSpace);
+      const char* szStart = szCurrent;
+      while (*szCurrent != '\0' && *szCurrent != ';' && *szCurrent != '}' && *szCurrent != '\n' && *szCurrent != '\r')
+        ++szCurrent;
+      const char* szEnd = szCurrent;
+      ezStringUtils::Trim(szStart, szEnd, nullptr, " \t");
+      ref_sContent.SetStartPosition(szCurrent);
+      if (szEnd > szStart)
+        return ezStringView(szStart, szEnd);
+      continue;
+    }
+    else
+    {
+      // "src" was part of another word, skip past it
+      ref_sContent.SetStartPosition(szCurrent);
+      continue;
     }
   }
-
-  return ezStringView();
 }
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRmlUiAssetDocument, 1, ezRTTINoAllocator)
@@ -112,6 +168,17 @@ ezTransformStatus ezRmlUiAssetDocument::InternalCreateThumbnail(const ThumbnailI
 
 ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependencies, ezStringView sFilePath) const
 {
+  ezSet<ezString> visited;
+  return FindDependencies(ref_Dependencies, sFilePath, visited);
+}
+
+ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependencies, ezStringView sFilePath, ezSet<ezString>& ref_visited) const
+{
+  ezString sFilePathStr = sFilePath;
+  if (ref_visited.Contains(sFilePathStr))
+    return EZ_SUCCESS;
+  ref_visited.Insert(sFilePathStr);
+
   ezStringBuilder sContent;
   {
     ezFileReader reader;
@@ -128,14 +195,14 @@ ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependenci
 
   while (true)
   {
-    ezStringView href = FindNextHREF(sContentView);
+    const ezStringView href = FindNextHREF(sContentView);
     if (href.IsEmpty())
       break;
 
     if (ezFileSystem::ExistsFile(href))
     {
       ref_Dependencies.AddFileDependency(href);
-      EZ_SUCCEED_OR_RETURN(FindDependencies(ref_Dependencies, href));
+      EZ_SUCCEED_OR_RETURN(FindDependencies(ref_Dependencies, href, ref_visited));
       continue;
     }
 
@@ -143,12 +210,75 @@ ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependenci
     if (ezFileSystem::ExistsFile(sTemp))
     {
       ref_Dependencies.AddFileDependency(sTemp);
-      EZ_SUCCEED_OR_RETURN(FindDependencies(ref_Dependencies, sTemp));
+      EZ_SUCCEED_OR_RETURN(FindDependencies(ref_Dependencies, sTemp, ref_visited));
       continue;
     }
   }
 
   return EZ_SUCCESS;
+}
+
+void ezRmlUiAssetDocument::FindPackageDependencies(ezSet<ezString>& ref_packageDeps, ezStringView sFilePath, ezSet<ezString>& ref_visited) const
+{
+  ezString sFilePathStr = sFilePath;
+  if (ref_visited.Contains(sFilePathStr))
+    return;
+  ref_visited.Insert(sFilePathStr);
+
+  ezStringBuilder sContent;
+  {
+    ezFileReader reader;
+    if (reader.Open(sFilePath).Failed())
+      return;
+    sContent.ReadAll(reader);
+  }
+
+  const ezStringView sFileDir = sFilePath.GetFileDirectory();
+  ezStringBuilder sTemp;
+
+  // Recurse into referenced rcss/rml files
+  {
+    ezStringView sContentView = sContent;
+    while (true)
+    {
+      const ezStringView href = FindNextHREF(sContentView);
+      if (href.IsEmpty())
+        break;
+
+      if (ezFileSystem::ExistsFile(href))
+      {
+        FindPackageDependencies(ref_packageDeps, href, ref_visited);
+      }
+      else
+      {
+        sTemp.SetPath(sFileDir, href);
+        if (ezFileSystem::ExistsFile(sTemp))
+          FindPackageDependencies(ref_packageDeps, sTemp, ref_visited);
+      }
+    }
+  }
+
+  // Collect source file references (images, fonts, etc.)
+  {
+    ezStringView sContentView = sContent;
+    while (true)
+    {
+      const ezStringView src = FindNextSrcValue(sContentView);
+      if (src.IsEmpty())
+        break;
+
+      if (ezFileSystem::ExistsFile(src))
+      {
+        ref_packageDeps.Insert(src);
+      }
+      else
+      {
+        sTemp.SetPath(sFileDir, src);
+        if (ezFileSystem::ExistsFile(sTemp))
+          ref_packageDeps.Insert(sTemp);
+      }
+    }
+  }
 }
 
 void ezRmlUiAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
@@ -157,11 +287,26 @@ void ezRmlUiAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) c
 
   const ezRmlUiAssetProperties* pProp = GetProperties();
 
+  // rcss/rml files referenced via href must be re-transformed and re-thumbnailed if changed, and packaged for runtime
   ezDependencyFile deps;
   FindDependencies(deps, pProp->m_sRmlFile).IgnoreResult();
 
   for (const auto& file : deps.GetFileDependencies())
   {
     pInfo->m_TransformDependencies.Insert(file);
+    pInfo->m_ThumbnailDependencies.Insert(file);
+    pInfo->m_PackageDependencies.Insert(file);
+  }
+
+  // source files (images, fonts) referenced via src must be packaged for runtime and affect the thumbnail,
+  // but do not affect the transform output (which only stores file paths)
+  ezSet<ezString> sourceDeps;
+  ezSet<ezString> visited;
+  FindPackageDependencies(sourceDeps, pProp->m_sRmlFile, visited);
+
+  for (const auto& file : sourceDeps)
+  {
+    pInfo->m_ThumbnailDependencies.Insert(file);
+    pInfo->m_PackageDependencies.Insert(file);
   }
 }

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
@@ -22,6 +22,10 @@ protected:
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 
   ezStatus FindDependencies(ezDependencyFile& ref_Dependencies, ezStringView sFilePath) const;
+  void FindPackageDependencies(ezSet<ezString>& ref_packageDeps, ezStringView sFilePath, ezSet<ezString>& ref_visited) const;
+
+private:
+  ezStatus FindDependencies(ezDependencyFile& ref_Dependencies, ezStringView sFilePath, ezSet<ezString>& ref_visited) const;
 
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 };

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetObjects.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetObjects.cpp
@@ -7,7 +7,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRmlUiAssetProperties, 1, ezRTTIDefaultAllocato
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("RmlFile", m_sRmlFile)->AddAttributes(new ezFileBrowserAttribute("Select Rml file", "*.rml", {}, "RmlUI")),
+    EZ_MEMBER_PROPERTY("RmlFile", m_sRmlFile)->AddAttributes(new ezFileBrowserAttribute("Select Rml file", "*.rml", {}, "RmlUI", ezDependencyFlags::Package | ezDependencyFlags::Thumbnail | ezDependencyFlags::Transform)),
     EZ_ENUM_MEMBER_PROPERTY("ScaleMode", ezRmlUiScaleMode, m_ScaleMode),
     EZ_MEMBER_PROPERTY("ReferenceResolution", m_ReferenceResolution)->AddAttributes(new ezDefaultValueAttribute(ezVec2U32(1920, 1080))),
   }

--- a/Data/Samples/RTS/ProjectData.ezExportFilter
+++ b/Data/Samples/RTS/ProjectData.ezExportFilter
@@ -9,5 +9,3 @@
 [INCLUDE]
 
 //TODO: add include patterns
-
-RmlUI\rmlui-default\assets.png

--- a/Data/Samples/RTS/UI/app-menu.ezRmlUiAsset
+++ b/Data/Samples/RTS/UI/app-menu.ezRmlUiAsset
@@ -35,9 +35,50 @@ o
 		u4 %Hash{7490952393100317776}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
-		VarArray %PackageDeps{}
+		VarArray %PackageDeps
+		{
+			s{"RmlUI/rmlui-default/assets.png"}
+			s{"RmlUI/rmlui-default/assets.rcss"}
+			s{"RmlUI/rmlui-default/button.rcss"}
+			s{"RmlUI/rmlui-default/common.rcss"}
+			s{"RmlUI/rmlui-default/expand.rcss"}
+			s{"RmlUI/rmlui-default/input-checkbox.rcss"}
+			s{"RmlUI/rmlui-default/input-radio.rcss"}
+			s{"RmlUI/rmlui-default/input-range.rcss"}
+			s{"RmlUI/rmlui-default/input-submit.rcss"}
+			s{"RmlUI/rmlui-default/input-text.rcss"}
+			s{"RmlUI/rmlui-default/progress.rcss"}
+			s{"RmlUI/rmlui-default/scrollbar.rcss"}
+			s{"RmlUI/rmlui-default/select.rcss"}
+			s{"RmlUI/rmlui-default/table.rcss"}
+			s{"RmlUI/rmlui-default/tabs.rcss"}
+			s{"RmlUI/rmlui-default/template.rml"}
+			s{"RmlUI/rmlui-default/textarea.rcss"}
+			s{"RmlUI/rmlui-default/window.rcss"}
+			s{"UI/app-menu.rcss"}
+			s{"UI/app-menu.rml"}
+		}
 		VarArray %References
 		{
+			s{"RmlUI/rmlui-default/assets.png"}
+			s{"RmlUI/rmlui-default/assets.rcss"}
+			s{"RmlUI/rmlui-default/button.rcss"}
+			s{"RmlUI/rmlui-default/common.rcss"}
+			s{"RmlUI/rmlui-default/expand.rcss"}
+			s{"RmlUI/rmlui-default/input-checkbox.rcss"}
+			s{"RmlUI/rmlui-default/input-radio.rcss"}
+			s{"RmlUI/rmlui-default/input-range.rcss"}
+			s{"RmlUI/rmlui-default/input-submit.rcss"}
+			s{"RmlUI/rmlui-default/input-text.rcss"}
+			s{"RmlUI/rmlui-default/progress.rcss"}
+			s{"RmlUI/rmlui-default/scrollbar.rcss"}
+			s{"RmlUI/rmlui-default/select.rcss"}
+			s{"RmlUI/rmlui-default/table.rcss"}
+			s{"RmlUI/rmlui-default/tabs.rcss"}
+			s{"RmlUI/rmlui-default/template.rml"}
+			s{"RmlUI/rmlui-default/textarea.rcss"}
+			s{"RmlUI/rmlui-default/window.rcss"}
+			s{"UI/app-menu.rcss"}
 			s{"UI/app-menu.rml"}
 		}
 		s %Tags{""}


### PR DESCRIPTION
Detect RmlUI package and thumbnail dependencies.
Export asset package dependencies during project export.