### PR TITLE
Added texture channel mappings for alpha masks

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -292,6 +292,13 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
       }
       break;
 
+      case ezTexture2DChannelMappingEnum::R1_ALPHA:
+      {
+        arguments << "-r";
+        arguments << "in0.a"; // always linear
+      }
+      break;
+
       case ezTexture2DChannelMappingEnum::RG1:
       {
         arguments << "-rg";
@@ -361,6 +368,24 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
         arguments << "in2.r";
         arguments << "-a";
         arguments << "in3.r";
+      }
+      break;
+
+      case ezTexture2DChannelMappingEnum::RGBWHITE_A1:
+      {
+        arguments << "-rgb";
+        arguments << "white";
+        arguments << "-a";
+        arguments << "in0.a"; // always linear
+      }
+      break;
+
+      case ezTexture2DChannelMappingEnum::RGBWHITE_R1:
+      {
+        arguments << "-rgb";
+        arguments << "white";
+        arguments << "-a";
+        arguments << "in0.r"; // always linear
       }
       break;
     }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
@@ -5,10 +5,11 @@
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezTexture2DChannelMappingEnum, 1)
-  EZ_ENUM_CONSTANTS(ezTexture2DChannelMappingEnum::R1)
+  EZ_ENUM_CONSTANTS(ezTexture2DChannelMappingEnum::R1, ezTexture2DChannelMappingEnum::R1_ALPHA)
   EZ_ENUM_CONSTANTS(ezTexture2DChannelMappingEnum::RG1, ezTexture2DChannelMappingEnum::R1_G2)
   EZ_ENUM_CONSTANTS(ezTexture2DChannelMappingEnum::RGB1, ezTexture2DChannelMappingEnum::RGB1_ABLACK, ezTexture2DChannelMappingEnum::R1_G2_B3)
   EZ_ENUM_CONSTANTS(ezTexture2DChannelMappingEnum::RGBA1, ezTexture2DChannelMappingEnum::RGB1_A2, ezTexture2DChannelMappingEnum::R1_G2_B3_A4)
+  EZ_ENUM_CONSTANTS(ezTexture2DChannelMappingEnum::RGBWHITE_A1, ezTexture2DChannelMappingEnum::RGBWHITE_R1)
 EZ_END_STATIC_REFLECTED_ENUM;
 
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezTexture2DResolution, 1)
@@ -183,7 +184,7 @@ void ezTextureAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaState
           break;
       }
 
