### PR TITLE
Introduced attribute to mark properties as required

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -240,9 +240,18 @@ void ezQtEditorApp::UiServicesEvents(const ezQtUiServices::Event& e)
             {
               const ezUuid objGuid = ezConversionUtils::ConvertStringToUuid(sObjRef);
 
-              if (auto pObj = pDoc->GetObjectManager()->GetObject(objGuid))
+              const ezDocumentObjectManager* pMan = pDoc->GetObjectManager();
+              const ezDocumentObject* pSelObj = pMan->GetObject(objGuid);
+
+              // Walk up to the nearest selectable ancestor, e.g. a component's owning game object.
+              while (pSelObj != nullptr && pMan->CanSelect(pSelObj).Failed())
               {
-                pDoc->GetSelectionManager()->SetSelection(pObj);
+                pSelObj = pSelObj->GetParent();
+              }
+
+              if (pSelObj != nullptr)
+              {
+                pDoc->GetSelectionManager()->SetSelection(pSelObj);
               }
             }
           }

--- a/Code/Editor/EditorFramework/PropertyGrid/AssetBrowserPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/AssetBrowserPropertyWidget.moc.h
@@ -3,6 +3,7 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/PropertyGrid/QtAssetLineEdit.moc.h>
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
+#include <QLabel>
 #include <QLineEdit>
 #include <QModelIndex>
 
@@ -43,10 +44,18 @@ protected:
 protected:
   void UpdateThumbnail(const ezUuid& guid, const char* szThumbnailPath);
 
+  /// Shows or hides the warning icon next to the asset reference field.
+  ///
+  /// bValueEmpty is whether the referenced text is empty; bValueValid is whether a non-empty text
+  /// resolved to a valid asset GUID. The icon is shown if the property is required and empty, or
+  /// if it is non-empty but doesn't reference a valid asset (regardless of whether it is required).
+  void UpdateRequiredIndicator(bool bValueEmpty, bool bValueValid);
+
   QPalette m_Pal;
   QHBoxLayout* m_pLayout;
   ezQtAssetLineEdit* m_pWidget;
   QToolButton* m_pButton;
+  QLabel* m_pWarningIcon;
   ezUInt32 m_uiThumbnailID;
   ezUuid m_AssetGuid;
 };

--- a/Code/Editor/EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
+#include <QLabel>
 #include <QLineEdit>
 
 class ezQtFileLineEdit;
@@ -32,9 +33,13 @@ protected:
   virtual void InternalSetValue(const ezVariant& value) override;
 
 protected:
+  void UpdateRequiredIndicator(bool bValueEmpty);
+
+protected:
   QHBoxLayout* m_pLayout = nullptr;
   ezQtFileLineEdit* m_pWidget = nullptr;
   QToolButton* m_pButton = nullptr;
+  QLabel* m_pWarningIcon = nullptr;
 };
 
 class EZ_EDITORFRAMEWORK_DLL ezQtExternalFilePropertyWidget : public ezQtStandardPropertyWidget

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -42,7 +42,13 @@ ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
 
   connect(pMenu, &QMenu::aboutToShow, this, &ezQtAssetPropertyWidget::OnShowMenu);
 
-  m_pLayout->addWidget(m_pWidget);
+  m_pWarningIcon = new QLabel(this);
+  m_pWarningIcon->setPixmap(ezQtUiServices::GetCachedIconResource(":/GuiFoundation/Icons/Warning.svg").pixmap(16, 16));
+  m_pWarningIcon->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  m_pWarningIcon->setVisible(false);
+
+  m_pLayout->addWidget(m_pWidget, 1);
+  m_pLayout->addWidget(m_pWarningIcon);
   m_pLayout->addWidget(m_pButton);
 
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageLoaded, this, &ezQtAssetPropertyWidget::ThumbnailLoaded) != nullptr, "signal/slot connection failed");
@@ -138,6 +144,19 @@ void ezQtAssetPropertyWidget::UpdateThumbnail(const ezUuid& guid, const char* sz
   }
 }
 
+void ezQtAssetPropertyWidget::UpdateRequiredIndicator(bool bValueEmpty, bool bValueValid)
+{
+  const bool bRequired = m_pProp->GetAttributeByType<ezRequiredAttribute>() != nullptr;
+  const bool bShow = (bRequired && bValueEmpty) || (!bValueEmpty && !bValueValid);
+
+  m_pWarningIcon->setVisible(bShow);
+
+  if (bShow)
+  {
+    m_pWarningIcon->setToolTip(bValueEmpty ? QStringLiteral("This property is required and must reference a valid asset.") : QStringLiteral("The selected file is not a valid asset."));
+  }
+}
+
 void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
 {
   ezQtScopedBlockSignals b(m_pWidget);
@@ -146,6 +165,7 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
   if (!value.IsValid())
   {
     m_pWidget->setPlaceholderText(QStringLiteral("<Multiple Values>"));
+    m_pWarningIcon->setVisible(false);
   }
   else
   {
@@ -167,6 +187,8 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
         m_Pal.setColor(QPalette::Active, QPalette::Text, Qt::red);
         m_Pal.setColor(QPalette::Inactive, QPalette::Text, Qt::red);
         m_pWidget->setPalette(m_Pal);
+
+        UpdateRequiredIndicator(false, false);
 
         return;
       }
@@ -224,6 +246,8 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
 
     m_pWidget->setPlaceholderText(QString());
     m_pWidget->setText(QString::fromUtf8(sText.GetData()));
+
+    UpdateRequiredIndicator(sText.IsEmpty(), m_AssetGuid.IsValid());
   }
 }
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -48,8 +48,8 @@ ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
   m_pWarningIcon->setVisible(false);
 
   m_pLayout->addWidget(m_pWidget, 1);
-  m_pLayout->addWidget(m_pWarningIcon);
   m_pLayout->addWidget(m_pButton);
+  m_pLayout->addWidget(m_pWarningIcon);
 
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageLoaded, this, &ezQtAssetPropertyWidget::ThumbnailLoaded) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/FileBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/FileBrowserPropertyWidget.cpp
@@ -46,8 +46,21 @@ ezQtFilePropertyWidget::ezQtFilePropertyWidget()
     m_pButton->setMenu(pMenu);
   }
 
+  m_pWarningIcon = new QLabel(this);
+  m_pWarningIcon->setPixmap(ezQtUiServices::GetCachedIconResource(":/GuiFoundation/Icons/Warning.svg").pixmap(16, 16));
+  m_pWarningIcon->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  m_pWarningIcon->setVisible(false);
+  m_pWarningIcon->setToolTip(QStringLiteral("This property is required and must reference a file."));
+
   m_pLayout->addWidget(m_pWidget);
   m_pLayout->addWidget(m_pButton);
+  m_pLayout->addWidget(m_pWarningIcon);
+}
+
+void ezQtFilePropertyWidget::UpdateRequiredIndicator(bool bValueEmpty)
+{
+  const bool bRequired = m_pProp->GetAttributeByType<ezRequiredAttribute>() != nullptr;
+  m_pWarningIcon->setVisible(bRequired && bValueEmpty);
 }
 
 bool ezQtFilePropertyWidget::IsValidFileReference(ezStringView sFile) const
