### PR TITLE
Automatic LOD for terrain patches

### DIFF
--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
@@ -17,8 +17,15 @@
 #include <TerrainPlugin/Rendering/TerrainRenderData.h>
 #include <TerrainPlugin/TerrainSystem.h>
 
+#include <Foundation/Configuration/CVar.h>
+#include <Foundation/Utilities/GraphicsUtils.h>
+#include <RendererCore/Pipeline/View.h>
+
+ezCVarFloat cvar_TerrainLodTargetCoverage("Terrain.LodTargetCoverage", 0.005f, ezCVarFlags::Default,
+  "Target screen-space coverage (fraction of view height) of one terrain grid cell at which a patch switches to the next-coarser LOD.");
+
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 1, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -31,6 +38,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 1, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("HeightImageSize", GetHeightImageSize, SetHeightImageSize)->AddAttributes(new ezDefaultValueAttribute(ezVec2(1.0f))),
     EZ_ACCESSOR_PROPERTY("HeightImageScale", GetHeightImageScale, SetHeightImageScale)->AddAttributes(new ezDefaultValueAttribute(32.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_ENUM_ACCESSOR_PROPERTY("Collider", ezTerrainPatchColliderMode, GetCollider, SetCollider),
+    EZ_ACCESSOR_PROPERTY("LodDistanceScale", GetLodDistanceScale, SetLodDistanceScale)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, ezVariant()), new ezMinValueTextAttribute("LOD Disabled")),
     EZ_ARRAY_ACCESSOR_PROPERTY("Surfaces", Surfaces_GetCount, Surfaces_GetValue, Surfaces_SetValue, Surfaces_Insert, Surfaces_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_SET_ACCESSOR_PROPERTY("TerrainTags", GetTags, Reflection_SetTag, Reflection_RemoveTag)->AddAttributes(new ezTagSetWidgetAttribute("Terrain")),
   }
@@ -55,6 +63,8 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 1, ezComponentMode::Static)
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
+
+constexpr float g_fSkirtDepth = 2.0f;
 
 ezTerrainPatchComponent::ezTerrainPatchComponent() = default;
 ezTerrainPatchComponent::~ezTerrainPatchComponent() = default;
@@ -126,6 +136,9 @@ void ezTerrainPatchComponent::SerializeComponent(ezWorldWriter& inout_stream) co
   s << m_vImageSize;
   s << m_fHeightScale;
   s << m_uiStableId;
+
+  // Version 2
+  s << m_fLodDistanceScale;
 }
 
 void ezTerrainPatchComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -153,6 +166,11 @@ void ezTerrainPatchComponent::DeserializeComponent(ezWorldReader& inout_stream)
   s >> m_vImageSize;
   s >> m_fHeightScale;
   s >> m_uiStableId;
+
+  if (uiVersion >= 2)
+  {
+    s >> m_fLodDistanceScale;
+  }
 }
 
 void ezTerrainPatchComponent::SetMaterial(const ezMaterialResourceHandle& hMaterial)
