### PR TITLE
Added asset check panel

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCheckRule.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCheckRule.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <Foundation/Reflection/Reflection.h>
+#include <Foundation/Types/Uuid.h>
+
+class ezDocument;
+class ezDocumentObject;
+class ezObjectAccessorBase;
+class ezAssetChecker;
+class ezAbstractProperty;
+
+/// Severity of an ezAssetCheckNote.
+struct ezAssetCheckSeverity
+{
+  enum Enum : ezUInt8
+  {
+    Warning,
+    Error,
+  };
+};
+
+/// A single issue reported by an ezAssetCheckRule for one asset.
+struct EZ_EDITORFRAMEWORK_DLL ezAssetCheckNote
+{
+  ezAssetCheckSeverity::Enum m_Severity = ezAssetCheckSeverity::Warning;
+  ezString m_sMessage;
+  ezUuid m_ObjectGuid;   ///< Invalid if the note is not tied to a specific object.
+  bool m_bFixed = false; ///< True if an auto-fix resolved this issue.
+};
+
+/// Passed to ezAssetCheckRule::CheckDocument to inspect the document and report issues.
+///
+/// The rule reports issues via ReportIssue. If IsAutoFixAllowed returns true, the rule may also
+/// modify the document through GetObjectAccessor and report the fixed issues with bFixed = true.
+/// The runner (ezAssetChecker) owns the undo transaction; rules must not start or finish one.
+class EZ_EDITORFRAMEWORK_DLL ezAssetCheckContext
+{
+public:
+  ezDocument* GetDocument() const { return m_pDocument; }
+  ezObjectAccessorBase* GetObjectAccessor() const;
+
+  /// Whether the rule is allowed to modify the document to fix issues.
+  bool IsAutoFixAllowed() const { return m_bAutoFix; }
+
+  /// Records an issue. When bFixed is true, m_uiFixCount is incremented so the runner knows the
+  /// document was modified and needs to be saved.
+  void ReportIssue(ezAssetCheckSeverity::Enum severity, ezStringView sMessage, const ezDocumentObject* pObject = nullptr, bool bFixed = false);
+
+  /// Returns the object's "Name" property (if present and non-empty), otherwise its type name.
+  static ezString GetObjectDisplayName(const ezDocumentObject* pObject);
+
+private:
+  friend class ezAssetChecker;
+
+  ezDocument* m_pDocument = nullptr;
+  bool m_bAutoFix = false;
+  ezUInt32 m_uiFixCount = 0; ///< Reset per rule by the runner; counts fixes applied to the document.
+  ezDynamicArray<ezAssetCheckNote>* m_pNotes = nullptr;
+};
+
+/// Base class for asset check rules.
+///
+/// Derive in any editor plugin (with EZ_ADD_DYNAMIC_REFLECTION and a default allocator) and the
+/// rule is auto-discovered via reflection. A rule inspects an open document and reports issues,
+/// optionally fixing them when auto-fix is enabled.
+class EZ_EDITORFRAMEWORK_DLL ezAssetCheckRule : public ezReflectedClass
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezAssetCheckRule, ezReflectedClass);
+
+public:
+  virtual ezStringView GetDisplayName() const = 0;
+  virtual ezStringView GetDescription() const = 0;
+
+  /// Whether the rule can fix the issues it reports. If false, auto-fix has no effect for it.
+  virtual bool CanFix() const { return false; }
+
+  /// Whether the rule should run on documents of the given type. Defaults to all types.
+  virtual bool AppliesToDocumentType(ezStringView sDocumentTypeName) const { return true; }
+
+  /// Inspects the document and reports all issues via ref_ctx.ReportIssue.
+  ///
+  /// The default implementation visits the document's root object and every object below it and
+  /// calls CheckObject for each (child objects reached through properties marked with
+  /// ezTemporaryAttribute are skipped). Rules that follow this per-object / per-property structure
+  /// only need to override CheckObject or CheckProperty. Override CheckDocument itself to replace
+  /// the traversal entirely.
+  ///
+  /// If ref_ctx.IsAutoFixAllowed() is true, the rule also fixes the issues through
+  /// ref_ctx.GetObjectAccessor() and reports them with bFixed = true. The runner manages the undo
+  /// transaction, so implementations must not call Start/Finish/CancelTransaction.
+  virtual void CheckDocument(ezAssetCheckContext& ref_ctx);
+
+  /// Allocates one instance of every reflected, allocatable rule type, sorted by display name.
+  static void CreateRules(ezDynamicArray<ezAssetCheckRule*>& out_rules);
+  static void DestroyRules(ezDynamicArray<ezAssetCheckRule*>& ref_rules);
+
+protected:
+  /// Inspects a single object as part of the default CheckDocument traversal.
+  ///
+  /// The default iterates all of the object's properties, skipping those marked with
+  /// ezTemporaryAttribute, and calls CheckProperty for each. Child objects are visited separately
+  /// by the traversal and must not be recursed into here.
+  virtual void CheckObject(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject);
+
+  /// Inspects a single property of an object. The default does nothing.
+  ///
+  /// Called for Member, Array, Set and Map properties alike. Use GetPropertyValues to read the
+  /// contained element values without having to special-case the property category.
+  virtual void CheckProperty(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject, const ezAbstractProperty* pProp);
+
+  /// Reads all element values of a property, regardless of its category.
+  ///
+  /// Member properties yield their single value; Array and Set properties yield all elements; Map
+  /// properties yield all values. out_indices receives the index/key that addresses each value,
+  /// usable with ezObjectAccessorBase::RemoveValue and related functions; for Member properties it
+  /// is an invalid ezVariant. Returns EZ_FAILURE for categories that hold no readable values (such
+  /// as pointer properties, whose targets are visited as separate child objects).
+  static ezResult GetPropertyValues(ezObjectAccessorBase* pAcc, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_indices, ezDynamicArray<ezVariant>& out_values);
+
+private:
+  void VisitObjectRecursive(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject);
+};