@@ -96,6 +109,7 @@ void ezQtFilePropertyWidget::InternalSetValue(const ezVariant& value)
   if (!value.IsValid())
   {
     m_pWidget->setPlaceholderText(QStringLiteral("<Multiple Values>"));
+    m_pWarningIcon->setVisible(false);
   }
   else
   {
@@ -103,12 +117,16 @@ void ezQtFilePropertyWidget::InternalSetValue(const ezVariant& value)
 
     m_pWidget->setPlaceholderText(QString());
     m_pWidget->setText(QString::fromUtf8(sText.GetData()));
+
+    UpdateRequiredIndicator(sText.IsEmpty());
   }
 }
 
 void ezQtFilePropertyWidget::on_TextFinished_triggered()
 {
   ezStringBuilder sText = m_pWidget->text().toUtf8().data();
+
+  UpdateRequiredIndicator(sText.IsEmpty());
 
   BroadcastValueChanged(sText.GetData());
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
@@ -9,7 +9,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetProperties, 4, ezRTTIDefaultA
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations)),
+    EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("MeshIncludeTags", m_sMeshIncludeTags),
     EZ_MEMBER_PROPERTY("MeshExcludeTags", m_sMeshExcludeTags)->AddAttributes(new ezDefaultValueAttribute("$;UCX_")),
     EZ_MEMBER_PROPERTY("DefaultSkeleton", m_sDefaultSkeleton)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skeleton"), new ezRequiredAttribute()),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetProperties, 4, ezRTTIDefaultA
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations)),
     EZ_MEMBER_PROPERTY("MeshIncludeTags", m_sMeshIncludeTags),
     EZ_MEMBER_PROPERTY("MeshExcludeTags", m_sMeshExcludeTags)->AddAttributes(new ezDefaultValueAttribute("$;UCX_")),
-    EZ_MEMBER_PROPERTY("DefaultSkeleton", m_sDefaultSkeleton)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skeleton")),
+    EZ_MEMBER_PROPERTY("DefaultSkeleton", m_sDefaultSkeleton)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skeleton"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("RecalculateNormals", m_bRecalculateNormals),
     EZ_MEMBER_PROPERTY("RecalculateTangents", m_bRecalculateTangents)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("HighPrecision", m_bHighPrecision),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -36,7 +36,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 4, ezRTTIDefault
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Animation", ezFileBrowserAttribute::MeshesWithAnimations)),
+    EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Animation", ezFileBrowserAttribute::MeshesWithAnimations), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("PreviewMesh", m_sPreviewMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned", ezDependencyFlags::Thumbnail)),
     EZ_MEMBER_PROPERTY("UseAnimationClip", m_sAnimationClipToExtract),
     EZ_MEMBER_PROPERTY("FirstFrame", m_uiFirstFrame),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
@@ -10,7 +10,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCollectionAssetEntry, 1, ezRTTIDefaultAllocato
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Name", m_sLookupName),
-    EZ_MEMBER_PROPERTY("Asset", m_sRedirectionAsset)->AddAttributes(new ezAssetBrowserAttribute("", "*", ezDependencyFlags::Package))
+    EZ_MEMBER_PROPERTY("Asset", m_sRedirectionAsset)->AddAttributes(new ezAssetBrowserAttribute("", "*", ezDependencyFlags::Package), new ezRequiredAttribute())
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -21,7 +21,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDecalAssetProperties, 3, ezRTTIDefaultAllocato
     EZ_ENUM_MEMBER_PROPERTY("Mode", ezDecalMode, m_Mode),
     EZ_MEMBER_PROPERTY("BlendModeColorize", m_bBlendModeColorize),
     EZ_MEMBER_PROPERTY("AlphaMask", m_sAlphaMask)->AddAttributes(new ezFileBrowserAttribute("Select Alpha Mask", ezFileBrowserAttribute::ImagesLdrOnly)),
-    EZ_MEMBER_PROPERTY("BaseColor", m_sBaseColor)->AddAttributes(new ezFileBrowserAttribute("Select Base Color Map", ezFileBrowserAttribute::ImagesLdrOnly)),
+    EZ_MEMBER_PROPERTY("BaseColor", m_sBaseColor)->AddAttributes(new ezFileBrowserAttribute("Select Base Color Map", ezFileBrowserAttribute::ImagesLdrOnly), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Normal", m_sNormal)->AddAttributes(new ezFileBrowserAttribute("Select Normal Map", ezFileBrowserAttribute::ImagesLdrOnly), new ezDefaultValueAttribute(ezStringView("Textures/NeutralNormal.tga"))), // wrap in ezStringView to prevent a memory leak report
     EZ_MEMBER_PROPERTY("ORM", m_sORM)->AddAttributes(new ezFileBrowserAttribute("Select ORM Map", ezFileBrowserAttribute::ImagesLdrOnly)),
     EZ_MEMBER_PROPERTY("Emissive", m_sEmissive)->AddAttributes(new ezFileBrowserAttribute("Select Emissive Map", ezFileBrowserAttribute::ImagesLdrOnly)),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetObjects.cpp
@@ -7,7 +7,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezImageDataAssetProperties, 1, ezRTTIDefaultAllo
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Input", m_sInputFile)->AddAttributes(new ezFileBrowserAttribute("Select Image", ezFileBrowserAttribute::ImagesLdrAndHdr))
+    EZ_MEMBER_PROPERTY("Input", m_sInputFile)->AddAttributes(new ezFileBrowserAttribute("Select Image", ezFileBrowserAttribute::ImagesLdrAndHdr), new ezRequiredAttribute())
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetObjects.cpp
@@ -7,7 +7,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezLUTAssetProperties, 1, ezRTTIDefaultAllocator<
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Input", GetInputFile, SetInputFile)->AddAttributes(new ezFileBrowserAttribute("Select CUBE file", "*.cube")),
+    EZ_ACCESSOR_PROPERTY("Input", GetInputFile, SetInputFile)->AddAttributes(new ezFileBrowserAttribute("Select CUBE file", "*.cube"), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetObjects.cpp
@@ -23,7 +23,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureCubeAssetProperties, 3, ezRTTIDefaultAl
 
     EZ_ENUM_MEMBER_PROPERTY("ChannelMapping", ezTextureCubeChannelMappingEnum, m_ChannelMapping),
 
-    EZ_ACCESSOR_PROPERTY("Input1", GetInputFile0, SetInputFile0)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
+    EZ_ACCESSOR_PROPERTY("Input1", GetInputFile0, SetInputFile0)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("Input2", GetInputFile1, SetInputFile1)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
     EZ_ACCESSOR_PROPERTY("Input3", GetInputFile2, SetInputFile2)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
     EZ_ACCESSOR_PROPERTY("Input4", GetInputFile3, SetInputFile3)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/AssetUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/AssetUtils.cpp
@@ -8,7 +8,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezMaterialResourceSlot, ezNoBase, 1, ezRTTIDefaul
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Label", m_sLabel)->AddAttributes(new ezReadOnlyAttribute()),
-    EZ_MEMBER_PROPERTY("Resource", m_sResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+    EZ_MEMBER_PROPERTY("Resource", m_sResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Highlight", m_bHighlight)->AddAttributes(new ezTemporaryAttribute()),
   }
   EZ_END_PROPERTIES;

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.cpp
@@ -11,7 +11,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSoundBankAssetProperties, 1, ezRTTIDefaultAllo
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("SoundBankFile", m_sSoundBank)->AddAttributes(new ezFileBrowserAttribute("Select SoundBank", "*.bank")),
+    EZ_MEMBER_PROPERTY("SoundBankFile", m_sSoundBank)->AddAttributes(new ezFileBrowserAttribute("Select SoundBank", "*.bank"), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -45,7 +45,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 3, ezRTTIDef
     EZ_MEMBER_PROPERTY("Radius2", m_fRadius2)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_MEMBER_PROPERTY("Height", m_fHeight)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_MEMBER_PROPERTY("Detail", m_uiDetail)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(0, 32)),
-    EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes)),
+    EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("MeshIncludeTags", m_sMeshIncludeTags),
     EZ_MEMBER_PROPERTY("MeshExcludeTags", m_sMeshExcludeTags),
     EZ_ARRAY_MEMBER_PROPERTY("Surfaces", m_Slots)->AddAttributes(new ezContainerAttribute(false, false, true)),

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetObjects.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetObjects.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezKrautAssetMaterial, ezNoBase, 1, ezRTTIDefaultA
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Label", m_sLabel)->AddAttributes(new ezReadOnlyAttribute()),
-    EZ_MEMBER_PROPERTY("Material", m_sMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "Kraut")),
+    EZ_MEMBER_PROPERTY("Material", m_sMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "Kraut"), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/MiniAudio/EditorPluginMiniAudio/SoundAsset/MiniAudioSoundAsset.cpp
+++ b/Code/EditorPlugins/MiniAudio/EditorPluginMiniAudio/SoundAsset/MiniAudioSoundAsset.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMiniAudioSoundAssetProperties, 1, ezRTTIDefaul
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ARRAY_MEMBER_PROPERTY("Files", m_SoundFiles)->AddAttributes(new ezFileBrowserAttribute("Select Sound", "*.wav;*.mp3")),
+    EZ_ARRAY_MEMBER_PROPERTY("Files", m_SoundFiles)->AddAttributes(new ezFileBrowserAttribute("Select Sound", "*.wav;*.mp3"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Group", m_sGroup)->AddAttributes(new ezDynamicStringEnumAttribute("MiniAudioSoundGroups")),
     EZ_MEMBER_PROPERTY("Loop", m_bLoop),
     EZ_MEMBER_PROPERTY("MinRandomVolume", m_fMinVolume)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.1f, 10.0f)),

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetObjects.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetObjects.cpp
@@ -7,7 +7,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRmlUiAssetProperties, 1, ezRTTIDefaultAllocato
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("RmlFile", m_sRmlFile)->AddAttributes(new ezFileBrowserAttribute("Select Rml file", "*.rml", {}, "RmlUI", ezDependencyFlags::Package | ezDependencyFlags::Thumbnail | ezDependencyFlags::Transform)),
+    EZ_MEMBER_PROPERTY("RmlFile", m_sRmlFile)->AddAttributes(new ezFileBrowserAttribute("Select Rml file", "*.rml", {}, "RmlUI", ezDependencyFlags::Package | ezDependencyFlags::Thumbnail | ezDependencyFlags::Transform), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("ScaleMode", ezRmlUiScaleMode, m_ScaleMode),
     EZ_MEMBER_PROPERTY("ReferenceResolution", m_ReferenceResolution)->AddAttributes(new ezDefaultValueAttribute(ezVec2U32(1920, 1080))),
   }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