@@ -292,11 +310,37 @@ void ezTerrainPatchComponent::OnDeactivated()
 
 ezResult ezTerrainPatchComponent::GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg)
 {
-  const ezVec3 vMin = ezVec3::MakeZero();
-  const ezVec3 vMax(m_fSize, m_fSize, m_fSize);
+  ezVec3 vMin = ezVec3::MakeZero();
+  ezVec3 vMax(m_fSize, m_fSize, m_fSize);
+
+  // The skirt extends the 4-vertex border ring outward and pulls those vertices down by SkirtDepth.
+  // LodDistanceScale == 0 ("LOD Disabled") turns the skirt off, so the bounds stay tight in that case.
+  if (m_fLodDistanceScale > 0.0f)
+  {
+    const float fSkirtWorld = 4.0f * (m_fSize / static_cast<float>(m_Resolution.GetValue()));
+    vMin.x -= fSkirtWorld;
+    vMin.y -= fSkirtWorld;
+    vMax.x += fSkirtWorld;
+    vMax.y += fSkirtWorld;
+    vMin.z -= g_fSkirtDepth;
+  }
 
   ref_bounds = ezBoundingBoxSphere::MakeFromBox(ezBoundingBox::MakeFromMinMax(vMin, vMax));
   return EZ_SUCCESS;
+}
+
+static float CalculateGridCellScreenCoverage(const ezVec3& vWorldPos, float fGridSpacing, const ezCamera& camera)
+{
+  const ezBoundingSphere sphere = ezBoundingSphere::MakeFromCenterAndRadius(vWorldPos, fGridSpacing * 0.5f);
+
+  if (camera.IsPerspective())
+  {
+    return ezGraphicsUtils::CalculateSphereScreenCoverage(sphere, camera.GetCenterPosition(), camera.GetFovY(1.0f));
+  }
+  else
+  {
+    return ezGraphicsUtils::CalculateSphereScreenCoverage(sphere.m_fRadius, camera.GetDimensionY(1.0f));
+  }
 }
 
 void ezTerrainPatchComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
@@ -325,15 +369,45 @@ void ezTerrainPatchComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg
   pRenderData->m_hNormalBuffer = hNormalBuffer;
   pRenderData->m_hCellMaterialBuffer = hCellMaterialBuffer;
   pRenderData->m_hVertexWeightBuffer = hVertexWeightBuffer;
+  const float fGridSpacing = m_fSize / static_cast<float>(m_Resolution.GetValue());
   pRenderData->m_uiCellsPerSide = (ezUInt32)m_Resolution.GetValue();
-  pRenderData->m_fGridSpacing = m_fSize / static_cast<float>(m_Resolution.GetValue());
+  pRenderData->m_fGridSpacing = fGridSpacing;
   pRenderData->m_uiDefaultMaterialIndex = m_uiBaseMaterialIndex;
+
+  // LodDistanceScale == 0 is the "LOD Disabled" special value: always render at full resolution
+  // and skip the skirt (there is no coarser neighbor LOD it would need to hide seams against).
+  const bool bLodEnabled = m_fLodDistanceScale > 0.0f;
+
+  ezUInt8 uiLod = 0;
+  float fLodFade = 0.0f;
+
+  if (bLodEnabled && msg.m_pView != nullptr)
+  {
+    const ezVec3 vCenter = GetOwner()->GetGlobalTransform() * ezVec3(m_fSize * 0.5f, m_fSize * 0.5f, 0.0f);
+    const float fCoverage0 = CalculateGridCellScreenCoverage(vCenter, fGridSpacing, *msg.m_pView->GetLodCamera());
+    const float fTargetCoverage = cvar_TerrainLodTargetCoverage / m_fLodDistanceScale;
+
+    const float fContinuousLod = ezMath::Clamp(ezMath::Log2(fTargetCoverage / ezMath::Max(fCoverage0, 0.00001f)), 0.0f, 2.0f);
+
+    uiLod = (ezUInt8)ezMath::Trunc(fContinuousLod);
+    const float fFrac = fContinuousLod - uiLod;
+
+    const float kFadeBand = 0.3f;
+    fLodFade = ezMath::Saturate((fFrac - (1.0f - kFadeBand)) / kFadeBand);
+  }
+
+  pRenderData->m_uiLod = uiLod;
+  pRenderData->m_fLodFade = fLodFade;
+  pRenderData->m_bRenderSkirt = bLodEnabled;
+  pRenderData->m_fSkirtDepth = g_fSkirtDepth;
   pRenderData->m_uiSortingKey = 0;
   pRenderData->m_uiNumInstances = 1;
   pRenderData->m_DataOffsets.m_uiInstance = m_InstanceDataOffset.m_uiOffset;
   pRenderData->m_hInstanceDataBuffer = hInstanceDataBuffer;
 
