### PR TITLE
Vulkan Validation Fixes

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Linux-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Linux-x64.yml
@@ -153,7 +153,7 @@ jobs:
           export VK_ICD_FILENAMES=/usr/local/share/vulkan/icd.d/lvp_icd.x86_64.json
         fi
         sudo sysctl -w kernel.yama.ptrace_scope=0 # Required for shared texture access
-        ./Output/Bin/LinuxNinjaGccDev64/RendererTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/RendererTest
+        ./Output/Bin/LinuxNinjaGccDev64/RendererTest -debugdevice -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/RendererTest
 
   - task: Bash@3
     displayName: EditorTest
@@ -179,7 +179,7 @@ jobs:
           export DISPLAY=:1
           export VK_ICD_FILENAMES=/usr/local/share/vulkan/icd.d/lvp_icd.x86_64.json
         fi
-        ./Output/Bin/LinuxNinjaGccDev64/GameEngineTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/GameEngineTest
+        ./Output/Bin/LinuxNinjaGccDev64/GameEngineTest -debugdevice -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/GameEngineTest
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'

--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -119,14 +119,14 @@ jobs:
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2026Dev64\RendererTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTest
+      script: Output\Bin\WinVs2026Dev64\RendererTest.exe -debugdevice -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTest
   - task: CmdLine@2
     displayName: RendererTest Vulkan
     condition: eq(variables['task.MSBuild.status'], 'success')
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2026Dev64\RendererTest.exe -renderer Vulkan -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTestVulkan
+      script: Output\Bin\WinVs2026Dev64\RendererTest.exe -debugdevice -renderer Vulkan -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTestVulkan
   - task: CmdLine@2
     displayName: EditorTest
     condition: eq(variables['task.MSBuild.status'], 'success')
@@ -142,7 +142,7 @@ jobs:
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2026Dev64\GameEngineTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\GameEngineTest
+      script: Output\Bin\WinVs2026Dev64\GameEngineTest.exe -debugdevice -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\GameEngineTest
   - task: PowerShell@2
     displayName: Copy Dumps
     condition: eq(variables['task.MSBuild.status'], 'success')

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -39,7 +39,7 @@ constexpr const char* szDefaultRenderer = "";
 #endif
 
 ezCommandLineOptionString opt_Renderer("app", "-renderer", "The renderer implementation to use.", szDefaultRenderer);