@@ -116,11 +116,13 @@ ezStatus ezSceneObjectManager::InternalCanMove(
 
 ezStatus ezSceneObjectManager::InternalCanSelect(const ezDocumentObject* pObject) const
 {
-  /*if (pObject->GetTypeAccessor().GetType() != ezGetStaticRTTI<ezGameObject>())
+  // Components etc. aren't selectable on their own; callers (e.g. ezQtEditorApp's object-reference
+  // navigation) walk up to the owning ezGameObject instead when this fails.
+  if (pObject->GetTypeAccessor().GetType() != ezGetStaticRTTI<ezGameObject>())
   {
     return ezStatus(
       ezFmt("Object of type '{0}' is not a 'ezGameObject' and can't be selected.", pObject->GetTypeAccessor().GetType()->GetTypeName()));
-  }*/
+  }
   return ezStatus(EZ_SUCCESS);
 }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
@@ -3,6 +3,7 @@
 #include "Foundation/Serialization/GraphPatch.h"
 #include <Core/World/GameObject.h>
 #include <EditorPluginScene/Objects/SceneObjectManager.h>
+#include <EditorPluginScene/Scene/Scene2Document.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneDocumentSettingsBase, 1, ezRTTINoAllocator)
@@ -116,14 +117,18 @@ ezStatus ezSceneObjectManager::InternalCanMove(
 
 ezStatus ezSceneObjectManager::InternalCanSelect(const ezDocumentObject* pObject) const
 {
-  // Components etc. aren't selectable on their own; callers (e.g. ezQtEditorApp's object-reference
-  // navigation) walk up to the owning ezGameObject instead when this fails.
-  if (pObject->GetTypeAccessor().GetType() != ezGetStaticRTTI<ezGameObject>())
-  {
-    return ezStatus(
-      ezFmt("Object of type '{0}' is not a 'ezGameObject' and can't be selected.", pObject->GetTypeAccessor().GetType()->GetTypeName()));
-  }
-  return ezStatus(EZ_SUCCESS);
+  const ezRTTI* pRtti = pObject->GetTypeAccessor().GetType();
+
+  if (pRtti == ezGetStaticRTTI<ezGameObject>())
+    return ezStatus(EZ_SUCCESS);
+
+  if (pRtti == ezGetStaticRTTI<ezSceneLayer>())
+    return ezStatus(EZ_SUCCESS);
+
+  if (pRtti == ezGetStaticRTTI<ezPrefabDocumentSettings>())
+    return ezStatus(EZ_SUCCESS);
+
+  return ezStatus(ezFmt("Object of type '{0}' is not a 'ezGameObject' and can't be selected.", pObject->GetTypeAccessor().GetType()->GetTypeName()));
 }
 
 namespace

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -630,7 +630,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSubstancePackageAssetProperties, 1, ezRTTIDefa
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("SubstanceFile", m_sSubstancePackage)->AddAttributes(new ezFileBrowserAttribute("Select Substance File", "*.sbs")),
+    EZ_MEMBER_PROPERTY("SubstanceFile", m_sSubstancePackage)->AddAttributes(new ezFileBrowserAttribute("Select Substance File", "*.sbs"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("OutputPattern", m_sOutputPattern)->AddAttributes(new ezDefaultValueAttribute(ezStringView("$(graph)_$(label)"))),
     EZ_ARRAY_MEMBER_PROPERTY("Graphs", m_Graphs)
   }

--- a/Code/Engine/Core/Collection/Implementation/CollectionComponent.cpp
+++ b/Code/Engine/Core/Collection/Implementation/CollectionComponent.cpp
@@ -9,7 +9,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezCollectionComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Collection", GetCollection, SetCollection)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_AssetCollection", ezDependencyFlags::Package)),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Collection", GetCollection, SetCollection)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_AssetCollection", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("RegisterNames", m_bRegisterNames),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/Core/Physics/Implementation/SurfaceResourceDescriptor.cpp
+++ b/Code/Engine/Core/Physics/Implementation/SurfaceResourceDescriptor.cpp
@@ -15,7 +15,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezSurfaceInteraction, ezNoBase, 1, ezRTTIDefaultA
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Type", m_sInteractionType)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum")),
-    EZ_RESOURCE_MEMBER_PROPERTY("Prefab", m_hPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
+    EZ_RESOURCE_MEMBER_PROPERTY("Prefab", m_hPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Prefab")),
     EZ_ENUM_MEMBER_PROPERTY("Alignment", ezSurfaceInteractionAlignment, m_Alignment),
     EZ_MEMBER_PROPERTY("Deviation", m_Deviation)->AddAttributes(new ezClampValueAttribute(ezVariant(ezAngle::MakeFromDegree(0.0f)), ezVariant(ezAngle::MakeFromDegree(90.0f)))),

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -8,7 +8,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezPrefabReferenceComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Prefab", GetPrefab, SetPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Prefab", GetPrefab, SetPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("ShowShapeIcons", GetShowShapeIcons, SetShowShapeIcons),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Prefab")),
   }

--- a/Code/Engine/Core/Scripting/Implementation/ScriptComponent.cpp
+++ b/Code/Engine/Core/Scripting/Implementation/ScriptComponent.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezScriptComponent, 2, ezComponentMode::Static)
   {
     EZ_ACCESSOR_PROPERTY("UpdateInterval", GetUpdateInterval, SetUpdateInterval)->AddAttributes(new ezClampValueAttribute(ezTime::MakeZero(), ezVariant())),
     EZ_ACCESSOR_PROPERTY("UpdateOnlyWhenSimulating", GetUpdateOnlyWhenSimulating, SetUpdateOnlyWhenSimulating)->AddAttributes(new ezDefaultValueAttribute(true)),
-    EZ_RESOURCE_ACCESSOR_PROPERTY("ScriptClass", GetScriptClass, SetScriptClass)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ScriptClass", ezDependencyFlags::Package)),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("ScriptClass", GetScriptClass, SetScriptClass)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ScriptClass", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("ScriptClass")),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -12,6 +12,9 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezHiddenAttribute, 1, ezRTTIDefaultAllocator<ezHiddenAttribute>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRequiredAttribute, 1, ezRTTIDefaultAllocator<ezRequiredAttribute>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTemporaryAttribute, 1, ezRTTIDefaultAllocator<ezTemporaryAttribute>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -24,6 +24,13 @@ class EZ_FOUNDATION_DLL ezHiddenAttribute : public ezPropertyAttribute
   EZ_ADD_DYNAMIC_REFLECTION(ezHiddenAttribute, ezPropertyAttribute);
 };
 