-      if (mapping == ezTexture2DChannelMappingEnum::R1 || mapping == ezTexture2DChannelMappingEnum::RGBA1 ||
+      if (mapping == ezTexture2DChannelMappingEnum::R1 || mapping == ezTexture2DChannelMappingEnum::R1_ALPHA || mapping == ezTexture2DChannelMappingEnum::RGBA1 ||
           mapping == ezTexture2DChannelMappingEnum::R1_G2_B3_A4 || mapping == ezTexture2DChannelMappingEnum::RGB1_A2 ||
           mapping == ezTexture2DChannelMappingEnum::R1_G2_B3_A4)
       {
@@ -193,6 +194,17 @@ void ezTextureAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaState
           props["DilateColor"].m_Visibility = ezPropertyUiState::Default;
         }
 
+        if (hasMips)
+        {
+          props["PreserveAlphaCoverage"].m_Visibility = ezPropertyUiState::Default;
+          props["AlphaThreshold"].m_Visibility = ezPropertyUiState::Default;
+        }
+      }
+
+      if (mapping == ezTexture2DChannelMappingEnum::RGBWHITE_A1 || mapping == ezTexture2DChannelMappingEnum::RGBWHITE_R1)
+      {
+        // RGB is a constant white, so dilating the color into transparent areas is pointless,
+        // but keeping the mask's coverage across mips is not.
         if (hasMips)
         {
           props["PreserveAlphaCoverage"].m_Visibility = ezPropertyUiState::Default;
@@ -232,10 +244,13 @@ ezInt32 ezTextureAssetProperties::GetNumInputFiles() const
   switch (m_ChannelMapping)
   {
     case ezTexture2DChannelMappingEnum::R1:
+    case ezTexture2DChannelMappingEnum::R1_ALPHA:
     case ezTexture2DChannelMappingEnum::RG1:
     case ezTexture2DChannelMappingEnum::RGB1:
     case ezTexture2DChannelMappingEnum::RGB1_ABLACK:
     case ezTexture2DChannelMappingEnum::RGBA1:
+    case ezTexture2DChannelMappingEnum::RGBWHITE_A1:
+    case ezTexture2DChannelMappingEnum::RGBWHITE_R1:
       return 1;
 
     case ezTexture2DChannelMappingEnum::R1_G2:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.h
@@ -14,6 +14,7 @@ struct ezTexture2DChannelMappingEnum
   enum Enum
   {
     R1,
+    R1_ALPHA,
 
     RG1,
     R1_G2,
@@ -25,6 +26,12 @@ struct ezTexture2DChannelMappingEnum
     RGB1_A2,
     RGB1_ABLACK,
     R1_G2_B3_A4,
+
+    // 'mask' textures: RGB is a constant white, the mask itself ends up in the alpha channel.
+    // Ideally this would be a single channel texture combined with a GPU side texture swizzle,
+    // but D3D11 has no support for component swizzles, so for now the white is baked in.
+    RGBWHITE_A1,
+    RGBWHITE_R1,
 
     Default = RGB1,
   };

--- a/Data/Tools/ezEditor/Localization/en/TextureAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/TextureAsset.txt
@@ -68,15 +68,18 @@ ezTexConvCompressionMode::High;Strong Compression
 
 ezImageAddressMode::ClampBorder;Clamp to Black
 
-ezTexture2DChannelMappingEnum::R1;Red - Single Input
-ezTexture2DChannelMappingEnum::RG1;Red Green - Single Input
+ezTexture2DChannelMappingEnum::R1;Red - Single Input (R)
+ezTexture2DChannelMappingEnum::R1_ALPHA;Red - Single Input (A)
+ezTexture2DChannelMappingEnum::RG1;Red Green - Single Input (RG)
 ezTexture2DChannelMappingEnum::R1_G2;RG - Input1.r, Input2.r
-ezTexture2DChannelMappingEnum::RGB1;RGB - Single Input
+ezTexture2DChannelMappingEnum::RGB1;RGB - Single Input (RGB)
 ezTexture2DChannelMappingEnum::R1_G2_B3;RGB - Input1.r, Input2.r, Input3.r
-ezTexture2DChannelMappingEnum::RGBA1;RGBA - Single Input
+ezTexture2DChannelMappingEnum::RGBA1;RGBA - Single Input (RGBA)
 ezTexture2DChannelMappingEnum::RGB1_A2;RGBA - Input1.rgb, Input2.r
 ezTexture2DChannelMappingEnum::R1_G2_B3_A4;RGBA - Input1.r, Input2.r, Input3.r, Input4.r
 ezTexture2DChannelMappingEnum::RGB1_ABLACK;RGBA - Input1.rgb, Alpha = Black
+ezTexture2DChannelMappingEnum::RGBWHITE_A1;RGBA - RGB = White, Alpha = Input1.a
+ezTexture2DChannelMappingEnum::RGBWHITE_R1;RGBA - RGB = White, Alpha = Input1.r
 
 ezTextureCubeChannelMappingEnum::RGB1;Cubemap: RGB - Single Input
 ezTextureCubeChannelMappingEnum::RGBA1;Cubemap: RGBA - Single Input


### PR DESCRIPTION
* Added a channel mapping for moving the ALPHA channel into a single channel RED texture.
* Added channel mappings for setting RGB to WHITE and alpha to RED or ALPHA of the input texture. The latter could be done more efficinetly with texture swizzling, once we don't need to support D3D11 anymore.