### PR TITLE
Apply build filters before dependency checks

### DIFF
--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/CMakeLists.txt
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/CMakeLists.txt
@@ -1,5 +1,7 @@
 ez_cmake_init()
 
+ez_apply_build_filter(EditorPluginFmod)
+
 ez_requires_editor()
 
 ez_requires_fmod()
@@ -19,5 +21,3 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 ez_link_target_fmod(${PROJECT_NAME})
-
-

--- a/Code/EnginePlugins/FmodPlugin/CMakeLists.txt
+++ b/Code/EnginePlugins/FmodPlugin/CMakeLists.txt
@@ -1,5 +1,7 @@
 ez_cmake_init()
 
+ez_apply_build_filter(FmodPlugin)
+
 ez_requires_fmod()
 
 # Get the name of this folder as the project name

--- a/Code/Tools/Libs/ModelImporter2/CMakeLists.txt
+++ b/Code/Tools/Libs/ModelImporter2/CMakeLists.txt
@@ -1,5 +1,7 @@
 ez_cmake_init()
 
+ez_apply_build_filter(ModelImporter2)
+
 ez_requires_assimp()
 
 # Get the name of this folder as the project name


### PR DESCRIPTION
Return from excluded optional projects before calling dependency helpers supplied by their optional source trees. This allows focused build filters to configure without those dependencies present.

(I am touching this because the vcpkg port says `-DEZ_BUILD_FILTER=FoundationOnly` and we intentionally do not provide those dependencies. https://github.com/microsoft/vcpkg/blob/4bca8fd8654e5ba76f92661db7bfe954768ad8ef/ports/ezfoundation/portfile.cmake#L22 )

This change authored by GPT 5.6-Sol