-  msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::LitOpaque, ezRenderData::Caching::IfStatic);
+  // LOD level and fade are recomputed from the current camera distance every frame, so the render
+  // data must not be cached across frames (caching would freeze it at whatever LOD was extracted once).
+  msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::LitOpaque, ezRenderData::Caching::Never);
 
   // The vertex shader samples these persistent GPU buffers, so declare them as render-graph
   // dependencies for the categories that render this patch.
@@ -379,6 +453,21 @@ void ezTerrainPatchComponent::SetBaseMaterialIndex(ezUInt8 uiIndex)
   {
     auto* pSystem = GetWorld()->GetOrCreateModule<ezTerrainSystem>();
     pSystem->ModifyHeightfieldTerrain(m_uiHeightfieldIndex).m_uiDefaultMaterialIndex = uiIndex;
+  }
+}
+
+void ezTerrainPatchComponent::SetLodDistanceScale(float fScale)
+{
+  fScale = ezMath::Max(fScale, 0.0f);
+  if (m_fLodDistanceScale != fScale)
+  {
+    const bool bSkirtChanged = (m_fLodDistanceScale > 0.0f) != (fScale > 0.0f);
+
+    m_fLodDistanceScale = fScale;
+    InvalidateCachedRenderData();
+
+    if (bSkirtChanged)
+      TriggerLocalBoundsUpdate();
   }
 }
 

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
@@ -95,9 +95,17 @@ public:
   ezUInt8 GetBaseMaterialIndex() const { return m_uiBaseMaterialIndex; }            // [ property ]
   void SetBaseMaterialIndex(ezUInt8 uiIndex);                                       // [ property ]
 
-  const ezTagSet& GetTags() const { return m_Tags; }                                // [ property ]
-  void Reflection_SetTag(const char* szTagName);                                    // [ property ]
-  void Reflection_RemoveTag(const char* szTagName);                                 // [ property ]
+  /// Divides the target grid-cell coverage used for automatic LOD selection, i.e. scales the
+  /// distance at which this patch switches LODs. 1 = default distance, > 1 switches later (at a
+  /// greater distance), < 1 switches earlier (at a smaller distance).
+  /// 0 ("LOD Disabled") turns automatic LOD off entirely: the patch always renders at full
+  /// resolution and the skirt (only needed to hide seams against a coarser LOD neighbor) is off too.
+  float GetLodDistanceScale() const { return m_fLodDistanceScale; } // [ property ]
+  void SetLodDistanceScale(float fScale);                           // [ property ]
+
+  const ezTagSet& GetTags() const { return m_Tags; }                // [ property ]
+  void Reflection_SetTag(const char* szTagName);                    // [ property ]
+  void Reflection_RemoveTag(const char* szTagName);                 // [ property ]
 
   /// Per-material-index physics surface handles. Entry i is the surface used when dominant material index == i.
   ezUInt32 Surfaces_GetCount() const;
@@ -136,5 +144,6 @@ private:
   ezVec2 m_vImageOffset = ezVec2::MakeZero();
   ezVec2 m_vImageSize = ezVec2(1.0f);
   float m_fHeightScale = 32.0f;
+  float m_fLodDistanceScale = 1.0f;
   bool m_bHeightImageDirty = false; ///< Set when the image resource reloads
 };

--- a/Code/EnginePlugins/TerrainPlugin/Rendering/TerrainRenderData.h
+++ b/Code/EnginePlugins/TerrainPlugin/Rendering/TerrainRenderData.h
@@ -45,6 +45,18 @@ public:
 
   /// Material slot index (0–7) used as the implicit fallback layer when no explicit brush covers a vertex.
   ezUInt32 m_uiDefaultMaterialIndex = 0;