--- a/Code/Editor/EditorFramework/Assets/AssetCheckRules.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCheckRules.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <EditorFramework/Assets/AssetCheckRule.h>
+
+/// Reports tag-set entries that are not registered in the project's tag configuration.
+///
+/// Unknown tags are ignored at runtime, so these are reported as warnings. Auto-fix removes them.
+class EZ_EDITORFRAMEWORK_DLL ezUnknownTagsAssetCheckRule : public ezAssetCheckRule
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezUnknownTagsAssetCheckRule, ezAssetCheckRule);
+
+public:
+  virtual ezStringView GetDisplayName() const override { return "Unknown Tags"; }
+  virtual ezStringView GetDescription() const override;
+  virtual bool CanFix() const override { return true; }
+
+protected:
+  virtual void CheckProperty(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject, const ezAbstractProperty* pProp) override;
+};
+
+/// Reports properties marked with ezRequiredAttribute that are left empty, or, for game object /
+/// component reference properties, that reference an object which does not exist (anymore).
+///
+/// There is no sensible value to auto-fix this with, so these are always reported as errors.
+class EZ_EDITORFRAMEWORK_DLL ezRequiredPropertyAssetCheckRule : public ezAssetCheckRule
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezRequiredPropertyAssetCheckRule, ezAssetCheckRule);
+
+public:
+  virtual ezStringView GetDisplayName() const override { return "Required Properties"; }
+  virtual ezStringView GetDescription() const override;
+
+protected:
+  virtual void CheckProperty(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject, const ezAbstractProperty* pProp) override;
+};
+
+/// Reports ezGameObjects that have no name, no components and no child objects, i.e. that have no
+/// effect on the scene. Auto-fix removes them.
+class EZ_EDITORFRAMEWORK_DLL ezEmptyGameObjectAssetCheckRule : public ezAssetCheckRule
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezEmptyGameObjectAssetCheckRule, ezAssetCheckRule);
+
+public:
+  virtual ezStringView GetDisplayName() const override { return "Empty Game Objects"; }
+  virtual ezStringView GetDescription() const override;
+  virtual bool CanFix() const override { return true; }
+  virtual bool AppliesToDocumentType(ezStringView sDocumentTypeName) const override;
+
+  virtual void CheckDocument(ezAssetCheckContext& ref_ctx) override;
+
+protected:
+  virtual void CheckObject(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject) override;
+
+private:
+  // Objects are collected while walking the tree and only removed afterwards, since removing an
+  // object during the traversal would invalidate the sibling array a parent frame is iterating over.
+  ezDynamicArray<const ezDocumentObject*> m_EmptyObjects;
+};