+/// \brief Marks a property as required. Asset check rules flag the property as an error if it is left empty
+/// (e.g. an empty string, or an empty/invalid game object or component reference).
+class EZ_FOUNDATION_DLL ezRequiredAttribute : public ezPropertyAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezRequiredAttribute, ezPropertyAttribute);
+};
+
 /// \brief A property attribute that indicates that the property is not to be serialized
 /// and whatever it points to only exists temporarily while running or in editor.
 class EZ_FOUNDATION_DLL ezTemporaryAttribute : public ezPropertyAttribute

--- a/Code/Engine/GameEngine/Animation/Implementation/ColorAnimationComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Implementation/ColorAnimationComponent.cpp
@@ -10,7 +10,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezColorAnimationComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Gradient", GetColorGradient, SetColorGradient)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_Gradient")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Gradient", GetColorGradient, SetColorGradient)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_Gradient"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Duration", m_Duration),
     EZ_ENUM_MEMBER_PROPERTY("SetColorMode", ezSetColorMode, m_SetColorMode),
     EZ_ENUM_MEMBER_PROPERTY("AnimationMode", ezPropertyAnimMode, m_AnimationMode),

--- a/Code/Engine/GameEngine/Animation/Implementation/PropertyAnimComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Implementation/PropertyAnimComponent.cpp
@@ -15,7 +15,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezPropertyAnimComponent, 3, ezComponentMode::Dynamic)
   {
     EZ_BEGIN_PROPERTIES
     {
-      EZ_RESOURCE_MEMBER_PROPERTY("Animation", m_hPropertyAnim)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Property_Animation")),
+      EZ_RESOURCE_MEMBER_PROPERTY("Animation", m_hPropertyAnim)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Property_Animation"), new ezRequiredAttribute()),
       EZ_MEMBER_PROPERTY("Playing", m_bPlaying)->AddAttributes(new ezDefaultValueAttribute(true)),
       EZ_ENUM_MEMBER_PROPERTY("Mode", ezPropertyAnimMode, m_AnimationMode),
       EZ_MEMBER_PROPERTY("RandomOffset", m_RandomOffset)->AddAttributes(new ezClampValueAttribute(ezTime::MakeFromSeconds(0), ezVariant())),

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
@@ -20,7 +20,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezAnimatedMeshComponent, 13, ezComponentMode::Static);
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Mesh", GetMesh, SetMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Mesh", GetMesh, SetMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_ACCESSOR_PROPERTY("CustomData", GetCustomData, SetCustomData)->AddAttributes(new ezDefaultValueAttribute(ezVec4(0, 1, 0, 1))),
     EZ_ARRAY_ACCESSOR_PROPERTY("Materials", Materials_GetCount, Materials_GetValue, Materials_SetValue, Materials_Insert, Materials_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimationControllerComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimationControllerComponent.cpp
@@ -16,7 +16,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezAnimationControllerComponent, 4, ezComponentMode::Stat
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("AnimGraph", m_hAnimGraph)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Keyframe_Graph")),
+    EZ_RESOURCE_MEMBER_PROPERTY("AnimGraph", m_hAnimGraph)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Keyframe_Graph"), new ezRequiredAttribute()),
 
     EZ_ENUM_MEMBER_PROPERTY("RootMotionMode", ezRootMotionMode, m_RootMotionMode),
     EZ_ENUM_MEMBER_PROPERTY("InvisibleUpdateRate", ezAnimationInvisibleUpdateRate, m_InvisibleUpdateRate),

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -19,7 +19,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezLodAnimatedMeshLod, ezNoBase, 2, ezRTTIDefaultA
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Mesh", m_hMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Mesh", m_hMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Threshold", m_fThreshold)
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
@@ -22,7 +22,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSimpleAnimationComponent, 3, ezComponentMode::Static);
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("AnimationClip", m_hAnimationClip)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Keyframe_Animation")),
+    EZ_RESOURCE_MEMBER_PROPERTY("AnimationClip", m_hAnimationClip)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Keyframe_Animation"), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("AnimationMode", ezPropertyAnimMode, m_AnimationMode),
     EZ_MEMBER_PROPERTY("Speed", m_fSpeed)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_ENUM_MEMBER_PROPERTY("RootMotionMode", ezRootMotionMode, m_RootMotionMode),

--- a/Code/Engine/GameEngine/Configuration/Implementation/RendererProfileConfigs.cpp
+++ b/Code/Engine/GameEngine/Configuration/Implementation/RendererProfileConfigs.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRenderPipelineProfileConfig, 1, ezRTTIDefaultA
   EZ_BEGIN_PROPERTIES
   {
     // MainRenderPipeline.ezRenderPipelineAsset
-    EZ_MEMBER_PROPERTY("MainRenderPipeline", m_sMainRenderPipeline)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_RenderPipeline"), new ezDefaultValueAttribute(ezStringView("{ c533e113-2a4c-4f42-a546-653c78f5e8a7 }"))),
+    EZ_MEMBER_PROPERTY("MainRenderPipeline", m_sMainRenderPipeline)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_RenderPipeline"), new ezDefaultValueAttribute(ezStringView("{ c533e113-2a4c-4f42-a546-653c78f5e8a7 }")), new ezRequiredAttribute()),
     // EditorRenderPipeline.ezRenderPipelineAsset
     //EZ_MEMBER_PROPERTY("EditorRenderPipeline", m_sEditorRenderPipeline)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_RenderPipeline"), new ezDefaultValueAttribute(ezStringView("{ da463c4d-c984-4910-b0b7-a0b3891d0448 }"))),
     // DebugRenderPipeline.ezRenderPipelineAsset

--- a/Code/Engine/GameEngine/Gameplay/Implementation/SceneTransitionComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/SceneTransitionComponent.cpp
@@ -21,7 +21,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSceneTransitionComponent, 1 /* version */, ezComponent
   EZ_BEGIN_PROPERTIES
   {
     EZ_ENUM_MEMBER_PROPERTY("Mode", ezSceneLoadMode, m_Mode),
-    EZ_MEMBER_PROPERTY("TargetScene", m_sTargetScene)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Scene",  ezDependencyFlags::Package)),
+    EZ_MEMBER_PROPERTY("TargetScene", m_sTargetScene)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Scene",  ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("PreloadCollection", m_sPreloadCollectionFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_AssetCollection", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("SpawnPoint", m_sSpawnPoint),
     EZ_MEMBER_PROPERTY("RelativeSpawnPosition", m_bRelativeSpawnPosition)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/Engine/GameEngine/Gameplay/Implementation/SpawnBoxComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/SpawnBoxComponent.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSpawnBoxComponent, 1, ezComponentMode::Dynamic)
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("HalfExtents", GetHalfExtents, SetHalfExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(2.0f, 2.0f, 0.25f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
-    EZ_RESOURCE_MEMBER_PROPERTY("Prefab", m_hPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
+    EZ_RESOURCE_MEMBER_PROPERTY("Prefab", m_hPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("SpawnAtStart", GetSpawnAtStart, SetSpawnAtStart),
     EZ_ACCESSOR_PROPERTY("SpawnContinuously", GetSpawnContinuously, SetSpawnContinuously),
     EZ_MEMBER_PROPERTY("MinSpawnCount", m_uiMinSpawnCount)->AddAttributes(new ezDefaultValueAttribute(10)),

--- a/Code/Engine/GameEngine/Gameplay/Implementation/SpawnComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/SpawnComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSpawnComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Prefab", m_hPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
+    EZ_RESOURCE_MEMBER_PROPERTY("Prefab", m_hPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Prefab")),
     EZ_ACCESSOR_PROPERTY("AttachAsChild", GetAttachAsChild, SetAttachAsChild),
     EZ_ACCESSOR_PROPERTY("SpawnAtStart", GetSpawnAtStart, SetSpawnAtStart),

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
@@ -8,7 +8,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineState_NestedStateMachine, 1, ezRTT
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Resource", GetResource, SetResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine", ezDependencyFlags::Package)),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Resource", GetResource, SetResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("InitialState", GetInitialState, SetInitialState),
     EZ_MEMBER_PROPERTY("KeepCurrentStateOnExit", m_bKeepCurrentStateOnExit),
   }

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineComponent.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineComponent.cpp
@@ -238,7 +238,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezStateMachineComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Resource", GetResource, SetResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine", ezDependencyFlags::Package)),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Resource", GetResource, SetResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("InitialState", GetInitialState, SetInitialState),
     EZ_ACCESSOR_PROPERTY("BlackboardName", GetBlackboardName, SetBlackboardName)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardNamesEnum")),
   }

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineState_Script.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineState_Script.cpp
@@ -133,7 +133,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineState_Script, 1, ezRTTIDefaultAllo
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("ScriptClass", GetScriptClassFile, SetScriptClassFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ScriptClass")),
+    EZ_ACCESSOR_PROPERTY("ScriptClass", GetScriptClassFile, SetScriptClassFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ScriptClass"), new ezRequiredAttribute()),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("ScriptClass")),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimGraphResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimGraphResource.cpp
@@ -14,7 +14,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipMapping, 1, ezRTTIDefaultAllocato
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("ClipName", GetClipName, SetClipName)->AddAttributes(new ezDynamicStringEnumAttribute("AnimationClipMappingEnum")),
-    EZ_RESOURCE_MEMBER_PROPERTY("Clip", m_hClip)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Keyframe_Animation")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Clip", m_hClip)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Keyframe_Animation"), new ezRequiredAttribute()),
   }
     EZ_END_PROPERTIES;
 }

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
@@ -82,7 +82,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeleton, 2, ezRTTIDefaultAllocator<ez
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations)),
+    EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("ImportTransform", ezMeshImportTransform, m_ImportTransform),
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::NegativeX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
@@ -18,7 +18,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSkeletonPoseComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Skeleton", GetSkeleton, SetSkeleton)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skeleton")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Skeleton", GetSkeleton, SetSkeleton)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skeleton"), new ezRequiredAttribute()),
     EZ_ENUM_ACCESSOR_PROPERTY("Mode", ezSkeletonPoseMode, GetPoseMode, SetPoseMode),
     EZ_MEMBER_PROPERTY("EditBones", m_fDummy),
     EZ_MAP_ACCESSOR_PROPERTY("Bones", GetBones, GetBone, SetBone, RemoveBone)->AddAttributes(new ezExposedParametersAttribute("Skeleton"), new ezContainerAttribute(false, true, false)),