-ezCommandLineOptionBool opt_DebugDevice("app", "-debugdevice", "Whether to create a debug GAL device.", false);
+ezCommandLineOptionBool opt_RendererDebugDevice("app", "-debugdevice", "Whether to create a debug GAL device.", false);
 
 void ezGameApplication::Init_ConfigureAssetManagement()
 {
@@ -244,7 +244,7 @@ void ezGameApplication::Init_SetupGraphicsDevice()
 {
   ezGALDeviceCreationDescription DeviceInit;
 
-  DeviceInit.m_bDebugDevice = opt_DebugDevice.GetOptionValue(ezCommandLineOption::LogMode::Never);
+  DeviceInit.m_bDebugDevice = opt_RendererDebugDevice.GetOptionValue(ezCommandLineOption::LogMode::Never);
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
   DeviceInit.m_bDebugDevice = true;
 #endif

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -39,6 +39,7 @@ constexpr const char* szDefaultRenderer = "";
 #endif
 
 ezCommandLineOptionString opt_Renderer("app", "-renderer", "The renderer implementation to use.", szDefaultRenderer);
+ezCommandLineOptionBool opt_DebugDevice("app", "-debugdevice", "Whether to create a debug GAL device.", false);
 
 void ezGameApplication::Init_ConfigureAssetManagement()
 {
@@ -243,6 +244,7 @@ void ezGameApplication::Init_SetupGraphicsDevice()
 {
   ezGALDeviceCreationDescription DeviceInit;
 
+  DeviceInit.m_bDebugDevice = opt_DebugDevice.GetOptionValue(ezCommandLineOption::LogMode::Never);
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
   DeviceInit.m_bDebugDevice = true;
 #endif

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraph.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraph.cpp
@@ -860,7 +860,7 @@ void ezRenderGraph::CullDeadPasses()
   }
 
   // Seed the alive set with passes that have side effects or write to imported resources.
-  ezHybridArray<ezUInt16, 16> stack;
+  ezHybridArray<ezUInt16, 16, ezTempAllocatorWrapper> stack;
   for (ezUInt16 i = 0; i < uiNumPasses; ++i)
   {
     const Pass& pass = m_Passes[i];

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -274,7 +274,7 @@ void ezRenderGraphManager::GetExecutionSummary(ezRenderGraphInspectionSummary& o
 
   if (ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice())
   {
-    ezDynamicArray<ezGALSwapChainHandle> swapChains;
+    ezDynamicArray<ezGALSwapChainHandle> swapChains(ezTempAllocator::Get());
     pDevice->GetAllSwapChains(swapChains);
     out_summary.m_AvailableSwapChains.Reserve(swapChains.GetCount());
     for (ezGALSwapChainHandle hSwapChain : swapChains)

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -274,7 +274,7 @@ void ezRenderGraphManager::GetExecutionSummary(ezRenderGraphInspectionSummary& o
 
   if (ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice())
   {
-    ezDynamicArray<ezGALSwapChainHandle> swapChains(ezTempAllocator::Get());
+    ezTempArray<ezGALSwapChainHandle> swapChains;
     pDevice->GetAllSwapChains(swapChains);
     out_summary.m_AvailableSwapChains.Reserve(swapChains.GetCount());
     for (ezGALSwapChainHandle hSwapChain : swapChains)

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphManager.cpp
@@ -205,7 +205,7 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
     for (auto pRenderGraph : s_ExecutingGraphs)
     {
       // Collect observers for this graph.
-      ezHybridArray<ezRenderGraphPassObserver*, 4> graphObservers;
+      ezHybridArray<ezRenderGraphPassObserver*, 4, ezTempAllocatorWrapper> graphObservers;
       for (auto* pObserver : s_ExecutingObservers)
       {
         if (pObserver->m_pGraph == pRenderGraph)
@@ -221,10 +221,10 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
 
 
 
-  ezHybridArray<ezGALTextureBarrier, 8> textureBarriers;
+  ezHybridArray<ezGALTextureBarrier, 8, ezTempAllocatorWrapper> textureBarriers;
   s_pStateTracker->RevertTextureState([&](const ezGALTextureBarrier& barrier)
     { textureBarriers.PushBack(barrier); });
-  ezHybridArray<ezGALBufferBarrier, 8> bufferBarriers;
+  ezHybridArray<ezGALBufferBarrier, 8, ezTempAllocatorWrapper> bufferBarriers;
   s_pStateTracker->RevertBufferState([&](const ezGALBufferBarrier& barrier)
     { bufferBarriers.PushBack(barrier); });
 
@@ -234,7 +234,7 @@ void ezRenderGraphManager::ExecuteRenderGraphs(ezGALDevice* pDevice)
   for (s_uiCurrentGraphIndex = 0; s_uiCurrentGraphIndex < s_ExecutingGraphs.GetCount(); ++s_uiCurrentGraphIndex)
   {
     // Collect valid observers for this graph.
-    ezHybridArray<ezRenderGraphPassObserver*, 4> graphObservers;
+    ezHybridArray<ezRenderGraphPassObserver*, 4, ezTempAllocatorWrapper> graphObservers;
     for (auto* pObserver : s_ExecutingObservers)
     {
       if (pObserver->m_bValid && pObserver->m_pGraph == s_ExecutingGraphs[s_uiCurrentGraphIndex])

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphResourceAllocator.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphResourceAllocator.cpp
@@ -2,6 +2,7 @@
 
 #include <Foundation/Algorithm/HashingUtils.h>
 #include <RendererCore/RenderGraph/RenderGraphResourceAllocator.h>
+#include <Foundation/Memory/FrameAllocator.h>
 
 ezRenderGraphResourceAllocator::ezRenderGraphResourceAllocator(ezRenderGraphResourcePool* pPool)
   : m_pPool(pPool)
@@ -12,6 +13,18 @@ ezRenderGraphResourceAllocator::ezRenderGraphResourceAllocator(ezRenderGraphReso
 ezRenderGraphResourceAllocator::~ezRenderGraphResourceAllocator()
 {
   FreeResources();
+}
+
+ezRenderGraphResourceAllocator::TextureGroup::TextureGroup()
+  : m_All(ezFrameAllocator::GetCurrentAllocator())
+  , m_Available(ezFrameAllocator::GetCurrentAllocator())
+{
+}
+
+ezRenderGraphResourceAllocator::BufferGroup::BufferGroup()
+  : m_All(ezFrameAllocator::GetCurrentAllocator())
+  , m_Available(ezFrameAllocator::GetCurrentAllocator())
+{
 }
 
 ezRenderGraphResourceAllocator::ezRenderGraphResourceAllocator(ezRenderGraphResourceAllocator&& rhs) noexcept

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphResourceAllocator.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphResourceAllocator.cpp
@@ -1,8 +1,8 @@
 #include <RendererCore/RendererCorePCH.h>
 
 #include <Foundation/Algorithm/HashingUtils.h>
-#include <RendererCore/RenderGraph/RenderGraphResourceAllocator.h>
 #include <Foundation/Memory/FrameAllocator.h>
+#include <RendererCore/RenderGraph/RenderGraphResourceAllocator.h>
 
 ezRenderGraphResourceAllocator::ezRenderGraphResourceAllocator(ezRenderGraphResourcePool* pPool)
   : m_pPool(pPool)

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphUtils.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphUtils.cpp
@@ -1,5 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
+#include <Foundation/Configuration/Startup.h>
 #include <RendererCore/RenderContext/BindGroupBuilder.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderGraph/RenderGraph.h>
@@ -8,7 +9,6 @@
 #include <RendererFoundation/Descriptors/Enumerations.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Texture.h>
-#include <Foundation/Configuration/Startup.h>
 
 namespace
 {

--- a/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphUtils.cpp
+++ b/Code/Engine/RendererCore/RenderGraph/Implementation/RenderGraphUtils.cpp
@@ -8,7 +8,36 @@
 #include <RendererFoundation/Descriptors/Enumerations.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Texture.h>
-#include <RendererFoundation/Shader/ShaderUtils.h>
+#include <Foundation/Configuration/Startup.h>
+
+namespace
+{
+  static ezShaderResourceHandle g_hDownscaleShader;
+}
+
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(RendererCore, RenderGraphUtils)
+
+BEGIN_SUBSYSTEM_DEPENDENCIES
+  "Foundation",
+  "Core",
+  "ResourceManager",
+  "RenderGraphManager"
+END_SUBSYSTEM_DEPENDENCIES
+
+ON_HIGHLEVELSYSTEMS_STARTUP
+{
+  g_hDownscaleShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/Pipeline/Downscale.ezShader");
+  EZ_ASSERT_DEV(g_hDownscaleShader.IsValid(), "Could not load Downscale shader.");
+}
+
+ON_HIGHLEVELSYSTEMS_SHUTDOWN
+{
+  g_hDownscaleShader.Invalidate();
+}
+
+EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
 
 ezRenderGraphTextureHandle ezRenderGraphUtils::GenerateMipMaps(ezGALTextureHandle hTexture, ezGALTextureRange range, ezRenderGraph& ref_renderGraph)
 {
@@ -35,9 +64,6 @@ ezRenderGraphTextureHandle ezRenderGraphUtils::GenerateMipMaps(ezGALTextureHandl
   if (range.m_uiMipLevels <= 1)
     return hGraphTexture;
 
-  ezShaderResourceHandle hDownscaleShader = ezResourceManager::LoadResource<ezShaderResource>("Shaders/Pipeline/Downscale.ezShader");
-  EZ_ASSERT_DEV(hDownscaleShader.IsValid(), "Could not load Downscale shader.");
-
   static ezHashedString sCameraMode = ezMakeHashedString("CAMERA_MODE");
   static ezHashedString sPerspective = ezMakeHashedString("CAMERA_MODE_PERSPECTIVE");
 
@@ -60,11 +86,11 @@ ezRenderGraphTextureHandle ezRenderGraphUtils::GenerateMipMaps(ezGALTextureHandl
       pass.ReadTexture(hGraphTexture, sourceRange, ezGALResourceState::ShaderResource, ezGALShaderStageFlags::PixelShader);
       pass.AddColorTarget(hGraphTexture, targetRange, {}, {}, ezGALResourceFormat::Invalid, ezGALTextureType::Texture2DArray);
       pass.HasSideEffects();
-      pass.SetExecuteCallback([hGraphTexture, sourceRange, hDownscaleShader](const ezRenderGraphContext& context)
+      pass.SetExecuteCallback([hGraphTexture, sourceRange](const ezRenderGraphContext& context)
         {
           ezRenderContext* pRenderContext = context.GetRenderContext();
           pRenderContext->SetShaderPermutationVariable(sCameraMode, sPerspective);
-          pRenderContext->BindShader(hDownscaleShader);
+          pRenderContext->BindShader(g_hDownscaleShader);
 
           ezBindGroupBuilder& bindGroup = pRenderContext->GetBindGroup();
           bindGroup.BindTexture("Input", context.ResolveTexture(hGraphTexture), sourceRange, ezGALResourceFormat::Invalid, ezGALTextureType::Texture2DArray);

--- a/Code/Engine/RendererCore/RenderGraph/RenderGraphResourceAllocator.h
+++ b/Code/Engine/RendererCore/RenderGraph/RenderGraphResourceAllocator.h
@@ -55,6 +55,7 @@ private:
 
   struct TextureGroup
   {
+    TextureGroup();
     ezUInt32 m_uiNextPoolIndex = 0;
     ezHybridArray<ezSharedPtr<ezPooledRenderTexture>, 1> m_All;
     ezHybridArray<ezSharedPtr<ezPooledRenderTexture>, 1> m_Available;
@@ -64,6 +65,7 @@ private:
 
   struct BufferGroup
   {
+    BufferGroup();
     ezUInt32 m_uiNextPoolIndex = 0;
     ezHybridArray<ezSharedPtr<ezPooledRenderBuffer>, 1> m_All;
     ezHybridArray<ezSharedPtr<ezPooledRenderBuffer>, 1> m_Available;

--- a/Code/Engine/RendererFoundation/Utils/Implementation/ResourceStateTracker.cpp
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/ResourceStateTracker.cpp
@@ -8,16 +8,35 @@
 #include <Foundation/Memory/FrameAllocator.h>
 #include <RendererFoundation/Resources/ProxyTexture.h>
 
+ezGALResourceStateTracker::TextureState::TextureState()
+  : m_SubResourceStates(ezFrameAllocator::GetCurrentAllocator())
+{
+}
+
 ezGALResourceStateTracker::ezGALResourceStateTracker(ezGALDevice* pDevice)
   : m_pDevice(pDevice)
 {
   EZ_ASSERT_DEBUG(pDevice != nullptr, "Device must not be null");
+  m_GALDeviceEventSubscriptionID = ezGALDevice::s_Events.AddEventHandler(ezMakeDelegate(&ezGALResourceStateTracker::GALDeviceEventHandler, this));
+}
+
+ezGALResourceStateTracker::~ezGALResourceStateTracker()
+{
+  ezGALDevice::s_Events.RemoveEventHandler(m_GALDeviceEventSubscriptionID);
 }
 
 void ezGALResourceStateTracker::Clear()
 {
   m_TextureStates.Clear();
   m_BufferStates.Clear();
+}
+
+void ezGALResourceStateTracker::GALDeviceEventHandler(const ezGALDeviceEvent& e)
+{
+  if (e.m_Type == ezGALDeviceEvent::AfterEndFrame && e.m_pDevice == m_pDevice)
+  {
+    Clear();
+  }
 }
 
 // --- Initial State ---

--- a/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
@@ -10,6 +10,21 @@ ezRingBufferTracker::ezRingBufferTracker(ezUInt32 uiAlignment, ezUInt32 uiTotalS
   EZ_ASSERT_DEBUG(ezMath::IsPowerOf2(m_uiAlignment), "Non-power of two alignment not supported");
 }
 
+ezResult ezRingBufferTracker::CanAllocate(ezUInt32 uiSize) const
+{
+  uiSize = ezMemoryUtils::AlignSize(uiSize, m_uiAlignment);
+  if (m_uiFree < uiSize)
+    return EZ_FAILURE;
+
+  if (m_uiCurrentOffset + uiSize > m_uiTotalSize)
+  {
+    const ezUInt32 uiSkip = m_uiTotalSize - m_uiCurrentOffset;
+    if (m_uiFree - uiSkip < uiSize)
+      return EZ_FAILURE;
+  }
+  return EZ_SUCCESS;
+}
+
 ezResult ezRingBufferTracker::Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiAllocatedOffset)
 {
   uiSize = ezMemoryUtils::AlignSize(uiSize, m_uiAlignment);

--- a/Code/Engine/RendererFoundation/Utils/ResourceStateTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/ResourceStateTracker.h
@@ -3,6 +3,7 @@
 #include <RendererFoundation/RendererFoundationDLL.h>
 
 #include <Foundation/Algorithm/HashingUtils.h>
+#include <Foundation/Communication/Event.h>
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Types/Delegate.h>
@@ -10,6 +11,7 @@
 #include <RendererFoundation/Descriptors/Enumerations.h>
 
 class ezGALDevice;
+struct ezGALDeviceEvent;
 
 template <>
 struct ezHashHelper<ezGALTextureHandle>
@@ -43,19 +45,21 @@ struct ezHashHelper<ezGALBufferHandle>
 ///
 /// For resources that are first seen without an explicit initial state, the tracker starts from the resource default state (ezGAL*CreationDescription::GetDefaultState) with stage Auto.
 ///
-/// Barrier emission is callback-based: callbacks are only invoked when a barrier is needed. A barrier is required when the state changes, or when the previous
-/// state contains ezGALResourceState::UnorderedAccess (UAV write-after-write).
+/// Barrier emission is callback-based: callbacks are only invoked when a barrier is needed. A barrier is required when the state changes, or when the previous state contains ezGALResourceState::UnorderedAccess (UAV write-after-write).
+/// States cannot be tracked across frames and before the frame end all resources must be reverted to their default state via RevertTextureState / RevertBufferState.
 class EZ_RENDERERFOUNDATION_DLL ezGALResourceStateTracker
 {
 public:
   struct SubResourceState
   {
+    EZ_DECLARE_POD_TYPE();
     ezBitflags<ezGALResourceState> m_State;
     ezBitflags<ezGALShaderStageFlags> m_Stages;
   };
 
   struct TextureState
   {
+    TextureState();
     ezGALTextureRange m_FullRange; ///< Range covering the entire texture, filled on first occurrence.
     /// If size == 1, the single entry represents the entire resource (compressed).
     /// If size > 1, each entry corresponds to a sub-resource at index:
@@ -65,7 +69,7 @@ public:
 
 public:
   explicit ezGALResourceStateTracker(ezGALDevice* pDevice);
-  ~ezGALResourceStateTracker() = default;
+  ~ezGALResourceStateTracker();
 
   ezGALResourceStateTracker(const ezGALResourceStateTracker&) = delete;
   ezGALResourceStateTracker& operator=(const ezGALResourceStateTracker&) = delete;
@@ -124,6 +128,7 @@ public:
 
   ///@}
 private:
+  void GALDeviceEventHandler(const ezGALDeviceEvent& e);
   void ResolveProxyTexture(ezGALTextureHandle& ref_hTexture,
     ezGALTextureRange& ref_range) const;
   TextureState& GetOrCreateTextureState(ezGALTextureHandle hTexture);
@@ -132,6 +137,7 @@ private:
 
 private:
   ezGALDevice* m_pDevice = nullptr;
+  ezEventSubscriptionID m_GALDeviceEventSubscriptionID = 0;
   ezHashTable<ezGALTextureHandle, TextureState> m_TextureStates;
   ezHashTable<ezGALBufferHandle, SubResourceState> m_BufferStates;
 };

--- a/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
@@ -25,6 +25,11 @@ public:
   /// \param uiTotalSize The size of the memory.
   ezRingBufferTracker(ezUInt32 uiAlignment, ezUInt32 uiTotalSize); // [tested]
 
+  // Checks whether a contiguous memory block of the given size can be allocated.
+  /// \param uiSize Size requested.
+  /// \return Returns EZ_FAILURE if not enough memory remains to fulfil the allocation.
+  ezResult CanAllocate(ezUInt32 uiSize) const;  // [tested]
+
   /// Allocates memory of the given size.
   /// \param uiSize Size requested.
   /// \param uiCurrentFrame The current frame for which this allocation is tracked.

--- a/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
@@ -28,7 +28,7 @@ public:
   // Checks whether a contiguous memory block of the given size can be allocated.
   /// \param uiSize Size requested.
   /// \return Returns EZ_FAILURE if not enough memory remains to fulfil the allocation.
-  ezResult CanAllocate(ezUInt32 uiSize) const;  // [tested]
+  ezResult CanAllocate(ezUInt32 uiSize) const; // [tested]
 
   /// Allocates memory of the given size.
   /// \param uiSize Size requested.

--- a/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
@@ -172,9 +172,12 @@ void ezInitContextVulkan::InitTexture(const ezGALTextureVulkan* pTexture, vk::Im
   }
   else
   {
-    // We don't actually know what the current state is of an existing native object. The only use case right now are back buffers created by swap chains so for now we just throw away the current content and barrier into the preferred layout.
-    barriers.TextureBarrier(pTexture->GetImage(), pTexture->GetFullRange(),
-      ezGALResourceState::Unknown, defaultState);
+    // We don't actually know what the current state is of an existing native object, so switch from Unknown to default.
+    // This must not be done for swap chains textures as these are not allowed to be touched until acquired. The initial layout is set for these at the first time of acquire.
+    if (!pTexture->GetDescription().m_TextureFlags.IsSet(ezGALTextureUsageFlags::Presentable))
+    {
+      barriers.TextureBarrier(pTexture->GetImage(), pTexture->GetFullRange(), ezGALResourceState::Unknown, defaultState);
+    }
   }
 }
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -10,8 +10,8 @@
 #include <RendererVulkan/Device/SwapChainVulkan.h>
 #include <RendererVulkan/Pools/SemaphorePoolVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
-#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/BarrierUtilsVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -11,6 +11,7 @@
 #include <RendererVulkan/Pools/SemaphorePoolVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
+#include <RendererVulkan/Utils/BarrierUtilsVulkan.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>
@@ -136,6 +137,14 @@ void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
 #endif
 
   m_RenderTargets.m_hRTs[0] = m_SwapChainTextures[m_uiCurrentSwapChainImage];
+  if (!m_DefaultLayoutApplied.IsBitSet(m_uiCurrentSwapChainImage))
+  {
+    m_DefaultLayoutApplied.SetBit(m_uiCurrentSwapChainImage);
+    ezBarrierUtilsVulkan barriers(*pVulkanDevice, pVulkanDevice->GetCurrentCommandBuffer());
+    const ezGALTextureVulkan* pTexture = static_cast<const ezGALTextureVulkan*>(pVulkanDevice->GetTexture(m_SwapChainTextures[m_uiCurrentSwapChainImage]));
+
+    barriers.TextureBarrier(pTexture->GetImage(), pTexture->GetFullRange(), ezGALResourceState::Unknown, pTexture->GetDescription().GetDefaultState());
+  }
   pVulkanDevice->AddWaitSemaphore(ezGALDeviceVulkan::SemaphoreInfo::MakeWaitSemaphore(m_CurrentPipelineImageAvailableSemaphore, vk::PipelineStageFlagBits::eColorAttachmentOutput));
   pVulkanDevice->ReclaimLater(m_CurrentPipelineImageAvailableSemaphore);
 }
@@ -418,6 +427,7 @@ ezResult ezGALSwapChainVulkan::CreateSwapChainInternal()
     TexDesc.m_ResourceAccess.m_bImmutable = false;
     m_SwapChainTextures.PushBack(m_pVulkanDevice->CreateTextureInternal(TexDesc, ezArrayPtr<ezGALSystemMemoryDescription>()));
   }
+  m_DefaultLayoutApplied.SetCount(uiSwapChainImages, false);
   m_CurrentSize = ezSizeU32(swapChainCreateInfo.imageExtent.width, swapChainCreateInfo.imageExtent.height);
   m_RenderTargets.m_hRTs[0] = m_SwapChainTextures[0];
 
@@ -433,6 +443,7 @@ void ezGALSwapChainVulkan::DestroySwapChainInternal(ezGALDeviceVulkan* pVulkanDe
     pVulkanDevice->DestroyTexture(m_SwapChainTextures[i]);
   }
   m_SwapChainTextures.Clear();
+  m_DefaultLayoutApplied.Clear();
 
   for (vk::Semaphore& sem : m_ImageRenderFinishedSemaphores)
   {

--- a/Code/Engine/RendererVulkan/Device/SwapChainVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/SwapChainVulkan.h
@@ -38,6 +38,7 @@ protected:
   vk::SwapchainKHR m_VulkanSwapChain;
   ezHybridArray<vk::Image, 4> m_SwapChainImages;
   ezHybridArray<ezGALTextureHandle, 4> m_SwapChainTextures;
+  ezHybridBitfield<32> m_DefaultLayoutApplied;
   ezUInt32 m_uiCurrentSwapChainImage = 0;
 
   vk::Semaphore m_CurrentPipelineImageAvailableSemaphore;

--- a/Code/Engine/RendererVulkan/Pools/Implementation/UniformBufferPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/UniformBufferPoolVulkan.cpp
@@ -122,9 +122,9 @@ ezUniformBufferPoolVulkan::UniformBufferPool* ezUniformBufferPoolVulkan::GetFree
 {
   if (!m_FreePools.IsEmpty())
   {
-    // The back has the pool with the highest available memory. If this fails there is no point in checking other pools.
+    // The back has the pool with the highest available memory. If this fails, it is unlikely the other pools can allocate (could only happen due to fragmentation at the buffer wrap-around_.
     ezUniformBufferPoolVulkan::UniformBufferPool* pPool = m_FreePools.PeekBack();
-    if (pPool->GetFreeMemory() >= uiSize)
+    if (pPool->CanAllocate(uiSize).Succeeded())
     {
       m_FreePools.PopBack();
       return pPool;

--- a/Code/Engine/RendererVulkan/Pools/UniformBufferPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/UniformBufferPoolVulkan.h
@@ -44,6 +44,7 @@ private:
   {
     UniformBufferPool(ezUInt32 uiAlignment, ezUInt32 uiTotalSize);
     ~UniformBufferPool();
+    ezResult CanAllocate(ezUInt32 uiSize) const { return m_Tracker.CanAllocate(uiSize); }
     ezResult Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiStartOffset, ezByteArrayPtr& out_allocation);
     void Free(ezUInt64 uiUpToFrame);
     void Submit(ezGALDeviceVulkan* pDevice, ezUInt64 uiFrame);

--- a/Code/Engine/RendererVulkan/Utils/Implementation/BarrierUtilsVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/BarrierUtilsVulkan.cpp
@@ -1,6 +1,6 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
-// #define EZ_LOG_VULKAN_BARRIERS
+// #define VK_LOG_LAYOUT_CHANGES
 
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Device/DispatchContext.h>
@@ -154,15 +154,10 @@ namespace
       if (barriers.IsEmpty())
         return;
 
-#ifdef EZ_LOG_VULKAN_BARRIERS
+#ifdef VK_LOG_LAYOUT_CHANGES
       for (const vk::ImageMemoryBarrier2& b : barriers)
       {
-        void* bla = static_cast<VkImage>(b.image);
-        void* blub = reinterpret_cast<void*>(0x3d000000003d);
-        if (bla == blub)
-        {
-          ezLog::Info("CommandBuffer: {}, VkBarrier: Image {} | {} -> {}", ezArgP(static_cast<VkCommandBuffer>(commandBuffer)), ezArgP(static_cast<VkImage>(b.image)), vk::to_string(b.oldLayout).c_str(), vk::to_string(b.newLayout).c_str());
-        }
+        ezLog::Info("CommandBuffer: {}, VkBarrier: Image {} | {} -> {}", ezArgP(static_cast<VkCommandBuffer>(ref_commandBuffer)), ezArgP(static_cast<VkImage>(b.image)), vk::to_string(b.oldLayout).c_str(), vk::to_string(b.newLayout).c_str());
       }
 #endif
 
@@ -185,7 +180,7 @@ namespace
 
     void TextureBarrier(const ezGALDeviceVulkan& device, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezGALTextureBarrier> barriers)
     {
-      ezHybridArray<vk::ImageMemoryBarrier2, 16> vkBarriers;
+      ezHybridArray<vk::ImageMemoryBarrier2, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
 
       for (const ezGALTextureBarrier& barrier : barriers)
@@ -209,7 +204,7 @@ namespace
 
     void TextureBarrier(const ezGALDeviceVulkan& device, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezTextureBarrierVulkan> barriers)
     {
-      ezHybridArray<vk::ImageMemoryBarrier2, 16> vkBarriers;
+      ezHybridArray<vk::ImageMemoryBarrier2, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
 
       for (const ezTextureBarrierVulkan& barrier : barriers)
@@ -232,7 +227,7 @@ namespace
 
     void BufferBarrier(const ezGALDeviceVulkan& device, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezGALBufferBarrier> barriers)
     {
-      ezHybridArray<vk::BufferMemoryBarrier2, 16> vkBarriers;
+      ezHybridArray<vk::BufferMemoryBarrier2, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
 
       for (const ezGALBufferBarrier& barrier : barriers)
@@ -254,7 +249,7 @@ namespace
 
     void BufferBarrier(const ezGALDeviceVulkan& device, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezBufferBarrierVulkan> barriers)
     {
-      ezHybridArray<vk::BufferMemoryBarrier2, 16> vkBarriers;
+      ezHybridArray<vk::BufferMemoryBarrier2, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
 
       for (const ezBufferBarrierVulkan& barrier : barriers)
@@ -425,15 +420,10 @@ namespace
       if (barriers.IsEmpty())
         return;
 
-#ifdef EZ_LOG_VULKAN_BARRIERS
+#ifdef VK_LOG_LAYOUT_CHANGES
       for (const vk::ImageMemoryBarrier& b : barriers)
       {
-        void* bla = static_cast<VkImage>(b.image);
-        void* blub = reinterpret_cast<void*>(0x3d000000003d);
-        if (bla == blub)
-        {
-          ezLog::Info("CommandBuffer: {}, VkBarrier: Image {} | {} -> {}", ezArgP(static_cast<VkCommandBuffer>(commandBuffer)), ezArgP(static_cast<VkImage>(b.image)), vk::to_string(b.oldLayout).c_str(), vk::to_string(b.newLayout).c_str());
-        }
+        ezLog::Info("CommandBuffer: {}, VkBarrier: Image {} | {} -> {}", ezArgP(static_cast<VkCommandBuffer>(ref_commandBuffer)), ezArgP(static_cast<VkImage>(b.image)), vk::to_string(b.oldLayout).c_str(), vk::to_string(b.newLayout).c_str());
       }
 #endif
 
@@ -460,7 +450,7 @@ namespace
 
     void TextureBarrier(const ezGALDeviceVulkan& device, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezGALTextureBarrier> barriers)
     {
-      ezHybridArray<vk::ImageMemoryBarrier, 16> vkBarriers;
+      ezHybridArray<vk::ImageMemoryBarrier, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
       vk::PipelineStageFlags srcStages;
       vk::PipelineStageFlags dstStages;
@@ -488,7 +478,7 @@ namespace
 
     void TextureBarrier(const ezGALDeviceVulkan& /*device*/, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezTextureBarrierVulkan> barriers)
     {
-      ezHybridArray<vk::ImageMemoryBarrier, 16> vkBarriers;
+      ezHybridArray<vk::ImageMemoryBarrier, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
       vk::PipelineStageFlags srcStages;
       vk::PipelineStageFlags dstStages;
@@ -515,7 +505,7 @@ namespace
 
     void BufferBarrier(const ezGALDeviceVulkan& device, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezGALBufferBarrier> barriers)
     {
-      ezHybridArray<vk::BufferMemoryBarrier, 16> vkBarriers;
+      ezHybridArray<vk::BufferMemoryBarrier, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
       vk::PipelineStageFlags srcStages;
       vk::PipelineStageFlags dstStages;
@@ -541,7 +531,7 @@ namespace
 
     void BufferBarrier(const ezGALDeviceVulkan& /*device*/, vk::CommandBuffer& ref_commandBuffer, ezArrayPtr<const ezBufferBarrierVulkan> barriers)
     {
-      ezHybridArray<vk::BufferMemoryBarrier, 16> vkBarriers;
+      ezHybridArray<vk::BufferMemoryBarrier, 16, ezTempAllocatorWrapper> vkBarriers;
       vkBarriers.Reserve(barriers.GetCount());
       vk::PipelineStageFlags srcStages;
       vk::PipelineStageFlags dstStages;

--- a/Code/EnginePlugins/InspectorPlugin/RenderGraphObserver.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/RenderGraphObserver.cpp
@@ -64,6 +64,9 @@ namespace RenderGraphObserverDetail
 
   static void RenderGraphRenderEventHandler(const ezRenderGraphRenderEvent& e)
   {
+    if (!ezTelemetry::IsConnectedToOther())
+      return;
+
     if (e.m_Type != ezRenderGraphRenderEvent::Type::AfterGraphExecution)
       return;
 

--- a/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
@@ -15,6 +15,7 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     EZ_TEST_INT(tracker.GetFreeMemory(), 65472);
 
     ezUInt32 uiOffset = 0;
+    EZ_TEST_RESULT(tracker.CanAllocate(65472));
     EZ_TEST_RESULT(tracker.Allocate(65472, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetTotalMemory(), 65472);
@@ -25,14 +26,20 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
   {
     ezRingBufferTracker tracker(64, 1024);
     ezUInt32 uiOffset = 0;
+
+    EZ_TEST_RESULT(tracker.CanAllocate(256));
     EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_RESULT(tracker.CanAllocate(256));
     EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 256);
+    EZ_TEST_RESULT(tracker.CanAllocate(256));
     EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 512);
+    EZ_TEST_RESULT(tracker.CanAllocate(256));
     EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 768);
+    EZ_TEST_BOOL(tracker.CanAllocate(256).Failed());
     EZ_TEST_BOOL(tracker.Allocate(256, 1, uiOffset).Failed());
     EZ_TEST_INT(tracker.GetFreeMemory(), 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 1024);
@@ -47,6 +54,7 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     tracker.Free(1);
     EZ_TEST_INT(tracker.GetFreeMemory(), 1024);
     EZ_TEST_INT(tracker.GetUsedMemory(), 0);
+    EZ_TEST_RESULT(tracker.CanAllocate(256));
     EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
   }
@@ -59,6 +67,7 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     {
       EZ_TEST_INT(tracker.GetTotalMemory(), 1024);
       tracker.Free(i - 4);
+      EZ_TEST_RESULT(tracker.CanAllocate(256));
       EZ_TEST_RESULT(tracker.Allocate(256, i, uiOffset));
       EZ_TEST_INT(uiOffset, (i * 256) % 1024);
       ezTempHybridArray<ezRingBufferTracker::FrameData, 2> frames;
@@ -76,6 +85,7 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     ezUInt32 uiOffset = 0;
 
     // Frame 1: Move a bit forward so we are at the end of the buffer in the next frame.
+    EZ_TEST_RESULT(tracker.CanAllocate(800));
     EZ_TEST_RESULT(tracker.Allocate(800, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 800);
@@ -89,11 +99,13 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     EZ_TEST_INT(tracker.GetUsedMemory(), 0);
 
     // Frame 2: We allocate memory and hit the end point exactly and then do another allocation.
+    EZ_TEST_RESULT(tracker.CanAllocate(200));
     EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
     EZ_TEST_INT(uiOffset, 800);
     EZ_TEST_INT(tracker.GetUsedMemory(), 200);
 
     // This allocation wraps around now.
+    EZ_TEST_RESULT(tracker.CanAllocate(200));
     EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 400);
@@ -110,12 +122,56 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     EZ_TEST_INT(frames[1].m_uiSize, 200);
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Buffer wrap around, no continuous block")
+  {
+    ezRingBufferTracker tracker(2, 1000);
+    ezUInt32 uiOffset = 0;
+
+    ezTempHybridArray<ezRingBufferTracker::FrameData, 2> frames;
+    // Frame 1: Allocate 100 bytes
+    EZ_TEST_RESULT(tracker.CanAllocate(100));
+    EZ_TEST_RESULT(tracker.Allocate(100, 1, uiOffset));
+    EZ_TEST_RESULT(tracker.SubmitFrame(1, frames));
+    EZ_TEST_INT(frames.GetCount(), 1);
+    EZ_TEST_INT(frames[0].m_uiFrame, 1);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 0);
+    EZ_TEST_INT(frames[0].m_uiSize, 100);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 100);
+    EZ_TEST_INT(tracker.GetFreeMemory(), 900);
+
+    // Frame 2: Allocate 700 bytes
+    EZ_TEST_RESULT(tracker.CanAllocate(700));
+    EZ_TEST_RESULT(tracker.Allocate(700, 2, uiOffset));
+    EZ_TEST_RESULT(tracker.SubmitFrame(2, frames));
+    EZ_TEST_INT(frames.GetCount(), 1);
+    EZ_TEST_INT(frames[0].m_uiFrame, 2);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 100);
+    EZ_TEST_INT(frames[0].m_uiSize, 700);
+
+    EZ_TEST_INT(tracker.GetUsedMemory(), 800);
+    EZ_TEST_INT(tracker.GetFreeMemory(), 200);
+
+    // Frame 3: Free frame 1 memory (100 bytes at the start of the ring buffer)
+    tracker.Free(1);
+
+    EZ_TEST_INT(tracker.GetUsedMemory(), 700);
+    EZ_TEST_INT(tracker.GetFreeMemory(), 300);
+
+    EZ_TEST_BOOL(tracker.CanAllocate(200).Succeeded());
+    EZ_TEST_BOOL(tracker.CanAllocate(300).Failed());
+
+    EZ_TEST_BOOL(tracker.Allocate(300, 3, uiOffset).Failed());
+    EZ_TEST_RESULT(tracker.CanAllocate(200));
+    EZ_TEST_BOOL(tracker.Allocate(200, 3, uiOffset).Succeeded());
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Allocation skip due to reaching the end of the buffer")
   {
     ezRingBufferTracker tracker(2, 1000);
     ezUInt32 uiOffset = 0;
 
     // Frame 1: Move a bit forward so we are at the end of the buffer in the next frame.
+    EZ_TEST_RESULT(tracker.CanAllocate(800));
     EZ_TEST_RESULT(tracker.Allocate(800, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 800);
@@ -129,11 +185,13 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, RingBufferTracker)
     EZ_TEST_INT(tracker.GetUsedMemory(), 0);
 
     // Frame 2: We allocate memory but do not hit the end point yet.
+    EZ_TEST_RESULT(tracker.CanAllocate(100));
     EZ_TEST_RESULT(tracker.Allocate(100, 2, uiOffset));
     EZ_TEST_INT(uiOffset, 800);
     EZ_TEST_INT(tracker.GetUsedMemory(), 100);
 
     // We allocate near the end of the buffer but it doesn't fit so 100 bytes are wasted as we skip to the start again.
+    EZ_TEST_RESULT(tracker.CanAllocate(200));
     EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 400);

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -104,6 +104,7 @@ ezResult ezGraphicsTest::CreateRenderer(ezGALDevice*& out_pDevice)
   // Create a device
   {
     ezGALDeviceCreationDescription DeviceInit;
+    DeviceInit.m_bDebugDevice = ezCommandLineUtils::GetGlobalInstance()->GetBoolOption("-debugdevice", false);
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
     DeviceInit.m_bDebugDevice = true;
 #endif

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -43,6 +43,7 @@ ezCommandLineOptionString opt_Filter("_TestFramework", "-filter", "Filter to exe
 ezCommandLineOptionPath opt_Json("_TestFramework", "-json", "JSON file to write.", "");
 ezCommandLineOptionPath opt_OutputDir("_TestFramework", "-outputDir", "Output directory", "");
 ezCommandLineOptionBool opt_List("_TestFramework", "-list", "List all test names and exit.", false);
+ezCommandLineOptionBool opt_DebugDevice("_TestFramework", "-debugdevice", "Whether to create a debug GAL device.", false);
 
 constexpr int s_iMaxErrorMessageLength = 512;
 

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: 5CQ8A5DB904E-A23127-426D-4D6D-ESA93071E0893
+Change me: 5CQ8QsA5DB904E-A23127-426D-4D6D-ESA93071E0893


### PR DESCRIPTION
* Reduce number of allocations in the render graph during stable frames.
* Added `-debugdevice` command line argument to tests and engine. This enables the GAL device debug flag. This will enable Vulkan validation.
* CI tests now run with Vulkan validation.
* Fixed Vulkan validation issue with swapchain textures being touched before being acquired. Initial layout is now set on first acquire.