### PR TITLE
Fixed revert to default of exposed parameters

### DIFF
--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersDefaultStateProvider.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersDefaultStateProvider.cpp
@@ -174,19 +174,13 @@ ezStatus ezExposedParametersAsTypeDefaultStateProvider::RevertProperty(ezDefault
 
 ezResult ezExposedParametersAsTypeDefaultStateProvider::GetDefaultValueInternal(ezDefaultStateProvider::SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index, ezVariant& out_DefaultValue)
 {
-  if (superPtr.GetCount() <= 1)
-  {
-    out_DefaultValue = {};
-    return EZ_FAILURE;
-  }
-
   // As we derive from ezExposedParametersDefaultStateProvider, we first need to convert the exposed parameter type, prop, accessor into the actual underlying data structure that the base class expects before calling it.
   // * The ezExposedParametersAsTypeCommandAccessor proxies the ezExposedParameterCommandAccessor so the proxy source is the correct accessor.
   // * The object stays the same.
   // * The property from the exposed parameter type is replaced by the actual property that stores the exposed parameters in the real object.
   // * The index is the name of the property as that is how the parameter map is generated (keyed by parameter name).
   // With these changes made, we can rely on the base class to compute the default value.
-  out_DefaultValue = ezExposedParametersDefaultStateProvider::GetDefaultValue(superPtr.GetSubArray(1), m_pAccessor->GetSourceAccessor(), pObject, m_pAccessor->GetSourceAccessor()->m_pParameterProp, pProp->GetPropertyName());
+  out_DefaultValue = ezExposedParametersDefaultStateProvider::GetDefaultValue(superPtr, m_pAccessor->GetSourceAccessor(), pObject, m_pAccessor->GetSourceAccessor()->m_pParameterProp, pProp->GetPropertyName());
 
   ezStatus res(EZ_SUCCESS);
   // We now have the value of the exposed parameter. If this is a container, we need to dive into the index. If index is invalid, this is a no-op.

--- a/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
@@ -83,6 +83,7 @@ protected:
   virtual void UpdateElement(ezUInt32 index) override;
   virtual void UpdatePropertyMetaState() override;
   virtual void GetRequiredElements(ezDynamicArray<ezVariant>& out_keys) const override;
+  virtual void DoPrepareToDie() override;
 
 private:
   void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
@@ -569,6 +569,15 @@ void ezQtExposedParametersPropertyWidget::GetRequiredElements(ezDynamicArray<ezV
   }
 }
 
+void ezQtExposedParametersPropertyWidget::DoPrepareToDie()
+{
+  ezQtPropertyStandardTypeContainerWidget::DoPrepareToDie();
+  if (m_pTypeWidget)
+  {
+    m_pTypeWidget->PrepareToDie();
+  }
+}
+
 void ezQtExposedParametersPropertyWidget::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
 {
   if (IsUndead())

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -6,6 +6,7 @@
 #include <EditorFramework/DragDrop/DragDropHandler.h>
 #include <EditorFramework/DragDrop/DragDropInfo.h>
 #include <EditorFramework/Object/ObjectPropertyPath.h>
+#include <EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h>
 #include <EditorPluginScene/Panels/LayerPanel/LayerAdapter.moc.h>
 #include <EditorPluginScene/Scene/LayerDocument.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
@@ -15,7 +16,6 @@
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
 #include <RendererCore/Lights/SphereReflectionProbeComponent.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
-#include <EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h>
 
 #include <QMimeData>
 

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -15,6 +15,7 @@
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
 #include <RendererCore/Lights/SphereReflectionProbeComponent.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
+#include <EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h>
 
 #include <QMimeData>
 
@@ -38,7 +39,7 @@ ezResult ezEditorSceneDocumentTest::InitializeTest()
   if (SUPER::InitializeTest().Failed())
     return EZ_FAILURE;
 
-  if (SUPER::CreateAndLoadProject("SceneTestProject").Failed())
+  if (SUPER::OpenProject("Data/UnitTests/EditorTest").Failed())
     return EZ_FAILURE;
 
   if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(); res.Failed())
@@ -334,13 +335,84 @@ void ezEditorSceneDocumentTest::PrefabOperations()
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Drag&Drop Prefabs")
   {
-    const char* szSpherePrefab = "{ a3ce5d3d-be5e-4bda-8820-b1ce3b3d33fd }";
+    const char* szSpherePrefab = "{ 195cdef0-45f1-0642-9fea-5dea95057fb9 }";
     pPrefab1 = DropAsset(m_pDoc, szSpherePrefab);
     EZ_TEST_BOOL(!m_pDoc->IsObjectEditorPrefab(pPrefab1->GetGuid()));
     EZ_TEST_BOOL(m_pDoc->IsObjectEnginePrefab(pPrefab1->GetGuid()));
+
+    // Test undo / redo of prefab creation
+    ProcessEvents(1);
+    EZ_TEST_STATUS(m_pDoc->GetCommandHistory()->Undo(1));
+    EZ_TEST_STATUS(m_pDoc->GetCommandHistory()->Redo(1));
+
     pPrefab2 = DropAsset(m_pDoc, szSpherePrefab, true);
     EZ_TEST_BOOL(m_pDoc->IsObjectEditorPrefab(pPrefab2->GetGuid()));
     EZ_TEST_BOOL(!m_pDoc->IsObjectEnginePrefab(pPrefab2->GetGuid()));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Modify Runtime Prefab Exposed Parameters")
+  {
+    m_pDoc->GetSelectionManager()->SetSelection(pPrefab1);
+
+    const ezDocumentObject* pPrefabComponent = pAccessor->GetChildObjectByName(pPrefab1, "Components", 0);
+    const ezAbstractProperty* pPropExposedParameters = pPrefabComponent->GetType()->FindPropertyByName("Parameters");
+    const auto* pAttrib = pPropExposedParameters->GetAttributeByType<ezExposedParametersAttribute>();
+    const ezAbstractProperty* pPropParameterSource = pPrefabComponent->GetType()->FindPropertyByName(pAttrib->GetParametersSource());
+
+    // Proxy exposed parameters array with exposed parameter type
+    ezUniquePtr<ezExposedParameterCommandAccessor> pProxy = EZ_DEFAULT_NEW(ezExposedParameterCommandAccessor, pAccessor, pPropExposedParameters, pPropParameterSource);
+    ezUniquePtr<ezExposedParametersAsTypeCommandAccessor> pTypeProxy = EZ_DEFAULT_NEW(ezExposedParametersAsTypeCommandAccessor, pProxy.Borrow());
+
+    ezTempHybridArray<ezPropertySelection, 1> selection;
+    selection.PushBack({pPrefabComponent, ezVariant()});
+    const ezRTTI* pCommonType = pProxy->GetCommonExposedParamsType(selection);
+    EZ_TEST_BOOL(pCommonType->GetTypeName().StartsWith("ezExposedParameters_"));
+    const ezAbstractProperty* pPropSortingDepthOffset = pCommonType->FindPropertyByName("SortingDepthOffset");
+    const ezAbstractProperty* pPropColor = pCommonType->FindPropertyByName("Color");
+    const ezAbstractProperty* pPropMaterial = pCommonType->FindPropertyByName("Material");
+
+    // Create default state on exposed parameter type proxy. This now thinks it's working on a type with fields (the exposed parameters)
+    ezDefaultObjectState defaultState(pCommonType, pTypeProxy.Borrow(), selection);
+    EZ_TEST_STRING(defaultState.GetStateProviderName(), "Exposed Parameters");
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropSortingDepthOffset));
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropColor));
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropMaterial));
+
+    // Make modifications on the proxy type and observe default state change
+    {
+      pTypeProxy->StartTransaction("Modify Exposed Parameters");
+      EZ_TEST_STATUS(pTypeProxy->SetValue(pPrefabComponent, pPropSortingDepthOffset, 0.1f));
+      pTypeProxy->FinishTransaction();
+    }
+
+    EZ_TEST_BOOL(!defaultState.IsDefaultValue(pPropSortingDepthOffset));
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropColor));
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropMaterial));
+
+    {
+      pTypeProxy->StartTransaction("Modify Exposed Parameters");
+      EZ_TEST_STATUS(defaultState.RevertProperty(pPropSortingDepthOffset));
+      EZ_TEST_STATUS(pTypeProxy->SetValue(pPrefabComponent, pPropColor, ezColor::AliceBlue));
+
+
+      EZ_TEST_STATUS(defaultState.RevertProperty(pPropMaterial));
+      pTypeProxy->FinishTransaction();
+    }
+
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropSortingDepthOffset));
+    EZ_TEST_BOOL(!defaultState.IsDefaultValue(pPropColor));
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropMaterial));
+
+    {
+      pTypeProxy->StartTransaction("Modify Exposed Parameters");
+      EZ_TEST_STATUS(pTypeProxy->SetValue(pPrefabComponent, pPropMaterial, "{ 7c71fc2d-2a1a-4938-9305-f3a0f26d73cc }")); // Lit material
+      EZ_TEST_STATUS(defaultState.RevertProperty(pPropColor));
+      pTypeProxy->FinishTransaction();
+    }
+
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropSortingDepthOffset));
+    EZ_TEST_BOOL(defaultState.IsDefaultValue(pPropColor));
+    EZ_TEST_BOOL(!defaultState.IsDefaultValue(pPropMaterial));
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Create Nodes and check default state")