+
+  /// LOD level. 0 = full resolution; each level steps over 2^LOD stored vertices between rendered corners.
+  ezUInt8 m_uiLod = 0;
+
+  /// [0, 1] blend of the vertices that vanish at the next-coarser LOD toward their interpolated position.
+  float m_fLodFade = 0.0f;
+
+  /// When set, the 4-vertex border ring is rendered as a downward-offset skirt around the patch.
+  bool m_bRenderSkirt = false;
+
+  /// World-space downward offset applied to skirt vertices. Only used when m_bRenderSkirt is set.
+  float m_fSkirtDepth = 0.0f;
 };
 
 /// Render data for GPU-direct voxel mesh rendering.

--- a/Code/EnginePlugins/TerrainPlugin/Rendering/TerrainRenderer.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Rendering/TerrainRenderer.cpp
@@ -57,20 +57,39 @@ void ezTerrainHeightfieldRenderer::RenderBatch(const ezRenderViewContext& render
       bindGroup.BindBuffer("perInstanceData", pInstanceDataBuffer->GetBufferForRendering());
     }
 
+    const ezUInt32 uiCellsFull = pRenderData->m_uiCellsPerSide;
+
     // +1 for vertex count (cells+1 vertices per side), +8 for 4-vertex border on each side.
-    const ezUInt32 uiStoredSize = pRenderData->m_uiCellsPerSide + 9;
+    const ezUInt32 uiStoredSize = uiCellsFull + 9;
+
+    // LOD: step over 2^LOD stored vertices between rendered corners. Reduce the step if it would not
+    // divide the grid evenly (keeps the reduced grid aligned to the full-resolution vertices).
+    ezUInt32 uiStep = 1u << ezMath::Min<ezUInt32>(pRenderData->m_uiLod, 2u);
+    while (uiStep > 1 && (uiCellsFull % uiStep) != 0)
+      uiStep >>= 1;
+
+    const ezUInt32 uiInnerCells = uiCellsFull / uiStep;
+
+    // The border ring is 4 stored vertices wide; at LOD step that maps to 4 / step skirt cells per side.
+    const ezUInt32 uiSkirtCells = pRenderData->m_bRenderSkirt ? (4u / uiStep) : 0u;
+    const ezUInt32 uiRenderCells = uiInnerCells + 2u * uiSkirtCells;
 
     HeightfieldRenderConstants constants;
     constants.GridSpacing = pRenderData->m_fGridSpacing;
     constants.FirstVertexIdx = 4 * uiStoredSize + 4; // skip 4 border rows and 4 border cols
     constants.VertexIdxPitch = uiStoredSize;
-    constants.CellsPerSide = pRenderData->m_uiCellsPerSide;
+    constants.CellsPerSide = uiCellsFull;
     constants.InstanceDataOffset = pRenderData->m_DataOffsets.m_uiInstance;
     constants.FallbackMaterialSlot = pRenderData->m_uiDefaultMaterialIndex;
+    constants.RenderCellsPerSide = uiRenderCells;
+    constants.VertexStep = uiStep;
+    constants.SkirtCells = uiSkirtCells;
+    constants.SkirtDepth = pRenderData->m_bRenderSkirt ? pRenderData->m_fSkirtDepth : 0.0f;
+    constants.LodFade = pRenderData->m_fLodFade;
     pContext->SetPushConstants("HeightfieldRenderConstants", constants);
 
     // No vertex buffer — SV_VertexID drives everything.
-    const ezUInt32 uiPrimitiveCount = pRenderData->m_uiCellsPerSide * pRenderData->m_uiCellsPerSide * 2;
+    const ezUInt32 uiPrimitiveCount = uiRenderCells * uiRenderCells * 2;
     pContext->BindNullMeshBuffer(ezGALPrimitiveTopology::Triangles, uiPrimitiveCount);
 
     pContext->DrawMeshBuffer().IgnoreResult();