--- a/Code/Editor/EditorFramework/Assets/AssetChecker.h
+++ b/Code/Editor/EditorFramework/Assets/AssetChecker.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <EditorFramework/Assets/AssetCheckRule.h>
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <Foundation/Containers/Deque.h>
+
+/// Input for ezAssetChecker::Run.
+struct ezAssetCheckOptions
+{
+  ezDynamicArray<ezAssetCheckRule*> m_Rules; ///< Rules to run. Owned by the caller (the dialog).
+  ezString m_sDocumentTypeName;              ///< If non-empty, only assets of this document type are checked.
+  ezString m_sNameFilter;                    ///< ezSearchPatternFilter, matched against the data-dir-relative asset path.
+  bool m_bAutoFix = false;                   ///< If true, rules that CanFix() apply fixes and modified documents are saved.
+};
+
+/// Result for a single asset that produced at least one note.
+struct ezAssetCheckResult
+{
+  ezUuid m_AssetGuid;
+  ezString m_sAssetPath;    ///< Data-dir-relative path, for display.
+  ezString m_sAbsAssetPath; ///< Absolute path, for opening on double-click.
+  ezDynamicArray<ezAssetCheckNote> m_Notes;
+  bool m_bSaved = false;
+};
+
+/// Aggregated outcome of a check run.
+struct ezAssetCheckSummary
+{
+  ezDeque<ezAssetCheckResult> m_Results; ///< Only assets that produced notes.
+  ezUInt32 m_uiAssetsChecked = 0;
+  ezUInt32 m_uiWarnings = 0;
+  ezUInt32 m_uiErrors = 0;
+  ezUInt32 m_uiFixed = 0;
+  ezUInt32 m_uiSaved = 0;
+  bool m_bCanceled = false;
+};
+
+/// Runs a set of ezAssetCheckRules over the assets selected by ezAssetCheckOptions.
+///
+/// Run is UI-free (it only drives the global ezProgress, which surfaces a modal progress dialog in
+/// the editor) so that a headless tool could call it as well. It must run on the main thread
+/// because it opens, modifies and saves documents.
+class EZ_EDITORFRAMEWORK_DLL ezAssetChecker
+{
+public:
+  static void Run(const ezAssetCheckOptions& options, ezAssetCheckSummary& out_summary);
+};

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCheckRule.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCheckRule.cpp
@@ -1,0 +1,165 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetCheckRule.h>
+#include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Object/DocumentObjectManager.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAssetCheckRule, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezObjectAccessorBase* ezAssetCheckContext::GetObjectAccessor() const
+{
+  return m_pDocument ? m_pDocument->GetObjectAccessor() : nullptr;
+}
+
+void ezAssetCheckContext::ReportIssue(ezAssetCheckSeverity::Enum severity, ezStringView sMessage, const ezDocumentObject* pObject /*= nullptr*/, bool bFixed /*= false*/)
+{
+  ezAssetCheckNote& note = m_pNotes->ExpandAndGetRef();
+  note.m_Severity = severity;
+  note.m_sMessage = sMessage;
+  note.m_bFixed = bFixed;
+
+  if (pObject != nullptr)
+  {
+    note.m_ObjectGuid = pObject->GetGuid();
+  }
+
+  if (bFixed)
+  {
+    ++m_uiFixCount;
+  }
+}
+
+ezString ezAssetCheckContext::GetObjectDisplayName(const ezDocumentObject* pObject)
+{
+  if (pObject == nullptr)
+    return ezString();
+
+  const ezVariant name = pObject->GetTypeAccessor().GetValue("Name");
+  if (name.IsValid() && name.CanConvertTo<ezString>())
+  {
+    const ezString sName = name.ConvertTo<ezString>();
+    if (!sName.IsEmpty())
+      return sName;
+  }
+
+  return pObject->GetType()->GetTypeName();
+}
+
+void ezAssetCheckRule::CheckDocument(ezAssetCheckContext& ref_ctx)
+{
+  const ezDocumentObject* pRoot = ref_ctx.GetDocument()->GetObjectManager()->GetRootObject();
+  VisitObjectRecursive(ref_ctx, pRoot);
+}
+
+void ezAssetCheckRule::VisitObjectRecursive(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject)
+{
+  CheckObject(ref_ctx, pObject);
+
+  for (const ezDocumentObject* pChild : pObject->GetChildren())
+  {
+    if (pChild->GetParentPropertyType() != nullptr &&
+        pChild->GetParentPropertyType()->GetAttributeByType<ezTemporaryAttribute>() != nullptr)
+      continue;
+
+    VisitObjectRecursive(ref_ctx, pChild);
+  }
+}
+
+void ezAssetCheckRule::CheckObject(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject)
+{
+  ezHybridArray<const ezAbstractProperty*, 32> properties;
+  pObject->GetType()->GetAllProperties(properties);
+
+  for (const ezAbstractProperty* pProp : properties)
+  {
+    if (pProp->GetAttributeByType<ezTemporaryAttribute>() != nullptr)
+      continue;
+
+    CheckProperty(ref_ctx, pObject, pProp);
+  }
+}
+
+void ezAssetCheckRule::CheckProperty(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject, const ezAbstractProperty* pProp)
+{
+}
+
+ezResult ezAssetCheckRule::GetPropertyValues(ezObjectAccessorBase* pAcc, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_indices, ezDynamicArray<ezVariant>& out_values)
+{
+  out_indices.Clear();
+  out_values.Clear();
+
+  switch (pProp->GetCategory())
+  {
+    case ezPropertyCategory::Member:
+    {
+      ezVariant value;
+      if (pAcc->GetValue(pObject, pProp, value).Failed())
+        return EZ_FAILURE;
+
+      out_indices.PushBack(ezVariant());
+      out_values.PushBack(value);
+      return EZ_SUCCESS;
+    }
+
+    case ezPropertyCategory::Array:
+    case ezPropertyCategory::Set:
+    {
+      if (pAcc->GetValues(pObject, pProp, out_values).Failed())
+        return EZ_FAILURE;
+
+      out_indices.Reserve(out_values.GetCount());
+      for (ezUInt32 i = 0; i < out_values.GetCount(); ++i)
+        out_indices.PushBack(i);
+      return EZ_SUCCESS;
+    }
+
+    case ezPropertyCategory::Map:
+    {
+      if (pAcc->GetKeys(pObject, pProp, out_indices).Failed())
+        return EZ_FAILURE;
+
+      out_values.Reserve(out_indices.GetCount());
+      for (const ezVariant& key : out_indices)
+      {
+        ezVariant value;
+        if (pAcc->GetValue(pObject, pProp, value, key).Failed())
+          return EZ_FAILURE;
+
+        out_values.PushBack(value);
+      }
+      return EZ_SUCCESS;
+    }
+
+    default:
+      return EZ_FAILURE;
+  }
+}
+
+void ezAssetCheckRule::CreateRules(ezDynamicArray<ezAssetCheckRule*>& out_rules)
+{
+  ezRTTI::ForEachDerivedType<ezAssetCheckRule>(
+    [&](const ezRTTI* pRtti)
+    {
+      out_rules.PushBack(pRtti->GetAllocator()->Allocate<ezAssetCheckRule>());
+    },
+    ezRTTI::ForEachOptions::ExcludeNonAllocatable);
+
+  out_rules.Sort([](ezAssetCheckRule* lhs, ezAssetCheckRule* rhs) -> bool
+    {
+      return lhs->GetDisplayName().Compare_NoCase(rhs->GetDisplayName()) < 0; //
+    });
+}
+
+void ezAssetCheckRule::DestroyRules(ezDynamicArray<ezAssetCheckRule*>& ref_rules)
+{
+  for (ezAssetCheckRule* pRule : ref_rules)
+  {
+    pRule->GetDynamicRTTI()->GetAllocator()->Deallocate(pRule);
+  }
+
+  ref_rules.Clear();
+}

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCheckRules.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCheckRules.cpp
@@ -1,0 +1,215 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <Core/World/GameObject.h>
+#include <EditorFramework/Assets/AssetCheckRules.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Object/DocumentObjectManager.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+#include <ToolsFoundation/Settings/ToolsTagRegistry.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezUnknownTagsAssetCheckRule, 1, ezRTTIDefaultAllocator<ezUnknownTagsAssetCheckRule>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRequiredPropertyAssetCheckRule, 1, ezRTTIDefaultAllocator<ezRequiredPropertyAssetCheckRule>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEmptyGameObjectAssetCheckRule, 1, ezRTTIDefaultAllocator<ezEmptyGameObjectAssetCheckRule>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezStringView ezUnknownTagsAssetCheckRule::GetDescription() const
+{
+  return "Detects tags used on objects that are not registered in the project's tag configuration. "
+         "Auto-fix removes these tags.";
+}
+
+void ezUnknownTagsAssetCheckRule::CheckProperty(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject, const ezAbstractProperty* pProp)
+{
+  // A tag-set property is a Set with the tag-set widget attribute.
+  if (pProp->GetCategory() != ezPropertyCategory::Set)
+    return;
+  if (pProp->GetAttributeByType<ezTagSetWidgetAttribute>() == nullptr)
+    return;
+
+  ezObjectAccessorBase* pAcc = ref_ctx.GetObjectAccessor();
+
+  ezHybridArray<ezVariant, 16> indices;
+  ezHybridArray<ezVariant, 16> values;
+  if (GetPropertyValues(pAcc, pObject, pProp, indices, values).Failed())
+    return;
+
+  // Iterate back-to-front so that removals keep the remaining indices valid.
+  for (ezUInt32 i = values.GetCount(); i-- > 0;)
+  {
+    if (!values[i].CanConvertTo<ezString>())
+      continue;
+
+    const ezString sTag = values[i].ConvertTo<ezString>();
+    if (ezToolsTagRegistry::IsTagKnown(sTag))
+      continue;
+
+    const ezString sObj = ezAssetCheckContext::GetObjectDisplayName(pObject);
+    ezStringBuilder sMsg;
+
+    if (ref_ctx.IsAutoFixAllowed())
+    {
+      if (pAcc->RemoveValue(pObject, pProp, indices[i]).Succeeded())
+      {
+        sMsg.SetFormat("Removed unknown tag '{}' from '{}' (property '{}').", sTag, sObj, pProp->GetPropertyName());
+        ref_ctx.ReportIssue(ezAssetCheckSeverity::Warning, sMsg, pObject, /*bFixed*/ true);
+      }
+      else
+      {
+        sMsg.SetFormat("Failed to remove unknown tag '{}' from '{}' (property '{}').", sTag, sObj, pProp->GetPropertyName());
+        ref_ctx.ReportIssue(ezAssetCheckSeverity::Error, sMsg, pObject, /*bFixed*/ false);
+      }
+    }
+    else
+    {
+      sMsg.SetFormat("Unknown tag '{}' on '{}' (property '{}').", sTag, sObj, pProp->GetPropertyName());
+      ref_ctx.ReportIssue(ezAssetCheckSeverity::Warning, sMsg, pObject, /*bFixed*/ false);
+    }
+  }
+}
+
+ezStringView ezRequiredPropertyAssetCheckRule::GetDescription() const
+{
+  return "Detects properties marked with ezRequiredAttribute that are empty, or, for game object / "
+         "component reference properties, that reference an object which does not exist.";
+}
+
+namespace
+{
+  bool IsEmptyOrInvalidRequiredValue(ezObjectAccessorBase* pAcc, const ezAbstractProperty* pProp, const ezVariant& value)
+  {
+    if (!value.IsValid() || !value.CanConvertTo<ezString>())
+      return true;
+
+    const ezString sValue = value.ConvertTo<ezString>();
+    if (sValue.IsEmpty())
+      return true;
+
+    // Game object / component reference properties store a stringified ezUuid; make sure it resolves.
+    if (pProp->GetAttributeByType<ezGameObjectReferenceAttribute>() != nullptr)
+    {
+      if (!ezConversionUtils::IsStringUuid(sValue))
+        return true;
+
+      const ezUuid guid = ezConversionUtils::ConvertStringToUuid(sValue);
+      if (pAcc->GetObject(guid) == nullptr)
+        return true;
+    }
+
+    return false;
+  }
+
+} // namespace
+
+void ezRequiredPropertyAssetCheckRule::CheckProperty(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject, const ezAbstractProperty* pProp)
+{
+  if (pProp->GetAttributeByType<ezRequiredAttribute>() == nullptr)
+    return;
+
+  ezObjectAccessorBase* pAcc = ref_ctx.GetObjectAccessor();
+
+  ezHybridArray<ezVariant, 16> indices;
+  ezHybridArray<ezVariant, 16> values;
+  if (GetPropertyValues(pAcc, pObject, pProp, indices, values).Failed())
+    return;
+
+  const ezString sObj = ezAssetCheckContext::GetObjectDisplayName(pObject);
+  ezStringBuilder sMsg;
+
+  // An empty container has no element to inspect but still fails the requirement.
+  if (values.IsEmpty())
+  {
+    sMsg.SetFormat("Required property '{}' on '{}' is empty.", pProp->GetPropertyName(), sObj);
+    ref_ctx.ReportIssue(ezAssetCheckSeverity::Error, sMsg, pObject);
+    return;
+  }
+
+  for (const ezVariant& value : values)
+  {
+    if (!IsEmptyOrInvalidRequiredValue(pAcc, pProp, value))
+      continue;
+
+    sMsg.SetFormat("Required property '{}' on '{}' is empty.", pProp->GetPropertyName(), sObj);
+    ref_ctx.ReportIssue(ezAssetCheckSeverity::Error, sMsg, pObject);
+  }
+}
+
+ezStringView ezEmptyGameObjectAssetCheckRule::GetDescription() const
+{
+  return "Detects game objects that have no name, no components and no child objects, and thus have "
+         "no effect on the scene. Auto-fix removes them.";
+}
+
+bool ezEmptyGameObjectAssetCheckRule::AppliesToDocumentType(ezStringView sDocumentTypeName) const
+{
+  return sDocumentTypeName == "Scene" || sDocumentTypeName == "Prefab" || sDocumentTypeName == "Layer";
+}
+
+void ezEmptyGameObjectAssetCheckRule::CheckDocument(ezAssetCheckContext& ref_ctx)
+{
+  m_EmptyObjects.Clear();
+
+  // The default traversal (via CheckObject below) only collects candidates; objects are removed
+  // afterwards so that removal doesn't invalidate a parent frame's ongoing child iteration.
+  ezAssetCheckRule::CheckDocument(ref_ctx);
+
+  ezObjectAccessorBase* pAcc = ref_ctx.GetObjectAccessor();
+  ezStringBuilder sMsg;
+
+  for (const ezDocumentObject* pObject : m_EmptyObjects)
+  {
+    const ezString sObj = ezAssetCheckContext::GetObjectDisplayName(pObject);
+
+    if (ref_ctx.IsAutoFixAllowed())
+    {
+      if (pAcc->RemoveObject(pObject).Succeeded())
+      {
+        sMsg.SetFormat("Removed empty game object '{}' (no name, no components, no children).", sObj);
+        ref_ctx.ReportIssue(ezAssetCheckSeverity::Warning, sMsg, pObject, /*bFixed*/ true);
+      }
+      else
+      {
+        sMsg.SetFormat("Failed to remove empty game object '{}'.", sObj);
+        ref_ctx.ReportIssue(ezAssetCheckSeverity::Error, sMsg, pObject, /*bFixed*/ false);
+      }
+    }
+    else
+    {
+      sMsg.SetFormat("Game object '{}' has no name, no components and no children.", sObj);
+      ref_ctx.ReportIssue(ezAssetCheckSeverity::Warning, sMsg, pObject, /*bFixed*/ false);
+    }
+  }
+
+  m_EmptyObjects.Clear();
+}
+
+void ezEmptyGameObjectAssetCheckRule::CheckObject(ezAssetCheckContext& ref_ctx, const ezDocumentObject* pObject)
+{
+  if (!pObject->GetType()->IsDerivedFrom<ezGameObject>())
+    return;
+
+  bool bHasChildOrComponent = false;
+  for (const ezDocumentObject* pChild : pObject->GetChildren())
+  {
+    if (pChild->GetParentProperty() == "Children" || pChild->GetParentProperty() == "Components")
+    {
+      bHasChildOrComponent = true;
+      break;
+    }
+  }
+
+  if (bHasChildOrComponent)
+    return;
+
+  ezVariant name;
+  if (ref_ctx.GetObjectAccessor()->GetValueByName(pObject, "Name", name).Succeeded() && name.CanConvertTo<ezString>() &&
+      !name.ConvertTo<ezString>().IsEmpty())
+    return;
+
+  m_EmptyObjects.PushBack(pObject);
+}

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetChecker.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetChecker.cpp
@@ -1,0 +1,223 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetChecker.h>
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <Foundation/Containers/Map.h>
+#include <Foundation/Utilities/Progress.h>
+#include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+#include <ToolsFoundation/Utilities/SearchPatternFilter.h>
+
+namespace
+{
+  struct AssetToCheck
+  {
+    ezUuid m_Guid;
+    ezString m_sAbsPath;
+    ezString m_sRelPath;
+    ezString m_sDocTypeName;
+  };
+} // namespace
+
+void ezAssetChecker::Run(const ezAssetCheckOptions& options, ezAssetCheckSummary& out_summary)
+{
+  ezSearchPatternFilter nameFilter;
+  nameFilter.SetSearchText(options.m_sNameFilter);
+
+  // Cache per-document-type whether any selected rule applies, so we don't re-check all rules for every asset.
+  ezMap<ezString, bool> ruleAppliesToDocType;
+
+  // 1. Snapshot the matching assets under the curator lock, then release it before opening documents.
+  ezDynamicArray<AssetToCheck> assets;
+  {
+    auto pKnownAssets = ezAssetCurator::GetSingleton()->GetKnownAssets();
+
+    for (auto it = pKnownAssets->GetIterator(); it.IsValid(); ++it)
+    {
+      const ezAssetInfo* pInfo = it.Value();
+      if (pInfo == nullptr || pInfo->m_pDocumentTypeDescriptor == nullptr)
+        continue;
+
+      const ezString& sDocTypeName = pInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName;
+
+      if (!options.m_sDocumentTypeName.IsEmpty() && options.m_sDocumentTypeName != sDocTypeName)
+        continue;
+
+      const ezStringView sRelPath = pInfo->m_Path.GetDataDirParentRelativePath();
+
+      if (!nameFilter.IsEmpty() && !nameFilter.PassesFilters(sRelPath))
+        continue;
+
+      // Skip assets that no selected rule would look at anyway.
+      bool bAnyRuleApplies = false;
+      if (auto itCached = ruleAppliesToDocType.Find(sDocTypeName); itCached.IsValid())
+      {
+        bAnyRuleApplies = itCached.Value();
+      }
+      else
+      {
+        for (const ezAssetCheckRule* pRule : options.m_Rules)
+        {
+          if (pRule->AppliesToDocumentType(sDocTypeName))
+          {
+            bAnyRuleApplies = true;
+            break;
+          }
+        }
+
+        ruleAppliesToDocType[sDocTypeName] = bAnyRuleApplies;
+      }
+
+      if (!bAnyRuleApplies)
+        continue;
+
+      AssetToCheck& a = assets.ExpandAndGetRef();
+      a.m_Guid = it.Key();
+      a.m_sAbsPath = pInfo->m_Path.GetAbsolutePath();
+      a.m_sRelPath = sRelPath;
+      a.m_sDocTypeName = sDocTypeName;
+    }
+  }
+
+  if (assets.IsEmpty())
+    return;
+
+  ezProgressRange range("Checking Assets", assets.GetCount(), true);
+
+  for (const AssetToCheck& asset : assets)
+  {
+    if (range.WasCanceled())
+    {
+      out_summary.m_bCanceled = true;
+      break;
+    }
+
+    ezStringBuilder sFileName = asset.m_sRelPath;
+    range.BeginNextStep(sFileName.GetFileNameAndExtension());
+
+    ++out_summary.m_uiAssetsChecked;
+
+    // 3. Open the document (reuse an already open one).
+    bool bWasOpen = false;
+    ezDocument* pDoc = ezDocumentManager::GetDocumentByGuid(asset.m_Guid);
+    if (pDoc != nullptr)
+    {
+      bWasOpen = true;
+    }
+    else
+    {
+      pDoc = ezQtEditorApp::GetSingleton()->OpenDocument(asset.m_sAbsPath, ezDocumentFlags::None);
+    }
+
+    if (pDoc == nullptr)
+    {
+      ezAssetCheckResult& result = out_summary.m_Results.ExpandAndGetRef();
+      result.m_AssetGuid = asset.m_Guid;
+      result.m_sAssetPath = asset.m_sRelPath;
+      result.m_sAbsAssetPath = asset.m_sAbsPath;
+      ezAssetCheckNote& note = result.m_Notes.ExpandAndGetRef();
+      note.m_Severity = ezAssetCheckSeverity::Error;
+      note.m_sMessage = "Could not open asset document.";
+      ++out_summary.m_uiErrors;
+      continue;
+    }
+
+    const bool bHadUnsavedChanges = pDoc->IsModified();
+
+    ezDynamicArray<ezAssetCheckNote> notes;
+    ezUInt32 uiTotalFixes = 0;
+
+    ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
+
+    // 5. Run each rule that applies to this document type.
+    for (ezAssetCheckRule* pRule : options.m_Rules)
+    {
+      if (!pRule->AppliesToDocumentType(asset.m_sDocTypeName))
+        continue;
+
+      ezAssetCheckContext ctx;
+      ctx.m_pDocument = pDoc;
+      ctx.m_pNotes = &notes;
+      ctx.m_uiFixCount = 0;
+      ctx.m_bAutoFix = options.m_bAutoFix && pRule->CanFix();
+
+      if (ctx.m_bAutoFix)
+      {
+        ezStringBuilder sTransaction;
+        sTransaction.SetFormat("Asset Check: {}", pRule->GetDisplayName());
+        pAcc->StartTransaction(sTransaction);
+
+        pRule->CheckDocument(ctx);
+
+        if (ctx.m_uiFixCount > 0)
+          pAcc->FinishTransaction();
+        else
+          pAcc->CancelTransaction();
+      }
+      else
+      {
+        pRule->CheckDocument(ctx);
+      }
+
+      uiTotalFixes += ctx.m_uiFixCount;
+    }
+
+    // 6. Save if the document was modified by a fix.
+    bool bSaved = false;
+    if (uiTotalFixes > 0)
+    {
+      if (bHadUnsavedChanges)
+      {
+        ezAssetCheckNote& note = notes.ExpandAndGetRef();
+        note.m_Severity = ezAssetCheckSeverity::Warning;
+        note.m_sMessage = "Document had unsaved changes; fixes were applied but the document was not saved automatically.";
+      }
+      else
+      {
+        const ezStatus res = pDoc->SaveDocument(true);
+        if (res.Failed())
+        {
+          ezStringBuilder sMsg;
+          sMsg.SetFormat("Failed to save document: {}", res.GetMessageString());
+          ezAssetCheckNote& note = notes.ExpandAndGetRef();
+          note.m_Severity = ezAssetCheckSeverity::Error;
+          note.m_sMessage = sMsg;
+        }
+        else
+        {
+          bSaved = true;
+          ++out_summary.m_uiSaved;
+        }
+      }
+    }
+
+    // 7. Close the document if we opened it and no window is using it.
+    if (!pDoc->HasWindowBeenRequested() && !bWasOpen)
+    {
+      pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    }
+
+    // 8. Accumulate counts and record the result if there is anything to report.
+    if (!notes.IsEmpty())
+    {
+      ezAssetCheckResult& result = out_summary.m_Results.ExpandAndGetRef();
+      result.m_AssetGuid = asset.m_Guid;
+      result.m_sAssetPath = asset.m_sRelPath;
+      result.m_sAbsAssetPath = asset.m_sAbsPath;
+      result.m_Notes = notes;
+      result.m_bSaved = bSaved;
+
+      for (const ezAssetCheckNote& note : notes)
+      {
+        if (note.m_Severity == ezAssetCheckSeverity::Error)
+          ++out_summary.m_uiErrors;
+        else
+          ++out_summary.m_uiWarnings;
+
+        if (note.m_bFixed)
+          ++out_summary.m_uiFixed;
+      }
+    }
+  }
+}

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -32,6 +32,7 @@
 #include <EditorFramework/Manipulators/SplineTangentManipulatorAdapter.h>
 #include <EditorFramework/Manipulators/TransformManipulatorAdapter.h>
 #include <EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.moc.h>