--- a/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
@@ -18,7 +18,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezBeamComponent, 1, ezComponentMode::Static)
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("TargetObject", DummyGetter, SetTargetObject)->AddAttributes(new ezGameObjectReferenceAttribute()),
-    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Color", m_Color)->AddAttributes(new ezDefaultValueAttribute(ezColor::White)),
     EZ_ACCESSOR_PROPERTY("Width", GetWidth, SetWidth)->AddAttributes(new ezDefaultValueAttribute(0.1f), new ezClampValueAttribute(0.001f, ezVariant()), new ezSuffixAttribute(" m")),
     EZ_ACCESSOR_PROPERTY("UVUnitsPerWorldUnit", GetUVUnitsPerWorldUnit, SetUVUnitsPerWorldUnit)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.01f, ezVariant())),

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
@@ -38,7 +38,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezLensFlareElement, ezNoBase, 1, ezRTTIDefaultAll
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Texture", m_hTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Texture", m_hTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("GreyscaleTexture", m_bGreyscaleTexture),
     EZ_MEMBER_PROPERTY("Color", m_Color)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_MEMBER_PROPERTY("ModulateByLightColor", m_bModulateByLightColor)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/Engine/RendererCore/Components/Implementation/RenderTargetActivatorComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RenderTargetActivatorComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezRenderTargetActivatorComponent, 1, ezComponentMode::St
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("RenderTarget", GetRenderTarget, SetRenderTarget)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Target", ezDependencyFlags::Package)),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("RenderTarget", GetRenderTarget, SetRenderTarget)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Target", ezDependencyFlags::Package), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_ATTRIBUTES

--- a/Code/Engine/RendererCore/Components/Implementation/SkyBoxComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SkyBoxComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSkyBoxComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("CubeMap", GetCubeMap, SetCubeMap)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Cube")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("CubeMap", GetCubeMap, SetCubeMap)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Cube"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("ExposureBias", GetExposureBias, SetExposureBias)->AddAttributes(new ezClampValueAttribute(-32.0f, 32.0f)),
     EZ_ACCESSOR_PROPERTY("InverseTonemap", GetInverseTonemap, SetInverseTonemap),
     EZ_ACCESSOR_PROPERTY("UseFog", GetUseFog, SetUseFog)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/Engine/RendererCore/Components/Implementation/SpriteComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SpriteComponent.cpp