--- a/Data/Plugins/Shaders/Terrain/Rendering/HeightfieldRenderConstants.h
+++ b/Data/Plugins/Shaders/Terrain/Rendering/HeightfieldRenderConstants.h
@@ -6,11 +6,16 @@
 /// Push constants for the heightfield terrain vertex and pixel shaders.
 BEGIN_PUSH_CONSTANTS(HeightfieldRenderConstants)
 {
-  FLOAT1(GridSpacing);         ///< World-space distance between adjacent vertices.
-  UINT1(FirstVertexIdx);       ///< Buffer index of the first vertex to render (top-left corner of the inner render grid, skipping the 4-vertex border).
+  FLOAT1(GridSpacing);         ///< World-space distance between adjacent full-resolution vertices.
+  UINT1(FirstVertexIdx);       ///< Buffer index of the inner render grid's top-left corner (skips the 4-vertex border).
   UINT1(VertexIdxPitch);       ///< Number of buffer entries per row.
-  UINT1(CellsPerSide);         ///< Number of rendered quads per side. Vertex count = CellsPerSide + 1.
+  UINT1(CellsPerSide);         ///< Number of full-resolution quads per side. Used to map rendered cells to baked material/weight cells.
   UINT1(InstanceDataOffset);   ///< Offset into the perInstanceData buffer for this patch (used for editor picking and world transform).
   UINT1(FallbackMaterialSlot); ///< Material slot index (0–7) used as the implicit fallback layer. Weight = max(0, 1 - w0 - w1 - w2 - w3).
+  UINT1(RenderCellsPerSide);   ///< Number of rendered quads per side, including skirt rings. Drives cellIndex decode.
+  UINT1(VertexStep);           ///< Stored-buffer index step between adjacent rendered vertices (2^LOD).
+  UINT1(SkirtCells);           ///< Number of skirt cell rings rendered on each side (0 = no skirt).
+  FLOAT1(SkirtDepth);          ///< World-space downward offset applied to skirt vertices.
+  FLOAT1(LodFade);             ///< [0, 1] blend of the vertices that vanish at the next-coarser LOD toward their interpolated position.
 }
 END_PUSH_CONSTANTS(HeightfieldRenderConstants)

--- a/Data/Plugins/Shaders/Terrain/Rendering/HeightfieldTerrainVS.h
+++ b/Data/Plugins/Shaders/Terrain/Rendering/HeightfieldTerrainVS.h
@@ -61,17 +61,36 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
   const uint cellIndex = vertexID / 6;
   const uint vertInCell = vertexID % 6;
 
-  const uint cellX = cellIndex % GET_PUSH_CONSTANT(HeightfieldRenderConstants, CellsPerSide);
-  const uint cellY = cellIndex / GET_PUSH_CONSTANT(HeightfieldRenderConstants, CellsPerSide);
+  const uint renderCells = GET_PUSH_CONSTANT(HeightfieldRenderConstants, RenderCellsPerSide);
+  const int step = (int)GET_PUSH_CONSTANT(HeightfieldRenderConstants, VertexStep);
+  const int skirt = (int)GET_PUSH_CONSTANT(HeightfieldRenderConstants, SkirtCells);
+  const int cellsFull = (int)GET_PUSH_CONSTANT(HeightfieldRenderConstants, CellsPerSide);
+  const int pitch = (int)GET_PUSH_CONSTANT(HeightfieldRenderConstants, VertexIdxPitch);
 
-  // lx/ly: 0-based vertex coordinates within the render grid.
-  const uint lx = cellX + QuadOffsets[vertInCell].x;
-  const uint ly = cellY + QuadOffsets[vertInCell].y;
+  const uint cellX = cellIndex % renderCells;
+  const uint cellY = cellIndex / renderCells;
 