--- a/Data/UnitTests/EditorTest/Prefabs/SphereTest.ezPrefab
+++ b/Data/UnitTests/EditorTest/Prefabs/SphereTest.ezPrefab
@@ -1,0 +1,487 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{13366408360499210911,450999814505422576}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Prefab"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{13366408360499210911,450999814505422576}}
+		u4 %Hash{18045166204319467473}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{14961651262991999470,16502020974313155629}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 618ee743-ed04-4fac-bf5f-572939db2f1d }"}
+			s{"{ b93a6e80-5bf7-48f0-b7b3-2097d0133159 }"}
+		}
+		VarArray %References
+		{
+			s{"{ 618ee743-ed04-4fac-bf5f-572939db2f1d }"}
+			s{"{ b93a6e80-5bf7-48f0-b7b3-2097d0133159 }"}
+		}
+		s %Tags{""}
+	}
+}
+o
+{
+	Uuid %id{u4{15553704901951152494,3396565974721332020}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Material;"}
+		s %RequiredTag{""}
+	}
+}
+o
+{
+	Uuid %id{u4{9948246446240471337,4408436558429944516}}
+	s %t{"ezExposeColorAlphaAttribute"}
+	u3 %v{1}
+	p{}
+}
+o
+{
+	Uuid %id{u4{7018703152054692451,5451256888400223123}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		f %DefaultValue{0}
+		s %Name{"SortingDepthOffset"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{17539131249204078083,11591601045575789819}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9948246446240471337,4408436558429944516}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Color %DefaultValue{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		s %Name{"Color"}
+		s %Type{"ezColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{8049455068719717512,15915507639849189529}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{15553704901951152494,3396565974721332020}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		s %DefaultValue{"{ b93a6e80-5bf7-48f0-b7b3-2097d0133159 }"}
+		s %Name{"Material"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{14961651262991999470,16502020974313155629}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters
+		{
+			Uuid{u4{7018703152054692451,5451256888400223123}}
+			Uuid{u4{17539131249204078083,11591601045575789819}}
+			Uuid{u4{8049455068719717512,15915507639849189529}}
+		}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{2324255810642070227,70445470100875326}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5119986735330434977,103483790410850583}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15236638820240362410,88341645071901106}}
+	s %t{"ezPrefabDocumentSettings"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ExposedProperties
+		{
+			Uuid{u4{4933378615177065397,14535142650610802171}}
+			Uuid{u4{7679627832208951171,14575478811826425380}}
+			Uuid{u4{12203885974944063414,8885188486104152410}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5119986735330434977,103483790410850583}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		VarArray %Materials
+		{
+			s{"{ b93a6e80-5bf7-48f0-b7b3-2097d0133159 }"}
+		}
+		s %Mesh{"{ 618ee743-ed04-4fac-bf5f-572939db2f1d }"}
+		f %SortingDepthOffset{0}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezSceneDocumentRoot"}
+	u3 %v{2}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{2324255810642070227,70445470100875326}}
+		}
+		Uuid %Settings{u4{15236638820240362410,88341645071901106}}
+	}
+}
+o
+{
+	Uuid %id{u4{12203885974944063414,8885188486104152410}}
+	s %t{"ezExposedSceneProperty"}
+	u3 %v{1}
+	p
+	{
+		s %Name{"Material"}
+		Uuid %Object{u4{5119986735330434977,103483790410850583}}
+		s %PropertyPath{"Materials[0]"}
+	}
+}
+o
+{
+	Uuid %id{u4{4933378615177065397,14535142650610802171}}
+	s %t{"ezExposedSceneProperty"}
+	u3 %v{1}
+	p
+	{
+		s %Name{"SortingDepthOffset"}
+		Uuid %Object{u4{5119986735330434977,103483790410850583}}
+		s %PropertyPath{"SortingDepthOffset"}
+	}
+}
+o
+{
+	Uuid %id{u4{7679627832208951171,14575478811826425380}}
+	s %t{"ezExposedSceneProperty"}
+	u3 %v{1}
+	p
+	{
+		s %Name{"Color"}
+		Uuid %Object{u4{5119986735330434977,103483790410850583}}
+		s %PropertyPath{"Color"}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{6914292285925798136,1108246313736053318}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11638255232360359673,3108610646416571142}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezExposedSceneProperty"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14332645745114734426,3197497487504472660}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneDocumentSettingsBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezPrefabDocumentSettings"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14633628111157529947,3328384510238863063}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezMeshComponentBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{17523044089822028024,3521005166208929094}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCategoryAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7605758958972330253,6687734095884105025}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponentBase"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{13649880205026559927,7297274558339895637}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObject"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3251891958765718680,9159887340540620231}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezDocumentRoot"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentRoot"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{14543630447052729839,9459039542380974471}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezObjectMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14700230518358869173,11472901527618371423}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettingsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16777871838542487558,12116962178824346014}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezRenderComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9604010176759229512,12868035041842190965}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPropertyAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}


### PR DESCRIPTION
Fixes #1946
* Revert incorrect previous fix to crash when undoing prefab creation in `ezExposedParametersAsTypeDefaultStateProvider::GetDefaultValueInternal`. The problem was the the GUI was updating its state on deleted objects. Correct fix is to implement `ezQtExposedParametersPropertyWidget::DoPrepareToDie` correctly so that the child type widget is marked as dead.
* Fixed a small bug in `ezExposedParametersAsTypeDefaultStateProvider::GetDefaultValueInternal`: The super array was reduced when passing to the base class. However, the base class is still operating on the same level so the same provider so the same super array needs to be passed in.
* Added unit tests for prefab default state and undo / redo while selected. Added a new SphereTest prefab with exposed parameters for this purpose.