### PR TITLE
Enable HTML log for all applications

### DIFF
--- a/Code/Editor/EditorFramework/Visualizers/Implementation/BoxVisualizerAdapter.cpp
+++ b/Code/Editor/EditorFramework/Visualizers/Implementation/BoxVisualizerAdapter.cpp
@@ -42,6 +42,10 @@ void ezBoxVisualizerAdapter::Update()
       {
         m_vScale *= val.ConvertTo<ezVec3>();
       }
+      else if (val.CanConvertTo<ezVec2>())
+      {
+        m_vScale *= val.ConvertTo<ezVec2>().GetAsVec3(1);
+      }
     }
   }
 

--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -6,6 +6,7 @@
 #include <Core/GameState/GameStateBase.h>
 #include <Core/System/Window.h>
 #include <Foundation/Application/Application.h>
+#include <Foundation/Logging/HTMLWriter.h>
 #include <Foundation/Types/UniquePtr.h>
 
 class ezWindowBase;
@@ -219,6 +220,8 @@ protected:
   ezEventSubscriptionID m_LogToConsoleID = 0;
   ezEventSubscriptionID m_LogToVsID = 0;
   ezEventSubscriptionID m_LogToTracingID = 0;
+  ezEventSubscriptionID m_LogToHTML = 0;
+  ezLogWriter::HTML m_LogHTML;
 
   /// \brief Executes all 'Init_' functions. Typically done after core system startup
   virtual void ExecuteInitFunctions();

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
@@ -173,6 +173,17 @@ void ezGameApplicationBase::Init_FileSystem_ConfigureDataDirs()
 
     appFileSystemConfig.Apply();
   }
+
+  {
+    // We need the file system before we can start the html logger.
+
+    ezGlobalLog::RemoveLogWriter(m_LogToHTML);
+    ezStringBuilder sLogFile;
+    sLogFile.SetFormat(":appdata/Log.htm");
+    m_LogHTML.BeginLog(sLogFile, GetApplicationName());
+
+    m_LogToHTML = ezGlobalLog::AddLogWriter(ezMakeDelegate(&ezLogWriter::HTML::LogMessageHandler, &m_LogHTML));
+  }
 }
 
 void ezGameApplicationBase::Init_LoadWorldModuleConfig()
@@ -268,5 +279,9 @@ void ezGameApplicationBase::Deinit_ShutdownLogging()
   // during development, keep these loggers active
   ezGlobalLog::RemoveLogWriter(m_LogToConsoleID);
   ezGlobalLog::RemoveLogWriter(m_LogToVsID);
+  ezGlobalLog::RemoveLogWriter(m_LogToTracingID);
 #endif
+
+  ezGlobalLog::RemoveLogWriter(m_LogToHTML);
+  m_LogHTML.EndLog();
 }

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -500,6 +500,14 @@ void ezRenderWorld::ExtractMainViews()
 
   s_bInExtract = true;
 
+  // must happen before the BeginExtraction broadcast, since listeners may call AddViewToRender,
+  // which appends the tasks that we have to wait for below
+  if (cvar_RenderingMultithreading)
+  {
+    EZ_LOCK(s_ExtractTasksMutex);
+    s_ExtractTasks.Clear();
+  }
+
   ezRenderWorldExtractionEvent extractionEvent;
   extractionEvent.m_Type = ezRenderWorldExtractionEvent::Type::BeginExtraction;
   extractionEvent.m_uiFrameCounter = s_uiFrameCounter;
@@ -507,8 +515,6 @@ void ezRenderWorld::ExtractMainViews()
 
   if (cvar_RenderingMultithreading)
   {
-    s_ExtractTasks.Clear();
-
     ezTaskGroupID extractTaskID = ezTaskSystem::CreateTaskGroup(ezTaskPriority::EarlyThisFrame);
     s_ExtractTasks.PushBack(extractTaskID);
 

--- a/Code/Engine/Utilities/Resources/ConfigFileResource.cpp
+++ b/Code/Engine/Utilities/Resources/ConfigFileResource.cpp
@@ -244,6 +244,8 @@ ezResourceLoadData ezConfigFileResourceLoader::OpenDataStream(const ezResource* 
         value.Trim(" ");
 
         line.SetSubString_FromTo(line.GetData(), szAssign);
+        // do not use szAssign after this line anymore
+
         line.ReplaceAll("\t", " ");
         line.ReplaceAll("  ", " ");
         line.Trim(" ");
@@ -253,7 +255,7 @@ ezResourceLoadData ezConfigFileResourceLoader::OpenDataStream(const ezResource* 
 
         if (line.StartsWith("int "))
         {
-          key.SetSubString_FromTo(line.GetData() + 4, szAssign);
+          key.SetSubString_FromTo(line.GetData() + 4, line.GetData() + line.GetElementCount());
           key.Trim(" ");
 
           if (bOverride && !intData.Contains(key))
@@ -273,7 +275,7 @@ ezResourceLoadData ezConfigFileResourceLoader::OpenDataStream(const ezResource* 
         }
         else if (line.StartsWith("float "))
         {
-          key.SetSubString_FromTo(line.GetData() + 6, szAssign);
+          key.SetSubString_FromTo(line.GetData() + 6, line.GetData() + line.GetElementCount());
           key.Trim(" ");
 
           if (bOverride && !floatData.Contains(key))
@@ -293,7 +295,7 @@ ezResourceLoadData ezConfigFileResourceLoader::OpenDataStream(const ezResource* 
         }
         else if (line.StartsWith("bool "))
         {
-          key.SetSubString_FromTo(line.GetData() + 5, szAssign);
+          key.SetSubString_FromTo(line.GetData() + 5, line.GetData() + line.GetElementCount());
           key.Trim(" ");
 
           if (bOverride && !boolData.Contains(key))
@@ -313,7 +315,7 @@ ezResourceLoadData ezConfigFileResourceLoader::OpenDataStream(const ezResource* 
         }
         else if (line.StartsWith("string "))
         {
-          key.SetSubString_FromTo(line.GetData() + 7, szAssign);
+          key.SetSubString_FromTo(line.GetData() + 7, line.GetData() + line.GetElementCount());
           key.Trim(" ");
 
           if (bOverride && !stringData.Contains(key))

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: 5CQ8QsA5DB904E-A23127-426D-4D6D-ESA93071E0893
+Change me: 5CQ8QsA5DB904E-A03127-426D-4D6E-ESA93071E0893


### PR DESCRIPTION
This was forgotten to be added to the base game application. Currently only enabled in development builds, though.

Also fixed incorrect memory access in ezConfigFileResourceLoader, and let the box visualizer work with 2D coordinates.