-  const uint idx = GET_PUSH_CONSTANT(HeightfieldRenderConstants, FirstVertexIdx) + ly * GET_PUSH_CONSTANT(HeightfieldRenderConstants, VertexIdxPitch) + lx;
+  // gx/gy: vertex coordinates within the rendered grid (0 .. renderCells), including skirt rings.
+  const uint gx = cellX + QuadOffsets[vertInCell].x;
+  const uint gy = cellY + QuadOffsets[vertInCell].y;
+
+  // Buffer coordinate relative to the inner-grid origin. Negative / beyond [0, cellsFull] means skirt,
+  // which reads into the 4-vertex border ring that the bake computed for normals.
+  const int bufX = ((int)gx - skirt) * step;
+  const int bufY = ((int)gy - skirt) * step;
+
+  const bool isSkirt = (bufX < 0) || (bufX > cellsFull) || (bufY < 0) || (bufY > cellsFull);
+
+  const int idx = (int)GET_PUSH_CONSTANT(HeightfieldRenderConstants, FirstVertexIdx) + bufY * pitch + bufX;
+
+  // Material/weight buffers are baked per full-resolution cell. Map this rendered cell to the covering
+  // full-resolution cell (clamped so skirt cells reuse the edge cell's material).
+  const int cellBufX = ((int)cellX - skirt) * step;
+  const int cellBufY = ((int)cellY - skirt) * step;
+  const uint fullCellIndex = (uint)(clamp(cellBufY, 0, cellsFull - 1) * cellsFull + clamp(cellBufX, 0, cellsFull - 1));
 
   // Read per-cell-corner weights (unique slot per corner per cell — no sharing between cells).
-  const uint vtxWeightPacked = TerrainWeights[cellIndex * 4u + CornerSlot[vertInCell]];
+  const uint vtxWeightPacked = TerrainWeights[fullCellIndex * 4u + CornerSlot[vertInCell]];
 
   // Carve sentinel: Step3 writes 0xFFFFFFFF for carved corners.
   // NaN position causes the spec to cull any triangle touching this vertex.
@@ -86,12 +105,66 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
   float h = TerrainHeights[idx];
   float3 localNormal = DecodeTerrainNormal(TerrainNormals[idx]);
 
+  // LOD fade: pull the vertices that vanish at the next-coarser level toward the position they
+  // interpolate to there. A vertex vanishes when its inner-grid index is odd along an axis; it then
+  // moves toward the average of its two (or four, at a diagonal) surviving neighbors. Skirt vertices
+  // are excluded — they read the outermost border ring and have no outer neighbor to sample.
+  // The normal is faded the same way: the coarse triangulation at fade=1 interpolates the normal
+  // linearly across the same neighbors, so the fine-grid normal at a vanishing vertex must be blended
+  // toward that average too, or lighting still shows the fine-grid bump at fade=1.
+  const float fade = GET_PUSH_CONSTANT(HeightfieldRenderConstants, LodFade);
+  if (fade > 0.0 && !isSkirt)
+  {
+    const int gvx = (int)gx - skirt;
+    const int gvy = (int)gy - skirt;
+    const bool ox = (gvx & 1) != 0;
+    const bool oy = (gvy & 1) != 0;
+    const int sx = step;
+    const int sp = step * pitch;
+
+    float targetH = h;
+    float3 targetN = localNormal;
+    if (ox && !oy)
+    {
+      targetH = 0.5 * (TerrainHeights[idx - sx] + TerrainHeights[idx + sx]);
+      targetN = 0.5 * (DecodeTerrainNormal(TerrainNormals[idx - sx]) + DecodeTerrainNormal(TerrainNormals[idx + sx]));
+    }
+    else if (!ox && oy)
+    {
+      targetH = 0.5 * (TerrainHeights[idx - sp] + TerrainHeights[idx + sp]);
+      targetN = 0.5 * (DecodeTerrainNormal(TerrainNormals[idx - sp]) + DecodeTerrainNormal(TerrainNormals[idx + sp]));
+    }
+    else if (ox && oy)
+    {
+      // The coarse quad is split TR-BL (see QuadOffsets/CornerSlot above), so the center vertex
+      // lies exactly on that diagonal in the coarser LOD — its true height/normal there is the
+      // average of the TR and BL corners only, not a bilinear blend of all 4 corners.
+      targetH = 0.5 * (TerrainHeights[idx + sx - sp] + TerrainHeights[idx - sx + sp]);
+      targetN = 0.5 * (DecodeTerrainNormal(TerrainNormals[idx + sx - sp]) + DecodeTerrainNormal(TerrainNormals[idx - sx + sp]));
+    }
+
+    h = lerp(h, targetH, fade);
+    localNormal = normalize(lerp(localNormal, targetN, fade));
+  }
+
+  // Skirt vertices keep their real height and normal but are pushed down to hide seams between patches.
+  // The border ring is always 4 full-resolution buffer units wide (SkirtCells * VertexStep == 4 at any
+  // LOD), so the ring distance can be measured directly in buffer units and stays comparable across LODs.
+  // Ramping the offset in with smoothstep (instead of jumping to -SkirtDepth on the first skirt vertex)
+  // avoids a visible crease at the patch edge.
+  const int distX = max(max(0, -bufX), bufX - cellsFull);
+  const int distY = max(max(0, -bufY), bufY - cellsFull);
+  const float ringT = saturate((float)max(distX, distY) / 4.0);
+  const float skirtFalloff = ringT * ringT * (3.0 - 2.0 * ringT);
+  const float zOffset = -GET_PUSH_CONSTANT(HeightfieldRenderConstants, SkirtDepth) * skirtFalloff;
+
   // Apply the object-to-world transform so the patch respects rotation and scale.
   const ezPerInstanceData instanceData = perInstanceData[GET_PUSH_CONSTANT(HeightfieldRenderConstants, InstanceDataOffset)];
   const float4x4 objectToWorld = TransformToMatrix(instanceData.ObjectToWorld);
   const float3x3 objectToWorldNormal = TransformToRotation(instanceData.ObjectToWorldNormal);
 