+#include <EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h>
 #include <EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h>
 #include <EditorFramework/Panels/CVarPanel/CVarPanel.moc.h>
 #include <EditorFramework/Panels/LogPanel/LogPanel.moc.h>
@@ -587,16 +588,19 @@ void ezQtEditorApp::CreatePanels()
   ezQtApplicationPanel* pLogPanel = new ezQtLogPanel(pDockManager);
   ezQtApplicationPanel* pCVarPanel = new ezQtCVarPanel(pDockManager);
   ezQtApplicationPanel* pLongOpsPanel = new ezQtLongOpsPanel(pDockManager);
+  ezQtApplicationPanel* pAssetCheckPanel = new ezQtAssetCheckPanel(pDockManager);
 
   pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetBrowserPanel);
   pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetCuratorPanel);
   pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLogPanel);
   pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pCVarPanel);
   pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLongOpsPanel);
+  pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetCheckPanel);
 
   // by default these panels can be hidden
   pCVarPanel->toggleView(false);
   pLongOpsPanel->toggleView(false);
+  pAssetCheckPanel->toggleView(false);
 
   pAssetBrowserPanel->raise();
 }

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
@@ -23,6 +23,9 @@ public:
   ezQtAssetCheckPanel(ads::CDockManager* pDockManager);
   ~ezQtAssetCheckPanel();
 