@@ -60,7 +60,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSpriteComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Texture", GetTexture, SetTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Texture", GetTexture, SetTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D"), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("BlendMode", ezSpriteBlendMode, m_BlendMode),
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_ACCESSOR_PROPERTY("Size", GetSize, SetSize)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f), new ezSuffixAttribute(" m")),

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalComponent.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalComponent.cpp
@@ -27,7 +27,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezDecalComponent, 8, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ARRAY_ACCESSOR_PROPERTY("Decals", DecalFile_GetCount, DecalFile_Get, DecalFile_Set, DecalFile_Insert, DecalFile_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Decal")),
+    EZ_ARRAY_ACCESSOR_PROPERTY("Decals", DecalFile_GetCount, DecalFile_Get, DecalFile_Set, DecalFile_Insert, DecalFile_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Decal"), new ezRequiredAttribute()),
     EZ_ENUM_ACCESSOR_PROPERTY("ProjectionAxis", ezBasisAxis, GetProjectionAxis, SetProjectionAxis),
     EZ_ACCESSOR_PROPERTY("Extents", GetExtents, SetExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(1.0f)), new ezClampValueAttribute(ezVec3(0.01f), ezVariant(25.0f))),
     EZ_ACCESSOR_PROPERTY("SizeVariance", GetSizeVariance, SetSizeVariance)->AddAttributes(new ezClampValueAttribute(0.0f, 1.0f)),

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -48,7 +48,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezCustomMeshComponent, 3, ezComponentMode::Static)
   {
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_ACCESSOR_PROPERTY("CustomData", GetCustomData, SetCustomData)->AddAttributes(new ezDefaultValueAttribute(ezVec4(0, 1, 0, 1))),
-    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS

--- a/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
@@ -85,7 +85,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezInstancedMeshComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Mesh", GetMesh, SetMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Mesh", GetMesh, SetMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("MainColor", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_ACCESSOR_PROPERTY("CustomData", GetCustomData, SetCustomData)->AddAttributes(new ezDefaultValueAttribute(ezVec4(0, 1, 0, 1))),
     EZ_ARRAY_ACCESSOR_PROPERTY("Materials", Materials_GetCount, Materials_GetValue, Materials_SetValue, Materials_Insert, Materials_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),

--- a/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezLodMeshLod, ezNoBase, 2, ezRTTIDefaultAllocator
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Mesh", m_hMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Mesh", m_hMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Threshold", m_fThreshold)
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponent.cpp
@@ -10,7 +10,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezMeshComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Mesh", GetMesh, SetMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Mesh", GetMesh, SetMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_ACCESSOR_PROPERTY("CustomData", GetCustomData, SetCustomData)->AddAttributes(new ezDefaultValueAttribute(ezVec4(0, 1, 0, 1))),
     EZ_ARRAY_ACCESSOR_PROPERTY("Materials", Materials_GetCount, Materials_GetValue, Materials_SetValue, Materials_Insert, Materials_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -242,7 +242,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezFmodEventComponent, 4, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("Volume", GetVolume, SetVolume)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("Pitch", GetPitch, SetPitch)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.1f, 10.0f)),
     EZ_ACCESSOR_PROPERTY("NoGlobalPitch", GetNoGlobalPitch, SetNoGlobalPitch),
-    EZ_RESOURCE_ACCESSOR_PROPERTY("SoundEvent", GetSoundEvent, SetSoundEvent)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Fmod_Event", ezDependencyFlags::Package)),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("SoundEvent", GetSoundEvent, SetSoundEvent)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Fmod_Event", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("UseOcclusion", GetUseOcclusion, SetUseOcclusion),
     EZ_ACCESSOR_PROPERTY("OcclusionThreshold", GetOcclusionThreshold, SetOcclusionThreshold)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("OcclusionCollisionLayer", GetOcclusionCollisionLayer, SetOcclusionCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -28,7 +28,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProjectileSurfaceInteraction, ezNoBase, 3, ezRT
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Surface", m_hSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
+    EZ_RESOURCE_MEMBER_PROPERTY("Surface", m_hSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("Reaction", ezProjectileReaction, m_Reaction),
     EZ_MEMBER_PROPERTY("Interaction", m_sInteraction)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum")),
     EZ_MEMBER_PROPERTY("ImpulseType", m_uiImpulseType)->AddAttributes(new ezDynamicEnumAttribute("PhysicsImpulseType")),

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -32,7 +32,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezClothSheetComponent, 1, ezComponentMode::Static)
       EZ_MEMBER_PROPERTY("Damping", m_fDamping)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
       EZ_MEMBER_PROPERTY("WindInfluence", m_fWindInfluence)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 10.0f)),
       EZ_BITFLAGS_ACCESSOR_PROPERTY("Flags", ezClothSheetFlags, GetFlags, SetFlags),
-      EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+      EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
       EZ_MEMBER_PROPERTY("Color", m_Color)->AddAttributes(new ezDefaultValueAttribute(ezColor::White)),
     }
     EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/GameComponentsPlugin/Placement/Implementation/RandomPrefabComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Placement/Implementation/RandomPrefabComponent.cpp
@@ -83,7 +83,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezRandomPrefabComponent, 1, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("MaxScale", GetMaxUniformScale, SetMaxUniformScale)->AddAttributes(new ezGroupAttribute("Random Transform"), new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.01f, 100.0f)),
     EZ_ACCESSOR_PROPERTY("Color1", GetColor1, SetColor1)->AddAttributes(new ezExposeColorAlphaAttribute(), new ezGroupAttribute("Random Color")),
     EZ_ACCESSOR_PROPERTY("Color2", GetColor2, SetColor2)->AddAttributes(new ezExposeColorAlphaAttribute(), new ezGroupAttribute("Random Color")),
-    EZ_ARRAY_ACCESSOR_PROPERTY("Prefabs", Prefabs_GetCount, Prefabs_GetValue, Prefabs_SetValue, Prefabs_Insert, Prefabs_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ARRAY_ACCESSOR_PROPERTY("Prefabs", Prefabs_GetCount, Prefabs_GetValue, Prefabs_SetValue, Prefabs_Insert, Prefabs_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab"), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
@@ -21,8 +21,8 @@ EZ_BEGIN_COMPONENT_TYPE(ezHeightfieldComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("HeightfieldImage", GetHeightfield, SetHeightfield)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_2D")),
-    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("HeightfieldImage", GetHeightfield, SetHeightfield)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_2D"), new ezRequiredAttribute()),
+    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("HalfExtents", GetHalfExtents, SetHalfExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec2(50))),
     EZ_ACCESSOR_PROPERTY("Height", GetHeight, SetHeight)->AddAttributes(new ezDefaultValueAttribute(50)),
     EZ_ACCESSOR_PROPERTY("Tesselation", GetTesselation, SetTesselation)->AddAttributes(new ezDefaultValueAttribute(ezVec2U32(128))),

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltBreakableSlabComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltBreakableSlabComponent.cpp
@@ -196,7 +196,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltBreakableSlabComponent, 1, ezComponentMode::Dynami
     EZ_ACCESSOR_PROPERTY("Width", GetWidth, SetWidth)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.1f, 8.0f), new ezSuffixAttribute(" m")),
     EZ_ACCESSOR_PROPERTY("Height", GetHeight, SetHeight)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.1f, 8.0f), new ezSuffixAttribute(" m")),
     EZ_ACCESSOR_PROPERTY("Thickness", GetThickness, SetThickness)->AddAttributes(new ezDefaultValueAttribute(0.02f), new ezClampValueAttribute(0.005f, 1.0f), new ezSuffixAttribute(" m")),
-    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("UVScale", GetUvScale, SetUvScale)->AddAttributes(new ezDefaultValueAttribute(ezVec2(1.0f))),
     EZ_MEMBER_PROPERTY("CollisionLayerStatic", m_uiCollisionLayerStatic)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("CollisionLayerDynamic", m_uiCollisionLayerDynamic)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltClothSheetComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltClothSheetComponent.cpp
@@ -37,7 +37,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltClothSheetComponent, 4, ezComponentMode::Static)
       EZ_MEMBER_PROPERTY("Damping", m_fDamping)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
       EZ_MEMBER_PROPERTY("Thickness", m_fThickness)->AddAttributes(new ezDefaultValueAttribute(0.05f), new ezClampValueAttribute(0.0f, 0.5f)),
       EZ_BITFLAGS_ACCESSOR_PROPERTY("Flags", ezJoltClothSheetFlags, GetFlags, SetFlags),