-  const float3 localPos = float3((float)lx * GET_PUSH_CONSTANT(HeightfieldRenderConstants, GridSpacing), (float)ly * GET_PUSH_CONSTANT(HeightfieldRenderConstants, GridSpacing), h);
+  const float gridSpacing = GET_PUSH_CONSTANT(HeightfieldRenderConstants, GridSpacing);
+  const float3 localPos = float3((float)bufX * gridSpacing, (float)bufY * gridSpacing, h + zOffset);
 
   // Analytical tangent for a heightfield: lies in the XZ plane, perpendicular to the normal.
   // Derived from dP/du = (GridSpacing, 0, dH/dx), orthogonalized: float3(n.z, 0, -n.x).
@@ -125,7 +198,7 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
   // DataOffsets.y: 4 cell-level material indices — identical for all 6 vertices of this cell.
   Output.DataOffsets = uint3(
     GET_PUSH_CONSTANT(HeightfieldRenderConstants, InstanceDataOffset),
-    TerrainCellMaterials[cellIndex],
+    TerrainCellMaterials[fullCellIndex],
     0u);
   return Output;
 }


### PR DESCRIPTION
Adds a new CVar "Terrain.LodTargetCoverage" which specifies how detailed terrain patches should appear on screen. Terrain patches that are more detailed than that, fade to LOD1 or LOD2. At the edges, a "skirt region" is rendered (with some offset downwards). This is supposed to overlap with nearby terrain patches. When patches are at different densities (due to LOD or different resolutions), this skirt prevents cracks from showing up. The LOD selection can be tweaked per patch to push it further out or pull it closer. LOD2 (1/16th triangle count) is the maximum LOD level, the skirt region isn't large enough for more reduction, and also the quality degrades too much after that.

Different patches rendered at different LOD levels:

<img width="1000" height="665" alt="grafik" src="https://github.com/user-attachments/assets/86467677-8320-4c57-b73d-3e6c77901306" />

<img width="1000" height="665" alt="grafik" src="https://github.com/user-attachments/assets/e2c85356-c9b9-4934-aaa2-d3c1266caf25" />