+protected:
+  virtual bool eventFilter(QObject* pWatched, QEvent* pEvent) override;
+
 private:
   void RunButtonClicked();
   void ResultTreeItemDoubleClicked(QTreeWidgetItem* pItem, int iColumn);

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <EditorFramework/Assets/AssetCheckRule.h>
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <EditorFramework/ui_AssetCheckPanel.h>
+#include <GuiFoundation/DockPanels/ApplicationPanel.moc.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+
+class QTreeWidgetItem;
+namespace ads
+{
+  class CDockManager;
+}
+
+/// Application wide panel that runs asset check rules over a selection of assets and lists the reported issues.
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetCheckPanel : public ezQtApplicationPanel, public Ui_AssetCheckPanel
+{
+  Q_OBJECT
+
+  EZ_DECLARE_SINGLETON(ezQtAssetCheckPanel);
+
+public:
+  ezQtAssetCheckPanel(ads::CDockManager* pDockManager);
+  ~ezQtAssetCheckPanel();
+
+private:
+  void RunButtonClicked();
+  void ResultTreeItemDoubleClicked(QTreeWidgetItem* pItem, int iColumn);
+
+  void FillRuleList();
+  void UpdateAssetTypeCombo();
+  void DocumentManagerEventHandler(const ezDocumentManager::Event& e);
+
+  ezDynamicArray<ezAssetCheckRule*> m_Rules;
+};

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.ui
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AssetCheckPanel</class>
+ <widget class="QWidget" name="AssetCheckPanel">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Check Assets</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+    <normaloff>:/GuiFoundation/Icons/Checklist.svg</normaloff>:/GuiFoundation/Icons/Checklist.svg</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="AssetsGroup">
+     <property name="title">
+      <string>Assets to Check</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="AssetTypeLabel">
+        <property name="text">
+         <string>Asset Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="AssetTypeCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="NameFilterLabel">
+        <property name="text">
+         <string>Name Filter:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="NameFilterEdit">
+        <property name="placeholderText">
+         <string>All parts must match (space separated), prefix a part with - to exclude</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="RulesGroup">
+     <property name="title">
+      <string>Rules</string>
+     </property>
+     <layout class="QVBoxLayout" name="rulesLayout">
+      <item>
+       <widget class="QListWidget" name="RuleList"/>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="AutoFixCheck">
+        <property name="text">
+         <string>Automatically fix issues</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="RunButton">
+     <property name="text">
+      <string>Run Check</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeWidget" name="ResultTree">
+     <property name="headerHidden">
+      <bool>true</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="StatusLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.ui
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.ui
@@ -19,74 +19,95 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="AssetsGroup">
-     <property name="title">
-      <string>Assets to Check</string>
+    <widget class="QSplitter" name="MainSplitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="AssetTypeLabel">
-        <property name="text">
-         <string>Asset Type:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="AssetTypeCombo"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="NameFilterLabel">
-        <property name="text">
-         <string>Name Filter:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="NameFilterEdit">
-        <property name="placeholderText">
-         <string>All parts must match (space separated), prefix a part with - to exclude</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="RulesGroup">
-     <property name="title">
-      <string>Rules</string>
-     </property>
-     <layout class="QVBoxLayout" name="rulesLayout">
-      <item>
-       <widget class="QListWidget" name="RuleList"/>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="AutoFixCheck">
-        <property name="text">
-         <string>Automatically fix issues</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="RunButton">
-     <property name="text">
-      <string>Run Check</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QTreeWidget" name="ResultTree">
-     <property name="headerHidden">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
+     <widget class="QWidget" name="RulesPane">
+      <layout class="QVBoxLayout" name="rulesPaneLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="AssetsGroup">
+         <property name="title">
+          <string>Assets to Check</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="AssetTypeLabel">
+            <property name="text">
+             <string>Asset Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="AssetTypeCombo"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="NameFilterLabel">
+            <property name="text">
+             <string>Name Filter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="NameFilterEdit">
+            <property name="placeholderText">
+             <string>All parts must match (space separated), prefix a part with - to exclude</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="RulesGroup">
+         <property name="title">
+          <string>Rules</string>
+         </property>
+         <layout class="QVBoxLayout" name="rulesLayout">
+          <item>
+           <widget class="QListWidget" name="RuleList"/>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="AutoFixCheck">
+            <property name="text">
+             <string>Automatically fix issues</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="RunButton">
+         <property name="text">
+          <string>Run Check</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QTreeWidget" name="ResultTree">
+      <property name="headerHidden">
+       <bool>true</bool>
       </property>