-      EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
+      EZ_RESOURCE_MEMBER_PROPERTY("Material", m_hMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezRequiredAttribute()),
       EZ_MEMBER_PROPERTY("TextureScale", m_vTextureScale)->AddAttributes(new ezDefaultValueAttribute(ezVec2(1.0f))),
       EZ_MEMBER_PROPERTY("Color", m_Color)->AddAttributes(new ezDefaultValueAttribute(ezColor::White)),
     }

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltGenerateCollisionComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltGenerateCollisionComponent.cpp
@@ -130,8 +130,8 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezJoltMeshMapping, ezNoBase, 1, ezRTTIDefaultAllo
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("RenderMesh", m_hRenderMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static", ezDependencyFlags::None)),
-    EZ_RESOURCE_MEMBER_PROPERTY("CollisionMesh", m_hCollisionMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Triangle", ezDependencyFlags::None)),
+    EZ_RESOURCE_MEMBER_PROPERTY("RenderMesh", m_hRenderMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static", ezDependencyFlags::None), new ezRequiredAttribute()),
+    EZ_RESOURCE_MEMBER_PROPERTY("CollisionMesh", m_hCollisionMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Triangle", ezDependencyFlags::None), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltShapeConvexHullComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltShapeConvexHullComponent.cpp
@@ -16,7 +16,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltShapeConvexHullComponent, 1, ezComponentMode::Stat
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("CollisionMesh", m_hCollisionMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Convex", ezDependencyFlags::Package)),
+    EZ_RESOURCE_MEMBER_PROPERTY("CollisionMesh", m_hCollisionMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Convex", ezDependencyFlags::Package), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS

--- a/Code/EnginePlugins/KrautPlugin/Components/KrautTreeComponent.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Components/KrautTreeComponent.cpp
@@ -29,7 +29,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezKrautTreeComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("KrautTree", GetKrautGeneratorResource, SetKrautGeneratorResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Kraut_Tree")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("KrautTree", GetKrautGeneratorResource, SetKrautGeneratorResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Kraut_Tree"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("VariationIndex", GetVariationIndex, SetVariationIndex)->AddAttributes(new ezDefaultValueAttribute(0xFFFF)),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/MiniAudioPlugin/Components/MiniAudioSoundComponent.cpp
+++ b/Code/EnginePlugins/MiniAudioPlugin/Components/MiniAudioSoundComponent.cpp
@@ -73,7 +73,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezMiniAudioSoundComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Sound", m_hSound)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_MiniAudio_Sound", ezDependencyFlags::Package)),
+    EZ_RESOURCE_MEMBER_PROPERTY("Sound", m_hSound)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_MiniAudio_Sound", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("Paused", GetPaused, SetPaused),
     EZ_ACCESSOR_PROPERTY("Volume", GetVolume, SetVolume)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("Pitch", GetPitch, SetPitch)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.1f, 10.0f)),

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_ColorGradient.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_ColorGradient.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleBehaviorFactory_ColorGradient, 3, ezRT
   {
     EZ_ENUM_MEMBER_PROPERTY("GradientSource", ezGradientSource, m_GradientSource),
     EZ_MEMBER_PROPERTY("Gradient", m_Gradient),
-    EZ_RESOURCE_MEMBER_PROPERTY("SharedGradient", m_hSharedGradient)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_Gradient")),
+    EZ_RESOURCE_MEMBER_PROPERTY("SharedGradient", m_hSharedGradient)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_Gradient"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("TintColor", m_TintColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("ColorGradientMode", ezParticleColorGradientMode, m_GradientMode),
     EZ_MEMBER_PROPERTY("GradientMaxSpeed", m_fMaxSpeed)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 100.0f)),

--- a/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
@@ -65,7 +65,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezParticleComponent, 5, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Effect", GetParticleEffectFile, SetParticleEffectFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect", ezDependencyFlags::Package)),
+    EZ_ACCESSOR_PROPERTY("Effect", GetParticleEffectFile, SetParticleEffectFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect", ezDependencyFlags::Package), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("SpawnAtStart", m_bSpawnAtStart)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_ENUM_MEMBER_PROPERTY("OnFinishedAction", ezOnComponentFinishedAction2, m_OnFinishedAction),
     EZ_MEMBER_PROPERTY("MinRestartDelay", m_MinRestartDelay),

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Effect.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Effect.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEventReactionFactory_Effect, 1, ezRTTI
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Effect", m_sEffect)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect")),
+    EZ_MEMBER_PROPERTY("Effect", m_sEffect)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect"), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("Alignment", ezSurfaceInteractionAlignment, m_Alignment),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Effect"), new ezExposeColorAlphaAttribute),
   }

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEventReactionFactory_Prefab, 1, ezRTTI
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Prefab", m_sPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_MEMBER_PROPERTY("Prefab", m_sPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab"), new ezRequiredAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("Alignment", ezSurfaceInteractionAlignment, m_Alignment),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Effect/ParticleTypeEffect.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Effect/ParticleTypeEffect.cpp
@@ -11,7 +11,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleTypeEffectFactory, 1, ezRTTIDefaultAll
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Effect", m_sEffect)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect")),
+    EZ_MEMBER_PROPERTY("Effect", m_sEffect)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect"), new ezRequiredAttribute()),
     // EZ_MEMBER_PROPERTY("Shared Instance Name", m_sSharedInstanceName), // there is currently no way (I can think of) to uniquely identify each sub-system for the 'shared owner'
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
@@ -17,7 +17,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleTypeMeshFactory, 1, ezRTTIDefaultAlloc
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Mesh", m_sMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static")),
+    EZ_MEMBER_PROPERTY("Mesh", m_sMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static"), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("Material", m_sMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
     EZ_MEMBER_PROPERTY("Scale", m_fScale)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("TintColorParam", m_sTintColorParameter),

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -661,7 +661,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProcPlacementComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Resource", GetResource, SetResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ProcGen_Graph")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Resource", GetResource, SetResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ProcGen_Graph"), new ezRequiredAttribute()),
     EZ_ARRAY_ACCESSOR_PROPERTY("BoxExtents", BoxExtents_GetCount, BoxExtents_GetValue, BoxExtents_SetValue, BoxExtents_Insert, BoxExtents_Remove),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -376,7 +376,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProcVertexColorComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ProcGen_Graph")),
+    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_ProcGen_Graph"), new ezRequiredAttribute()),
     EZ_ARRAY_ACCESSOR_PROPERTY("OutputDescs", OutputDescs_GetCount, GetOutputDesc, SetOutputDesc, OutputDescs_Insert, OutputDescs_Remove),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
@@ -372,7 +372,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeImageComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_MEMBER_PROPERTY("Image", m_hImage)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_2D")),
+    EZ_RESOURCE_MEMBER_PROPERTY("Image", m_hImage)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_2D"), new ezRequiredAttribute()),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS

