### PR TITLE
Use portable SIMD on MSVC ARM64

### DIFF
--- a/Code/Engine/Foundation/Platform/Win/Features_Platform.h
+++ b/Code/Engine/Foundation/Platform/Win/Features_Platform.h
@@ -87,7 +87,11 @@
 #    define EZ_SSE_LEVEL EZ_SSE_20
 #  endif
 #elif EZ_ENABLED(EZ_PLATFORM_ARCH_ARM)
-#  define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_NEON
+#  if defined(_MSC_VER) && !defined(__clang__)
+#    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_FPU
+#  else
+#    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_NEON
+#  endif
 #else
 #  error "Unknown architecture."
 #endif


### PR DESCRIPTION
MSVC does not provide __builtin_shufflevector, which the NEON SIMD implementation requires. Select the FPU implementation for the native MSVC frontend while retaining NEON for Clang.

This change was authored by GPT 5.6-Sol