-     </column>
+      <column>
+       <property name="text">
+        <string notr="true">1</string>
+       </property>
+      </column>
+     </widget>
     </widget>
    </item>
    <item>

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/Implementation/AssetCheckPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/Implementation/AssetCheckPanel.cpp
@@ -1,0 +1,225 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetChecker.h>
+#include <EditorFramework/Assets/AssetDocumentManager.h>
+#include <EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h>
+#include <Foundation/Math/ColorScheme.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+
+#include <QPushButton>
+
+EZ_IMPLEMENT_SINGLETON(ezQtAssetCheckPanel);
+
+ezQtAssetCheckPanel::ezQtAssetCheckPanel(ads::CDockManager* pDockManager)
+  : ezQtApplicationPanel(pDockManager, "Panel.AssetCheck")
+  , m_SingletonRegistrar(this)
+{
+  QWidget* pDummy = new QWidget();
+  setupUi(pDummy);
+  pDummy->setContentsMargins(0, 0, 0, 0);
+  pDummy->layout()->setContentsMargins(0, 0, 0, 0);
+
+  setIcon(ezQtUiServices::GetCachedIconResource(":/GuiFoundation/Icons/Checklist.svg"));
+  setWindowTitle(ezMakeQString(ezTranslate("Panel.AssetCheck")));
+  setWidget(pDummy);
+
+  connect(RunButton, &QPushButton::clicked, this, &ezQtAssetCheckPanel::RunButtonClicked);
+  connect(ResultTree, &QTreeWidget::itemDoubleClicked, this, &ezQtAssetCheckPanel::ResultTreeItemDoubleClicked);
+
+  ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezQtAssetCheckPanel::DocumentManagerEventHandler, this));
+
+  UpdateAssetTypeCombo();
+
+  ezAssetCheckRule::CreateRules(m_Rules);
+  FillRuleList();
+}
+
+ezQtAssetCheckPanel::~ezQtAssetCheckPanel()
+{
+  ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetCheckPanel::DocumentManagerEventHandler, this));
+
+  ezAssetCheckRule::DestroyRules(m_Rules);
+}
+
+void ezQtAssetCheckPanel::DocumentManagerEventHandler(const ezDocumentManager::Event& e)
+{
+  if (e.m_Type == ezDocumentManager::Event::Type::DocumentTypesAdded || e.m_Type == ezDocumentManager::Event::Type::DocumentTypesRemoved)
+  {
+    UpdateAssetTypeCombo();
+  }
+}
+
+void ezQtAssetCheckPanel::UpdateAssetTypeCombo()
+{
+  // Remember the previous selection (by asset type name) so a plugin (re-)load doesn't reset the user's choice.
+  const QString sPreviouslySelected = AssetTypeCombo->currentData().toString();
+
+  AssetTypeCombo->clear();
+  AssetTypeCombo->addItem("<All Asset Types>", QString());
+
+  ezSet<ezString> addedTypes;
+  for (auto it : ezDocumentManager::GetAllDocumentDescriptors())
+  {
+    const ezDocumentTypeDescriptor* pDesc = it.Value();
+    if (ezDynamicCast<ezAssetDocumentManager*>(pDesc->m_pManager) == nullptr)
+      continue;
+
+    if (addedTypes.Contains(pDesc->m_sDocumentTypeName))
+      continue;
+
+    addedTypes.Insert(pDesc->m_sDocumentTypeName);
+
+    const QString sTypeName = QString::fromUtf8(pDesc->m_sDocumentTypeName.GetData());
+    AssetTypeCombo->addItem(sTypeName, sTypeName);
+  }
+
+  if (const int iIndex = AssetTypeCombo->findData(sPreviouslySelected); iIndex >= 0)
+    AssetTypeCombo->setCurrentIndex(iIndex);
+}
+
+void ezQtAssetCheckPanel::FillRuleList()
+{
+  RuleList->clear();
+
+  for (ezUInt32 i = 0; i < m_Rules.GetCount(); ++i)
+  {
+    ezAssetCheckRule* pRule = m_Rules[i];
+
+    const ezStringBuilder sText = pRule->GetDisplayName();
+
+    QListWidgetItem* pItem = new QListWidgetItem(QString::fromUtf8(sText.GetData()), RuleList);
+    pItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
+    pItem->setCheckState(Qt::Checked);
+
+    ezStringBuilder sTooltip(pRule->GetDescription());
+
+    if (pRule->CanFix())
+    {
+      pItem->setForeground(ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green)));
+      sTooltip.Append("\n\nThis rule supports auto-fix.");
+    }
+
+    pItem->setToolTip(QString::fromUtf8(sTooltip.GetData()));
+    pItem->setData(Qt::UserRole, i);
+  }
+}
+
+void ezQtAssetCheckPanel::RunButtonClicked()
+{
+  ezAssetCheckOptions options;
+
+  const QVariant typeData = AssetTypeCombo->currentData();
+  options.m_sDocumentTypeName = typeData.toString().toUtf8().data();
+  options.m_sNameFilter = NameFilterEdit->text().toUtf8().data();
+  options.m_bAutoFix = AutoFixCheck->isChecked();
+
+  for (int i = 0; i < RuleList->count(); ++i)
+  {
+    QListWidgetItem* pItem = RuleList->item(i);
+    if (pItem->checkState() != Qt::Checked)
+      continue;
+
+    const ezUInt32 uiRuleIndex = pItem->data(Qt::UserRole).toUInt();
+    options.m_Rules.PushBack(m_Rules[uiRuleIndex]);
+  }
+
+  if (options.m_Rules.IsEmpty())
+  {
+    ezQtUiServices::GetSingleton()->MessageBoxInformation("Select at least one rule to run.");
+    return;
+  }
+
+  ezAssetCheckSummary summary;
+  {
+    // The modal progress dialog appears automatically via the global ezProgress.
+    ezAssetChecker::Run(options, summary);
+  }
+
+  // Fill the results tree.
+  ResultTree->clear();
+
+  const QIcon errorIcon = ezQtUiServices::GetSingleton()->GetCachedIconResource(":/GuiFoundation/Icons/Error.svg");
+  const QIcon warningIcon = ezQtUiServices::GetSingleton()->GetCachedIconResource(":/GuiFoundation/Icons/Warning.svg");
+
+  for (const ezAssetCheckResult& result : summary.m_Results)
+  {
+    ezUInt32 uiErrors = 0, uiWarnings = 0;
+    for (const ezAssetCheckNote& note : result.m_Notes)
+    {
+      if (note.m_Severity == ezAssetCheckSeverity::Error)
+        ++uiErrors;
+      else
+        ++uiWarnings;
+    }
+
+    ezStringBuilder sTitle;
+    sTitle.SetFormat("{}  ({} errors, {} warnings)", result.m_sAssetPath, uiErrors, uiWarnings);
+
+    // Link target understood by ezQtUiServices::GotoLinkTarget: "asset:<assetGuid>[#<objectGuid>]".
+    ezStringBuilder sAssetGuid;
+    ezConversionUtils::ToString(result.m_AssetGuid, sAssetGuid);
+    ezStringBuilder sAssetLink("asset:", sAssetGuid);
+
+    QTreeWidgetItem* pTop = new QTreeWidgetItem(ResultTree);
+    pTop->setText(0, QString::fromUtf8(sTitle.GetData()));
+    pTop->setIcon(0, uiErrors > 0 ? errorIcon : warningIcon);
+    pTop->setData(0, Qt::UserRole, QString::fromUtf8(sAssetLink.GetData()));
+
+    for (const ezAssetCheckNote& note : result.m_Notes)
+    {
+      ezStringBuilder sNote = note.m_sMessage;
+      if (note.m_bFixed)
+        sNote.Append(" (fixed)");
+
+      QTreeWidgetItem* pChild = new QTreeWidgetItem(pTop);
+      pChild->setText(0, QString::fromUtf8(sNote.GetData()));
+      pChild->setIcon(0, note.m_Severity == ezAssetCheckSeverity::Error ? errorIcon : warningIcon);
+
+      if (note.m_bFixed)
+        pChild->setForeground(0, ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green)));
+
+      // Append the object GUID so a double-click selects that object in the opened document.
+      ezStringBuilder sNoteLink = sAssetLink;
+      if (note.m_ObjectGuid.IsValid())
+      {
+        ezStringBuilder sObjGuid;
+        ezConversionUtils::ToString(note.m_ObjectGuid, sObjGuid);
+        sNoteLink.Append("#", sObjGuid);
+      }
+      pChild->setData(0, Qt::UserRole, QString::fromUtf8(sNoteLink.GetData()));
+    }
+
+    if (uiErrors > 0)
+      pTop->setExpanded(true);
+  }
+
+  ezStringBuilder sStatus;
+  if (summary.m_Results.IsEmpty())
+  {
+    sStatus = "No issues found.";
+  }
+  else
+  {
+    sStatus.SetFormat("Checked {} assets: {} errors, {} warnings, {} auto-fixed, {} documents saved.",
+      summary.m_uiAssetsChecked, summary.m_uiErrors, summary.m_uiWarnings, summary.m_uiFixed, summary.m_uiSaved);
+  }
+
+  if (summary.m_bCanceled)
+    sStatus.Append(" (Check was canceled; results are partial.)");
+
+  StatusLabel->setText(QString::fromUtf8(sStatus.GetData()));
+}
+
+void ezQtAssetCheckPanel::ResultTreeItemDoubleClicked(QTreeWidgetItem* pItem, int iColumn)
+{
+  if (pItem == nullptr)
+    return;
+
+  // Opens the asset and, if the link contains an object GUID, selects that object.
+  const QString sLinkTarget = pItem->data(0, Qt::UserRole).toString();
+  if (sLinkTarget.isEmpty())
+    return;
+
+  ezQtUiServices::GotoLinkTarget(sLinkTarget.toUtf8().data());
+}

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/Implementation/AssetCheckPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/Implementation/AssetCheckPanel.cpp
@@ -24,6 +24,13 @@ ezQtAssetCheckPanel::ezQtAssetCheckPanel(ads::CDockManager* pDockManager)
   setWindowTitle(ezMakeQString(ezTranslate("Panel.AssetCheck")));
   setWidget(pDummy);
 