--- a/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas3DComponent.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas3DComponent.cpp
@@ -26,7 +26,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezRmlUiCanvas3DComponent, 2, ezComponentMode::Static)
   EZ_BEGIN_PROPERTIES
   {
     EZ_RESOURCE_ACCESSOR_PROPERTY("ProxyMesh", GetProxyMesh, SetProxyMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static")),
-    EZ_RESOURCE_ACCESSOR_PROPERTY("BaseMaterial", GetBaseMaterial, SetBaseMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezDefaultValueAttribute("{ 05af8d07-0b38-44a6-8d50-49731ae2625d }")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("BaseMaterial", GetBaseMaterial, SetBaseMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material"), new ezDefaultValueAttribute("{ 05af8d07-0b38-44a6-8d50-49731ae2625d }"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("MaterialIndex", GetMaterialIndex, SetMaterialIndex)->AddAttributes(new ezDefaultValueAttribute(0)),
     EZ_ACCESSOR_PROPERTY("TextureSlotName", GetTextureSlotName, SetTextureSlotName)->AddAttributes(new ezDefaultValueAttribute("BaseTexture")),
     EZ_ACCESSOR_PROPERTY("TextureSize", GetTextureSize, SetTextureSize)->AddAttributes(new ezSuffixAttribute("px"), new ezDefaultValueAttribute(ezVec2U32(512, 512)), new ezClampValueAttribute(ezVec2U32(0), ezVec2U32(4096))),

--- a/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvasComponentBase.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvasComponentBase.cpp
@@ -14,7 +14,7 @@ EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezRmlUiCanvasComponentBase, 2)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_RESOURCE_ACCESSOR_PROPERTY("RmlFile", GetRmlResource, SetRmlResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Rml_UI")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("RmlFile", GetRmlResource, SetRmlResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Rml_UI"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("AutobindBlackboards", GetAutobindBlackboards, SetAutobindBlackboards),
     EZ_ACCESSOR_PROPERTY("SendEventMessage", GetSendEventMessage, SetSendEventMessage),
     EZ_ACCESSOR_PROPERTY("OnDemandUpdate", GetOnDemandUpdate, SetOnDemandUpdate)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
@@ -31,7 +31,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 2, ezComponentMode::Static)
   {
     EZ_ACCESSOR_PROPERTY("Size", GetSize, SetSize)->AddAttributes(new ezClampValueAttribute(16.0f, 256.0), new ezDefaultValueAttribute(128.0f)),
     EZ_ENUM_ACCESSOR_PROPERTY("Resolution", ezTerrainResolution, GetResolution, SetResolution),
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Material", GetMaterial, SetMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "Terrain-Heightfield")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Material", GetMaterial, SetMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "Terrain-Heightfield"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("BaseMaterialIndex", GetBaseMaterialIndex, SetBaseMaterialIndex)->AddAttributes(new ezClampValueAttribute(0, 31)),
     EZ_RESOURCE_ACCESSOR_PROPERTY("HeightImage", GetHeightImage, SetHeightImage)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_2D")),
     EZ_ACCESSOR_PROPERTY("HeightImageOffset", GetHeightImageOffset, SetHeightImageOffset),

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainVolumeComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainVolumeComponent.cpp
@@ -22,7 +22,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainVolumeComponent, 1, ezComponentMode::Static)
   {
     EZ_ENUM_ACCESSOR_PROPERTY("Resolution", ezTerrainResolution, GetResolution, SetResolution),
     EZ_ACCESSOR_PROPERTY("Size", GetSize, SetSize)->AddAttributes(new ezClampValueAttribute(1.0f, 1024.0f), new ezDefaultValueAttribute(64.0f)),
-    EZ_RESOURCE_ACCESSOR_PROPERTY("Material", GetMaterial, SetMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "Terrain-Voxel")),
+    EZ_RESOURCE_ACCESSOR_PROPERTY("Material", GetMaterial, SetMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "Terrain-Voxel"), new ezRequiredAttribute()),
     EZ_ACCESSOR_PROPERTY("BaseMaterialIndex", GetBaseMaterialIndex, SetBaseMaterialIndex)->AddAttributes(new ezClampValueAttribute(0, 15)),
     EZ_ACCESSOR_PROPERTY("FillHeight", GetFillHeight, SetFillHeight)->AddAttributes(new ezDefaultValueAttribute(-0.01f), new ezClampValueAttribute(-0.01f, 100.0f), new ezMinValueTextAttribute("Off")),
     EZ_ACCESSOR_PROPERTY("EnableCollider", GetEnableCollider, SetEnableCollider)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -1404,7 +1404,14 @@ ezQtPropertyEditorLineEditWidget::ezQtPropertyEditorLineEditWidget()
   m_pWidget->setFocusPolicy(Qt::FocusPolicy::StrongFocus);
   setFocusProxy(m_pWidget);
 
-  m_pLayout->addWidget(m_pWidget);
+  m_pWarningIcon = new QLabel(this);
+  m_pWarningIcon->setPixmap(ezQtUiServices::GetCachedIconResource(":/GuiFoundation/Icons/Warning.svg").pixmap(16, 16));
+  m_pWarningIcon->setToolTip(QStringLiteral("This property is required and must not be empty."));
+  m_pWarningIcon->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  m_pWarningIcon->setVisible(false);
+
+  m_pLayout->addWidget(m_pWidget, 1);
+  m_pLayout->addWidget(m_pWarningIcon);
 
   connect(m_pWidget, SIGNAL(editingFinished()), this, SLOT(on_TextFinished_triggered()));
 }
@@ -1447,11 +1454,17 @@ void ezQtPropertyEditorLineEditWidget::InternalSetValue(const ezVariant& value)
   if (!value.IsValid())
   {
     m_pWidget->setPlaceholderText(QStringLiteral("<Multiple Values>"));
+    m_pWarningIcon->setVisible(false);
   }
   else
   {
+    const ezString sValue = value.ConvertTo<ezString>();
+
     m_pWidget->setPlaceholderText(QString());
-    m_pWidget->setText(QString::fromUtf8(value.ConvertTo<ezString>().GetData()));
+    m_pWidget->setText(QString::fromUtf8(sValue.GetData()));
+
+    const bool bRequired = m_pProp->GetAttributeByType<ezRequiredAttribute>() != nullptr;
+    m_pWarningIcon->setVisible(bRequired && sValue.IsEmpty());
   }
 }
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
@@ -44,8 +44,8 @@ protected:
   virtual void OnInit() override {}
   virtual void InternalSetValue(const ezVariant& value) override;
 
-  QHBoxLayout* m_pLayout;
-  QCheckBox* m_pWidget;
+  QHBoxLayout* m_pLayout = nullptr;
+  QCheckBox* m_pWidget = nullptr;
 };
 
 
@@ -92,9 +92,9 @@ protected:
   virtual void OnInit() override;
   virtual void InternalSetValue(const ezVariant& value) override;
 
-  bool m_bTemporaryCommand;
-  QHBoxLayout* m_pLayout;
-  ezQtDoubleSpinBox* m_pWidget;
+  bool m_bTemporaryCommand = false;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtDoubleSpinBox* m_pWidget = nullptr;
 };
 
 /// *** ANGLE SPINBOX ***
@@ -114,9 +114,9 @@ protected:
   virtual void OnInit() override;
   virtual void InternalSetValue(const ezVariant& value) override;
 
-  bool m_bTemporaryCommand;
-  QHBoxLayout* m_pLayout;
-  ezQtDoubleSpinBox* m_pWidget;
+  bool m_bTemporaryCommand = false;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtDoubleSpinBox* m_pWidget = nullptr;
 };
 
 /// *** INT SPINBOX ***
@@ -280,8 +280,9 @@ protected:
   virtual void InternalSetValue(const ezVariant& value) override;
 
 protected:
-  QHBoxLayout* m_pLayout;
-  QLineEdit* m_pWidget;
+  QHBoxLayout* m_pLayout = nullptr;
+  QLineEdit* m_pWidget = nullptr;
+  QLabel* m_pWarningIcon = nullptr;
   ezEnum<ezVariantType> m_OriginalType;
 };
 
@@ -330,8 +331,8 @@ protected:
 protected:
   bool m_bExposeAlpha = false;
   bool m_bIsHDR = false;
-  QHBoxLayout* m_pLayout;
-  ezQtColorButtonWidget* m_pWidget;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtColorButtonWidget* m_pWidget = nullptr;
   ezVariant m_OriginalValue;
 };
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -16,7 +16,7 @@
 
 EZ_IMPLEMENT_SINGLETON(ezQtUiServices);
 
-ezEvent<const ezQtUiServices::Event&> ezQtUiServices::s_Events;
+ezEvent<const ezQtUiServices::Event&, ezMutex> ezQtUiServices::s_Events;
 ezEvent<const ezQtUiServices::TickEvent&> ezQtUiServices::s_TickEvent;
 
 ezMap<ezString, QIcon> ezQtUiServices::s_IconsCache;

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -44,7 +44,7 @@ public:
     TextType m_TextType = TextType::Info;
   };
 
-  static ezEvent<const ezQtUiServices::Event&> s_Events;
+  static ezEvent<const ezQtUiServices::Event&, ezMutex> s_Events;
 
   struct TickEvent
   {


### PR DESCRIPTION
The asset browser widget and text widget now display a warning icon when a property is empty that is marked as required.

Also marked many asset references as required.

<img width="855" height="354" alt="image" src="https://github.com/user-attachments/assets/2bc4724b-49e2-4a0c-9729-7828ce39134f" />