+  MainSplitter->setStretchFactor(0, 1);
+  MainSplitter->setStretchFactor(1, 2);
+
+  // The panel has no real geometry yet at construction time (ADS assigns it later), so setSizes() here would be
+  // clamped to a 0-size splitter and lost. Apply the ratio on the splitter's first real resize instead.
+  MainSplitter->installEventFilter(this);
+
   connect(RunButton, &QPushButton::clicked, this, &ezQtAssetCheckPanel::RunButtonClicked);
   connect(ResultTree, &QTreeWidget::itemDoubleClicked, this, &ezQtAssetCheckPanel::ResultTreeItemDoubleClicked);
 
@@ -40,6 +47,21 @@ ezQtAssetCheckPanel::~ezQtAssetCheckPanel()
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetCheckPanel::DocumentManagerEventHandler, this));
 
   ezAssetCheckRule::DestroyRules(m_Rules);
+}
+
+bool ezQtAssetCheckPanel::eventFilter(QObject* pWatched, QEvent* pEvent)
+{
+  if (pWatched == MainSplitter && pEvent->type() == QEvent::Resize)
+  {
+    const int iTotal = MainSplitter->orientation() == Qt::Horizontal ? MainSplitter->width() : MainSplitter->height();
+    if (iTotal > 0)
+    {
+      MainSplitter->setSizes({iTotal / 3, iTotal - (iTotal / 3)});
+      MainSplitter->removeEventFilter(this);
+    }
+  }
+
+  return ezQtApplicationPanel::eventFilter(pWatched, pEvent);
 }
 
 void ezQtAssetCheckPanel::DocumentManagerEventHandler(const ezDocumentManager::Event& e)

--- a/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Checklist.svg
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Checklist.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#ffffff">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-width="2"> <path d="M8.5 14.5h7.657"/> <path d="M8.5 10.5h7.657"/> <path d="M8.5 6.5h7.657"/> <path d="M5.5 14.5h0"/> <path d="M5.5 10.5h0"/> <path d="M5.5 6.5h0"/> </g> <path fill="none" stroke="#ffffff" stroke-linecap="round" stroke-width="2" d="M9.128 20.197H3.444a2.22 2.22 0 01-2.229-2.153V3.152A2.153 2.153 0 013.367.997h15.48A2.153 2.153 0 0121 3.152v8.738"/> <path fill="#ffffff" d="M16.5 23.499a1.464 1.464 0 01-1.094-.484l-2.963-2.969A1.479 1.479 0 0112 18.985a1.5 1.5 0 01.462-1.078 1.56 1.56 0 012.113.037l1.925 1.931 4.943-4.959a1.543 1.543 0 012.132.02 1.461 1.461 0 01.425 1.04 1.5 1.5 0 01-.45 1.068l-5.993 6.012a1.44 1.44 0 01-1.057.443z"/> </g>
+</svg>

--- a/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Heal.svg
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Heal.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ffffff" width="800px" height="800px" viewBox="0 0 50 50" version="1.2" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" overflow="inherit">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M42.924 13h-4.924v-5.226c0-3.736-2.948-6.774-6.694-6.774h-12.611c-3.748 0-6.695 3.038-6.695 6.774v5.226h-4.925c-3.356 0-6.075 2.591-6.075 5.937v23.007c0 3.345 2.719 6.056 6.075 6.056h35.849c3.355 0 6.076-2.711 6.076-6.057v-23.006c0-3.346-2.721-5.937-6.076-5.937zm-26.924-5.226c0-1.399 1.292-2.774 2.695-2.774h12.611c1.399 0 2.694 1.375 2.694 2.774v5.226h-18v-5.226zm20 27.226h-7v7h-8v-7h-7v-8h7v-7h8v7h7v8z"/>
+</g>
+</svg>

--- a/Code/Tools/Libs/GuiFoundation/QtResources/resources.qrc
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/resources.qrc
@@ -68,5 +68,7 @@
     <file>Icons/Object.svg</file>
     <file>Icons/Edit.svg</file>
     <file>Icons/Preset.svg</file>
+    <file>Icons/Checklist.svg</file>
+    <file>Icons/Heal.svg</file>
   </qresource>
 </RCC>

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -23,6 +23,7 @@ Panel.Log;Log
 Panel.AssetCurator;Asset Curator
 Panel.CVar;CVars
 Panel.LongOps;Background Operations
+Panel.AssetCheck;Check Assets
 
 # Property Widget
 CONTAINER_AddEntry;{0}: Add Entry


### PR DESCRIPTION
Fixes #1846.

Added a "Check Assets" panel that allows you to run validation rules on all assets in the project. This can be used to find errors in the data. The rules can theoretically be quite complex, though for now the built-in rules do very basic checks:
* check for unknown tags (fixes #1649)
* find empty objects
* find invalid required references (assets / files / strings)

Custom editor plugins can add custom validation rules as well.

<img width="1418" height="1223" alt="image" src="https://github.com/user-attachments/assets/7590615b-e879-47c4-a16c-7dead9ae46f7" />
