### PR TITLE
Particle System Improvements

### DIFF
--- a/Code/EnginePlugins/ParticlePlugin/Declarations.h
+++ b/Code/EnginePlugins/ParticlePlugin/Declarations.h
@@ -146,12 +146,33 @@ struct EZ_PARTICLEPLUGIN_DLL ezParticleTextureAtlasType
     RandomVariations,  ///< Pick random tile for variation
     FlipbookAnimation, ///< Animate through tiles over lifetime
     RandomYAnimatedX,  ///< Random Y row, animate X over lifetime
+    RandomXAnimatedY,  ///< Random X column, animate Y over lifetime
 
     Default = None
   };
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleTextureAtlasType);
+
+//////////////////////////////////////////////////////////////////////////
+
+/// Which edge of the source texture is treated as "forward" (i.e. unrotated)
+struct EZ_PARTICLEPLUGIN_DLL ezParticleTextureAtlasOrientation
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    Up,    ///< Texture's authored "forward" edge is unrotated (current/default behavior)
+    Right, ///< Cell content rotated 90° clockwise
+    Down,  ///< Cell content rotated 180°
+    Left,  ///< Cell content rotated 270° clockwise
+
+    Default = Up
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleTextureAtlasOrientation);
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/Code/EnginePlugins/ParticlePlugin/ParticlePluginPCH.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/ParticlePluginPCH.cpp
@@ -41,6 +41,16 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezParticleTextureAtlasType, 1)
   EZ_ENUM_CONSTANT(ezParticleTextureAtlasType::RandomVariations),
   EZ_ENUM_CONSTANT(ezParticleTextureAtlasType::FlipbookAnimation),
   EZ_ENUM_CONSTANT(ezParticleTextureAtlasType::RandomYAnimatedX),
+  EZ_ENUM_CONSTANT(ezParticleTextureAtlasType::RandomXAnimatedY),
+EZ_END_STATIC_REFLECTED_ENUM;
+
+//////////////////////////////////////////////////////////////////////////
+
+EZ_BEGIN_STATIC_REFLECTED_ENUM(ezParticleTextureAtlasOrientation, 1)
+  EZ_ENUM_CONSTANT(ezParticleTextureAtlasOrientation::Up),
+  EZ_ENUM_CONSTANT(ezParticleTextureAtlasOrientation::Right),
+  EZ_ENUM_CONSTANT(ezParticleTextureAtlasOrientation::Down),
+  EZ_ENUM_CONSTANT(ezParticleTextureAtlasOrientation::Left),
 EZ_END_STATIC_REFLECTED_ENUM;
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.cpp
@@ -24,7 +24,7 @@ ezParticleRenderer::TempSystemCB::~TempSystemCB()
   ezRenderContext::DeleteConstantBufferStorage(m_hConstantBuffer);
 }
 
-void ezParticleRenderer::TempSystemCB::SetGenericData(const ezTransform& objectTransform, ezTime effectLifeTime, ezUInt8 uiNumVariationsX, ezUInt8 uiNumVariationsY, ezUInt8 uiNumFlipbookAnimsX, ezUInt8 uiNumFlipbookAnimsY, float fNormalCurvature, float fLightDirectionality, float fGeometryProximityFadeOut, float fCameraProximityFadeOut)
+void ezParticleRenderer::TempSystemCB::SetGenericData(const ezTransform& objectTransform, ezTime effectLifeTime, ezUInt8 uiNumVariationsX, ezUInt8 uiNumVariationsY, ezUInt8 uiNumFlipbookAnimsX, ezUInt8 uiNumFlipbookAnimsY, float fNormalCurvature, float fLightDirectionality, float fGeometryProximityFadeOut, float fCameraProximityFadeOut, ezUInt8 uiTextureAtlasOrientation)
 {
   ezParticleSystemConstants& cb = m_pConstants->GetDataForWriting();
   cb.ObjectToWorldMatrix = objectTransform.GetAsMat4();
@@ -37,7 +37,7 @@ void ezParticleRenderer::TempSystemCB::SetGenericData(const ezTransform& objectT
   cb.LightDirectionality = fLightDirectionality;
   cb.GeometryProximityFadeOut = fGeometryProximityFadeOut;
   cb.CameraProximityFadeOut = fCameraProximityFadeOut;
-  cb.ParticlePadding = 0;
+  cb.TextureAtlasOrientation = uiTextureAtlasOrientation;
 }
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.h
@@ -36,7 +36,7 @@ protected:
     ~TempSystemCB();
 
     /// Sets general particle system rendering parameters including transform, texture variations, and lighting.
-    void SetGenericData(const ezTransform& objectTransform, ezTime effectLifeTime, ezUInt8 uiNumVariationsX, ezUInt8 uiNumVariationsY, ezUInt8 uiNumFlipbookAnimsX, ezUInt8 uiNumFlipbookAnimsY, float fNormalCurvature = 0, float fLightDirectionality = 0, float fGeometryProximityFadeOut = 0.1f, float fCameraProximityFadeOut = 0.5f);
+    void SetGenericData(const ezTransform& objectTransform, ezTime effectLifeTime, ezUInt8 uiNumVariationsX, ezUInt8 uiNumVariationsY, ezUInt8 uiNumFlipbookAnimsX, ezUInt8 uiNumFlipbookAnimsY, float fNormalCurvature = 0, float fLightDirectionality = 0, float fGeometryProximityFadeOut = 0.1f, float fCameraProximityFadeOut = 0.5f, ezUInt8 uiTextureAtlasOrientation = 0);
 
     /// Sets trail-specific rendering parameters.
     void SetTrailData(float fSnapshotFraction, ezInt32 iNumUsedTrailPoints);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
@@ -36,6 +36,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleTypeQuadFactory, 2, ezRTTIDefaultAlloc
     EZ_MEMBER_PROPERTY("CustomMaterial", m_sCustomMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", "QuadParticle")),
     EZ_MEMBER_PROPERTY("Texture", m_sTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D"), new ezDefaultValueAttribute(ezStringView("{ e00262e8-58f5-42f5-880d-569257047201 }"))),// wrap in ezStringView to prevent a memory leak report
     EZ_ENUM_MEMBER_PROPERTY("TextureAtlas", ezParticleTextureAtlasType, m_TextureAtlasType),
+    EZ_ENUM_MEMBER_PROPERTY("TextureOrientation", ezParticleTextureAtlasOrientation, m_TextureAtlasOrientation),
     EZ_MEMBER_PROPERTY("NumSpritesX", m_uiNumSpritesX)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(1, 16)),
     EZ_MEMBER_PROPERTY("NumSpritesY", m_uiNumSpritesY)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(1, 16)),
     EZ_MEMBER_PROPERTY("TintColorParam", m_sTintColorParameter),
@@ -68,6 +69,7 @@ void ezParticleTypeQuadFactory::CopyTypeProperties(ezParticleType* pObject, bool
   pType->m_uiNumSpritesY = m_uiNumSpritesY;
   pType->m_sTintColorParameter = ezTempHashedString(m_sTintColorParameter.GetData());
   pType->m_TextureAtlasType = m_TextureAtlasType;
+  pType->m_TextureAtlasOrientation = m_TextureAtlasOrientation;
   pType->m_fStretch = m_fStretch;
   pType->m_LightingMode = m_LightingMode;
   pType->m_fNormalCurvature = m_fNormalCurvature;
@@ -99,6 +101,7 @@ enum class TypeQuadVersion
   Version_6, // added particle lighting
   Version_7, // added custom material support
   Version_8, // added proximity fade out parameters
+  Version_9, // added texture atlas orientation
 
   // insert new version numbers above
   Version_Count,
@@ -139,6 +142,9 @@ void ezParticleTypeQuadFactory::Save(ezStreamWriter& inout_stream) const
   // Version 8
   inout_stream << m_fGeometryProximityFadeOut;
   inout_stream << m_fCameraProximityFadeOut;
+
+  // Version 9
+  inout_stream << m_TextureAtlasOrientation;
 }
 
 void ezParticleTypeQuadFactory::Load(ezStreamReader& inout_stream, const ezParticleEffectDescriptor& ownerEffectDescriptor, const ezParticleSystemDescriptor& ownerSystemDescriptor)
@@ -202,6 +208,11 @@ void ezParticleTypeQuadFactory::Load(ezStreamReader& inout_stream, const ezParti
     inout_stream >> m_fGeometryProximityFadeOut;
     inout_stream >> m_fCameraProximityFadeOut;
   }
+
+  if (uiVersion >= 9)
+  {
+    inout_stream >> m_TextureAtlasOrientation;
+  }
 }
 
 void ezParticleTypeQuadFactory::QueryFinalizerDependencies(ezSet<const ezRTTI*>& inout_finalizerDeps) const
@@ -233,7 +244,7 @@ void ezParticleTypeQuad::CreateRequiredStreams()
     CreateStream("Axis", ezProcessingStream::DataType::Float3, &m_pStreamAxis, true);
   }
 
-  if (m_TextureAtlasType == ezParticleTextureAtlasType::RandomVariations || m_TextureAtlasType == ezParticleTextureAtlasType::RandomYAnimatedX)
+  if (m_TextureAtlasType == ezParticleTextureAtlasType::RandomVariations || m_TextureAtlasType == ezParticleTextureAtlasType::RandomYAnimatedX || m_TextureAtlasType == ezParticleTextureAtlasType::RandomXAnimatedY)
   {
     CreateStream("Variation", ezProcessingStream::DataType::Int, &m_pStreamVariation, false);
   }
@@ -494,6 +505,7 @@ void ezParticleTypeQuad::AddParticleRenderData(ezMsgExtractRenderData& msg, cons
   pRenderData->m_uiNumFlipbookAnimationsX = 1;
   pRenderData->m_uiNumFlipbookAnimationsY = 1;
   pRenderData->m_LightingMode = m_LightingMode;
+  pRenderData->m_TextureAtlasOrientation = m_TextureAtlasOrientation;
   pRenderData->m_fNormalCurvature = m_fNormalCurvature;
   pRenderData->m_fLightDirectionality = m_fLightDirectionality;
   pRenderData->m_fGeometryProximityFadeOut = m_fGeometryProximityFadeOut;
@@ -536,6 +548,11 @@ void ezParticleTypeQuad::AddParticleRenderData(ezMsgExtractRenderData& msg, cons
     case ezParticleTextureAtlasType::RandomYAnimatedX:
       pRenderData->m_uiNumFlipbookAnimationsX = m_uiNumSpritesX;
       pRenderData->m_uiNumVariationsY = m_uiNumSpritesY;
+      break;
+
+    case ezParticleTextureAtlasType::RandomXAnimatedY:
+      pRenderData->m_uiNumVariationsX = m_uiNumSpritesX;
+      pRenderData->m_uiNumFlipbookAnimationsY = m_uiNumSpritesY;
       break;
   }
 

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.h
@@ -53,6 +53,7 @@ public:
   ezEnum<ezParticleTypeRenderMode> m_RenderMode;
   ezEnum<ezParticleLightingMode> m_LightingMode;
   ezEnum<ezParticleTextureAtlasType> m_TextureAtlasType;
+  ezEnum<ezParticleTextureAtlasOrientation> m_TextureAtlasOrientation;
   ezUInt8 m_uiNumSpritesX = 1;
   ezUInt8 m_uiNumSpritesY = 1;
   bool m_bUseCustomMaterial = false;
@@ -90,6 +91,7 @@ public:
   ezEnum<ezParticleTypeRenderMode> m_RenderMode;
   ezEnum<ezParticleLightingMode> m_LightingMode;
   ezEnum<ezParticleTextureAtlasType> m_TextureAtlasType;
+  ezEnum<ezParticleTextureAtlasOrientation> m_TextureAtlasOrientation;
   ezUInt8 m_uiNumSpritesX = 1;
   ezUInt8 m_uiNumSpritesY = 1;
 

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.cpp
@@ -97,7 +97,7 @@ void ezParticleQuadRenderer::RenderBatch(const ezRenderViewContext& renderViewCo
 
     ConfigureRenderMode(pRenderData, pRenderContext);
 
-    systemConstants.SetGenericData(pRenderData->m_GlobalTransform, pRenderData->m_TotalEffectLifeTime, pRenderData->m_uiNumVariationsX, pRenderData->m_uiNumVariationsY, pRenderData->m_uiNumFlipbookAnimationsX, pRenderData->m_uiNumFlipbookAnimationsY, pRenderData->m_fNormalCurvature, pRenderData->m_fLightDirectionality, pRenderData->m_fGeometryProximityFadeOut, pRenderData->m_fCameraProximityFadeOut);
+    systemConstants.SetGenericData(pRenderData->m_GlobalTransform, pRenderData->m_TotalEffectLifeTime, pRenderData->m_uiNumVariationsX, pRenderData->m_uiNumVariationsY, pRenderData->m_uiNumFlipbookAnimationsX, pRenderData->m_uiNumFlipbookAnimationsY, pRenderData->m_fNormalCurvature, pRenderData->m_fLightDirectionality, pRenderData->m_fGeometryProximityFadeOut, pRenderData->m_fCameraProximityFadeOut, pRenderData->m_TextureAtlasOrientation.GetValue());
 
     pRenderContext->SetShaderPermutationVariable("PARTICLE_QUAD_MODE", pRenderData->m_QuadModePermutation);
 

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.h
@@ -27,6 +27,7 @@ public:
   ezUInt8 m_uiNumVariationsY = 1;
   ezUInt8 m_uiNumFlipbookAnimationsX = 1;
   ezUInt8 m_uiNumFlipbookAnimationsY = 1;
+  ezEnum<ezParticleTextureAtlasOrientation> m_TextureAtlasOrientation;
   ezEnum<ezParticleTypeRenderMode> m_RenderMode;
   ezEnum<ezParticleLightingMode> m_LightingMode;
 

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.cpp
@@ -23,6 +23,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleTypeTrailFactory, 1, ezRTTIDefaultAllo
     EZ_MEMBER_PROPERTY("Texture", m_sTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D"), new ezDefaultValueAttribute(ezStringView("{ e00262e8-58f5-42f5-880d-569257047201 }"))),// wrap in ezStringView to prevent a memory leak report
     EZ_MEMBER_PROPERTY("Segments", m_uiMaxPoints)->AddAttributes(new ezDefaultValueAttribute(6), new ezClampValueAttribute(3, 64)),
     EZ_ENUM_MEMBER_PROPERTY("TextureAtlas", ezParticleTextureAtlasType, m_TextureAtlasType),
+    EZ_ENUM_MEMBER_PROPERTY("TextureOrientation", ezParticleTextureAtlasOrientation, m_TextureAtlasOrientation),
     EZ_MEMBER_PROPERTY("NumSpritesX", m_uiNumSpritesX)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(1, 16)),
     EZ_MEMBER_PROPERTY("NumSpritesY", m_uiNumSpritesY)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(1, 16)),
     EZ_MEMBER_PROPERTY("TintColorParam", m_sTintColorParameter),
@@ -48,6 +49,7 @@ void ezParticleTypeTrailFactory::CopyTypeProperties(ezParticleType* pObject, boo
   pType->m_uiMaxPoints = m_uiMaxPoints;
   pType->m_hTexture.Invalidate();
   pType->m_TextureAtlasType = m_TextureAtlasType;
+  pType->m_TextureAtlasOrientation = m_TextureAtlasOrientation;
   pType->m_uiNumSpritesX = m_uiNumSpritesX;
   pType->m_uiNumSpritesY = m_uiNumSpritesY;
   pType->m_sTintColorParameter = ezTempHashedString(m_sTintColorParameter.GetData());
@@ -95,6 +97,7 @@ enum class TypeTrailVersion
   Version_5, // added distortion mode
   Version_6, // added particle lighting
   Version_7, // added custom material support
+  Version_8, // added texture atlas orientation
 
   // insert new version numbers above
   Version_Count,
@@ -133,6 +136,9 @@ void ezParticleTypeTrailFactory::Save(ezStreamWriter& inout_stream) const
   // Version 7
   inout_stream << m_bUseCustomMaterial;
   inout_stream << m_sCustomMaterial;
+
+  // Version 8
+  inout_stream << m_TextureAtlasOrientation;
 }
 
 void ezParticleTypeTrailFactory::Load(ezStreamReader& inout_stream, const ezParticleEffectDescriptor& ownerEffectDescriptor, const ezParticleSystemDescriptor& ownerSystemDescriptor)
@@ -189,6 +195,11 @@ void ezParticleTypeTrailFactory::Load(ezStreamReader& inout_stream, const ezPart
     inout_stream >> m_bUseCustomMaterial;
     inout_stream >> m_sCustomMaterial;
   }
+
+  if (uiVersion >= 8)
+  {
+    inout_stream >> m_TextureAtlasOrientation;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -213,7 +224,7 @@ void ezParticleTypeTrail::CreateRequiredStreams()
 
   m_pStreamVariation = nullptr;
 
-  if (m_TextureAtlasType == ezParticleTextureAtlasType::RandomVariations || m_TextureAtlasType == ezParticleTextureAtlasType::RandomYAnimatedX)
+  if (m_TextureAtlasType == ezParticleTextureAtlasType::RandomVariations || m_TextureAtlasType == ezParticleTextureAtlasType::RandomYAnimatedX || m_TextureAtlasType == ezParticleTextureAtlasType::RandomXAnimatedY)
   {
     CreateStream("Variation", ezProcessingStream::DataType::Int, &m_pStreamVariation, false);
   }
@@ -308,6 +319,7 @@ void ezParticleTypeTrail::ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg,
   pRenderData->m_TrailPointsShared = m_TrailPointsShared;
   pRenderData->m_fSnapshotFraction = m_fSnapshotFraction;
   pRenderData->m_LightingMode = m_LightingMode;
+  pRenderData->m_TextureAtlasOrientation = m_TextureAtlasOrientation;
   pRenderData->m_fNormalCurvature = m_fNormalCurvature;
   pRenderData->m_fLightDirectionality = m_fLightDirectionality;
   pRenderData->m_hCustomMaterial = m_hCustomMaterial;
@@ -335,6 +347,11 @@ void ezParticleTypeTrail::ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg,
     case ezParticleTextureAtlasType::RandomYAnimatedX:
       pRenderData->m_uiNumFlipbookAnimationsX = m_uiNumSpritesX;
       pRenderData->m_uiNumVariationsY = m_uiNumSpritesY;
+      break;
+
+    case ezParticleTextureAtlasType::RandomXAnimatedY:
+      pRenderData->m_uiNumVariationsX = m_uiNumSpritesX;
+      pRenderData->m_uiNumFlipbookAnimationsY = m_uiNumSpritesY;
       break;
   }
 

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.h
@@ -25,6 +25,7 @@ public:
   ezTime m_UpdateDiff;
   ezString m_sTexture;
   ezEnum<ezParticleTextureAtlasType> m_TextureAtlasType;
+  ezEnum<ezParticleTextureAtlasOrientation> m_TextureAtlasOrientation;
   ezUInt8 m_uiNumSpritesX = 1;
   ezUInt8 m_uiNumSpritesY = 1;
   ezString m_sTintColorParameter;
@@ -54,6 +55,7 @@ public:
   ezTime m_UpdateDiff;
   ezTexture2DResourceHandle m_hTexture;
   ezEnum<ezParticleTextureAtlasType> m_TextureAtlasType;
+  ezEnum<ezParticleTextureAtlasOrientation> m_TextureAtlasOrientation;
   ezUInt8 m_uiNumSpritesX = 1;
   ezUInt8 m_uiNumSpritesY = 1;
   ezTempHashedString m_sTintColorParameter;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.cpp
@@ -118,7 +118,7 @@ void ezParticleTrailRenderer::RenderBatch(const ezRenderViewContext& renderViewC
 
     bindGroupMaterial.BindTexture("ParticleTexture", pRenderData->m_hTexture);
 
-    systemConstants.SetGenericData(pRenderData->m_GlobalTransform, pRenderData->m_TotalEffectLifeTime, pRenderData->m_uiNumVariationsX, pRenderData->m_uiNumVariationsY, pRenderData->m_uiNumFlipbookAnimationsX, pRenderData->m_uiNumFlipbookAnimationsY, pRenderData->m_fNormalCurvature, pRenderData->m_fLightDirectionality);
+    systemConstants.SetGenericData(pRenderData->m_GlobalTransform, pRenderData->m_TotalEffectLifeTime, pRenderData->m_uiNumVariationsX, pRenderData->m_uiNumVariationsY, pRenderData->m_uiNumFlipbookAnimationsX, pRenderData->m_uiNumFlipbookAnimationsY, pRenderData->m_fNormalCurvature, pRenderData->m_fLightDirectionality, 0.1f, 0.5f, pRenderData->m_TextureAtlasOrientation.GetValue());
     systemConstants.SetTrailData(pRenderData->m_fSnapshotFraction, pRenderData->m_uiMaxTrailPoints);
 
     ezUInt32 uiNumParticles = pRenderData->m_BaseParticleData.GetCount();

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.h
@@ -30,6 +30,7 @@ public:
   ezUInt8 m_uiNumVariationsY = 1;
   ezUInt8 m_uiNumFlipbookAnimationsX = 1;
   ezUInt8 m_uiNumFlipbookAnimationsY = 1;
+  ezEnum<ezParticleTextureAtlasOrientation> m_TextureAtlasOrientation;
 
   ezEnum<ezParticleTypeRenderMode> m_RenderMode;
   ezEnum<ezParticleLightingMode> m_LightingMode;

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/DefaultQuadParticle.ezShader
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/DefaultQuadParticle.ezShader
@@ -20,7 +20,7 @@ CAMERA_MODE
 
 [SHADER]
 
-#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2;
+#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2; float2 ParticleUV : TEXCOORD3;
 #define USE_TEXCOORD0
 #define USE_COLOR0
 
@@ -50,7 +50,12 @@ struct PS_IN
   float FogAmount : FOG;
   float Life : TEXCOORD1;
   float Variation : TEXCOORD2;
+  float2 ParticleUV : TEXCOORD3;
 };
+
+Prefer the UV accessors over touching these fields directly:
+  GetParticleQuadUV()      - raw [0-1] across the particle, ignores the flipbook / variation atlas
+  GetParticleFlipbookUV()  - the atlas transformed coordinate, i.e. what ParticleTexture uses below
 
 Particle System constants can be accessed through the ezParticleSystemConstants buffer, see
   Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleSystemConstants.h

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/DefaultTrailParticle.ezShader
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/DefaultTrailParticle.ezShader
@@ -20,7 +20,7 @@ CAMERA_MODE
 
 [SHADER]
 
-#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2;
+#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2; float2 ParticleUV : TEXCOORD3;
 #define USE_TEXCOORD0
 #define USE_COLOR0
 
@@ -50,7 +50,13 @@ struct PS_IN
   float FogAmount : FOG;
   float Life : TEXCOORD1;
   float Variation : TEXCOORD2;
+  float2 ParticleUV : TEXCOORD3;
 };
+
+Prefer the UV accessors over touching these fields directly:
+  GetParticleQuadUV()      - raw [0-1] across the trail, ignores the flipbook / variation atlas
+                             .x runs across the trail, .y along it
+  GetParticleFlipbookUV()  - the atlas transformed coordinate, i.e. what ParticleTexture uses below
 
 Particle System constants can be accessed through the ezParticleSystemConstants buffer, see
   Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleSystemConstants.h

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleCommonVS.h
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleCommonVS.h
@@ -153,6 +153,23 @@ float2 ComputeAtlasTexCoordRandomAnimated(float2 baseTexCoord, uint numVarsX, ui
   return texCoordOffsetAndSize.xy + baseTexCoord * texCoordOffsetAndSize.zw;
 }
 
+// Rotates a normalized [0-1]^2 local UV (e.g. within one atlas cell) around its center.
+// orientation: 0 = Up (identity), 1 = Right (90° CW), 2 = Down (180°), 3 = Left (270° CW)
+// Lets a texture authored with its "forward" content running in any of the 4 cardinal
+// directions be used correctly, regardless of which direction the particle stretches/moves in.
+float2 RotateAtlasCellUV(float2 uv, uint orientation)
+{
+  float2 c = uv - 0.5;
+  float2 r = c;
+  if (orientation == 1)
+    r = float2(c.y, -c.x);  // Right, 90°
+  else if (orientation == 2)
+    r = float2(-c.x, -c.y); // Down, 180°
+  else if (orientation == 3)
+    r = float2(-c.y, c.x);  // Left, 270°
+  return r + 0.5;
+}
+
 float3 CalculateParticleLighting(float4 screenPosition, float3 worldPosition, float3 worldNormal)
 {
   float3 totalLight = 0.0f;

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/ParticlePixelShader.h
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/ParticlePixelShader.h
@@ -14,6 +14,7 @@ struct TMP_PS_IN
   float FogAmount : FOG;
   float Life : TEXCOORD1;
   float Variation : TEXCOORD2;
+  float2 ParticleUV : TEXCOORD3;
 };
 
 struct PS_GLOBALS
@@ -117,3 +118,17 @@ float4 main(PS_IN Input)
 }
 
 #endif
+
+// The raw [0-1] coordinate across the particle, unaffected by the flipbook / variation atlas.
+// Use this to sample textures that should NOT be chopped up by the flipbook, e.g. a background
+// pattern that a flipbook mask is blended with.
+float2 GetParticleQuadUV()
+{
+  return G.Input.ParticleUV;
+}
+
+// The flipbook / variation transformed coordinate, i.e. what the built-in particle texture uses.
+float2 GetParticleFlipbookUV()
+{
+  return G.Input.TexCoord0;
+}

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleSystemConstants.h
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleSystemConstants.h
@@ -30,5 +30,5 @@ CONSTANT_BUFFER2(ezParticleSystemConstants, 2, BG_DRAW_CALL)
   FLOAT1(GeometryProximityFadeOut);
   FLOAT1(CameraProximityFadeOut);
 
-  INT1(ParticlePadding);
+  UINT1(TextureAtlasOrientation); // 0=Up,1=Right,2=Down,3=Left
 };

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/QuadParticleVertexShader.h
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/QuadParticleVertexShader.h
@@ -22,6 +22,7 @@ struct TMP_VS_OUT
   float FogAmount : FOG;
   float Life : TEXCOORD1;
   float Variation : TEXCOORD2;
+  float2 ParticleUV : TEXCOORD3;
 };
 
 TMP_VS_OUT main(TMP_VS_IN input)
@@ -35,6 +36,7 @@ TMP_VS_OUT main(TMP_VS_IN input)
   ret.FogAmount = 1.0;  // 1 == no fog
   ret.Life = 1.0;       // 1 == just spawned
   ret.Variation = 42.0; // purely random value
+  ret.ParticleUV = input.TexCoord0;
 
   return ret;
 }
@@ -83,11 +85,16 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
 
   float fVariation = (baseParticle.Variation & 255) / 255.0;
 
+  // the raw [0-1] coordinate across the quad, before the flipbook / variation atlas transform is applied
 #  if PARTICLE_QUAD_MODE == PARTICLE_QUAD_MODE_AXIS_ALIGNED
-  ret.TexCoord0 = ComputeAtlasTexCoordRandomAnimated(QuadTexCoordsAxisAligned[vertexIndex], TextureAtlasVariationFramesX, TextureAtlasVariationFramesY, fVariation, TextureAtlasFlipbookFramesX, TextureAtlasFlipbookFramesY, 1.0f - particleLife);
+  float2 quadUV = QuadTexCoordsAxisAligned[vertexIndex];
 #  else
-  ret.TexCoord0 = ComputeAtlasTexCoordRandomAnimated(QuadTexCoordsBillboard[vertexIndex], TextureAtlasVariationFramesX, TextureAtlasVariationFramesY, fVariation, TextureAtlasFlipbookFramesX, TextureAtlasFlipbookFramesY, 1.0f - particleLife);
+  float2 quadUV = QuadTexCoordsBillboard[vertexIndex];
 #  endif
+
+  float2 rotatedUV = RotateAtlasCellUV(quadUV, TextureAtlasOrientation);
+  ret.ParticleUV = rotatedUV;
+  ret.TexCoord0 = ComputeAtlasTexCoordRandomAnimated(rotatedUV, TextureAtlasVariationFramesX, TextureAtlasVariationFramesY, fVariation, TextureAtlasFlipbookFramesX, TextureAtlasFlipbookFramesY, 1.0f - particleLife);
 
 #  if PARTICLE_LIGHTING_MODE == PARTICLE_LIGHTING_MODE_VERTEX_LIT
   float3 diffuseLight = CalculateParticleLighting(quad.screenPosition, quad.worldPosition, quad.normal);

--- a/Data/Plugins/ParticlePlugin/Shaders/Particles/TrailParticleVertexShader.h
+++ b/Data/Plugins/ParticlePlugin/Shaders/Particles/TrailParticleVertexShader.h
@@ -15,6 +15,7 @@ struct TMP_VS_OUT
   float2 TexCoord0 : TEXCOORD0;
   float4 Color0 : COLOR0;
   float FogAmount : FOG;
+  float2 ParticleUV : TEXCOORD3;
 };
 
 TMP_VS_OUT main(TMP_VS_IN input)
@@ -26,6 +27,7 @@ TMP_VS_OUT main(TMP_VS_IN input)
   ret.TexCoord0 = input.TexCoord0;
   ret.Color0 = float4(1, 1, 1, 1);
   ret.FogAmount = 1.0; // 1 == no fog
+  ret.ParticleUV = input.TexCoord0;
 
   return ret;
 }
@@ -68,6 +70,7 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
     ret.FogAmount = 1.0;
     ret.Life = particleLife;
     ret.Variation = 0.0;
+    ret.ParticleUV = float2(0, 0);
   }
   else
   {
@@ -80,9 +83,11 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
     // UV step is currently calculated over the maximum number of segments, instead of the active number of segments
     // this means at start the texture is cut off, instead of stretching over the full UV space
     // doing it differently would be very complicated though
-    float uvStep = textureAtlasRect.z / (NumUsedTrailPoints - 2);
-    float uvCoord = uvStep * vertexTrailPointIndex;
-    float uvSubtract = uvStep * SnapshotFraction; // to adjust the UV coordinates while the first position glides along, to not have jumps when a new segment is added
+    // computed in normalized [0-1] local space (i.e. relative to one atlas cell), so that
+    // RotateAtlasCellUV below can rotate it the same way as the Quad particle type does
+    float uvStepLocal = 1.0 / (NumUsedTrailPoints - 2);
+    float alongLocal = uvStepLocal * vertexTrailPointIndex;
+    float uvSubtractLocal = uvStepLocal * SnapshotFraction; // to adjust the UV coordinates while the first position glides along, to not have jumps when a new segment is added
 
     int prevTrailPointIdx = max(vertexTrailPointIndex - 1, 0);
     int nextTrailPointIdx = min(vertexTrailPointIndex + 1, trailParticle.NumPoints - 1);
@@ -102,17 +107,24 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
     float4 screenPosition = mul(GetWorldToScreenMatrix(), worldPosition);
 
     ret.Position = screenPosition;
-    ret.TexCoord0.y = textureAtlasRect.x + uvCoord;
-    ret.TexCoord0.x = textureAtlasRect.y + textureAtlasRect.w * (1.0 - QuadPosOffsets[vertexSubIndex].y);
 
     // do NOT adjust the UV of the very first vertex, that is the one moves all the time and is always at UV.x == 0
     // however, DO adjust the coordinate of the LAST vertex, since that is not moving and needs to "fade away" (out of the UV space, ie > 1)
-    if (ret.TexCoord0.y > textureAtlasRect.x)
-      ret.TexCoord0.y -= uvSubtract;
+    if (alongLocal > 0.0)
+      alongLocal -= uvSubtractLocal;
 
     // manually clamp the texCoords
     // this could be set as a sampler state, but it would not work with sub-ranges
-    ret.TexCoord0.y = min(textureAtlasRect.x + textureAtlasRect.z, ret.TexCoord0.y);
+    alongLocal = min(1.0, alongLocal);
+
+    // the raw [0-1] local coordinate within one atlas cell, before the flipbook / variation atlas
+    // transform and orientation rotation are applied; .x runs across the trail, .y along it
+    float2 acrossAlongLocal = float2(1.0 - QuadPosOffsets[vertexSubIndex].y, alongLocal);
+    float2 rotatedUV = RotateAtlasCellUV(acrossAlongLocal, TextureAtlasOrientation);
+
+    ret.ParticleUV = rotatedUV;
+    ret.TexCoord0.y = textureAtlasRect.x + rotatedUV.y * textureAtlasRect.z;
+    ret.TexCoord0.x = textureAtlasRect.y + rotatedUV.x * textureAtlasRect.w;
 
     float3 centerNormal = normalize(cross(dirRight, dirUp));
     float3 cornerNormal = normalize(offsetUp.xyz);

--- a/Data/Samples/RTS/Prefabs/Environment/Sun_data/Sun.ezMaterialAsset
+++ b/Data/Samples/RTS/Prefabs/Environment/Sun_data/Sun.ezMaterialAsset
@@ -339,7 +339,7 @@ o
 o
 {
 	Uuid %id{u4{6241561801560546210,5271871044825063978}}
-	s %t{"ShaderNode::UV_Scroll"}
+	s %t{"ShaderNode::UVScroll"}
 	u3 %v{1}
 	p
 	{
@@ -1203,7 +1203,7 @@ o
 			Uuid{u4{13620391104002069818,7672537951123968627}}
 			Uuid{u4{2057838931552913371,17892806788685602908}}
 		}
-		s %TypeName{"ShaderNode::UV_Scroll"}
+		s %TypeName{"ShaderNode::UVScroll"}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Samples/Testing Chambers/Effects/CustomParticleShader.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Effects/CustomParticleShader.ezMaterialAsset
@@ -564,7 +564,7 @@ o
 o
 {
 	Uuid %id{u4{18047790002961758510,10225871948574216028}}
-	s %t{"ShaderNode::UV_Scroll"}
+	s %t{"ShaderNode::UVScroll"}
 	u3 %v{1}
 	p
 	{
@@ -880,7 +880,7 @@ o
 			Uuid{u4{13620391104002069818,7672537951123968627}}
 			Uuid{u4{2057838931552913371,17892806788685602908}}
 		}
-		s %TypeName{"ShaderNode::UV_Scroll"}
+		s %TypeName{"ShaderNode::UVScroll"}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Tools/ezEditor/Localization/en/ParticlePlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ParticlePlugin.txt
@@ -35,6 +35,7 @@ ezEffectInvisibleUpdateRate::Max10fps;Max 10 FPS
 ezEffectInvisibleUpdateRate::Max5fps;Max 5 FPS
 
 ezParticleTextureAtlasType::RandomYAnimatedX;Random Row, Animated Column
+ezParticleTextureAtlasType::RandomXAnimatedY;Random Column, Animated Row
 
 ezParticleBehaviorFactory_ColorGradient;Color Gradient
 ezParticleBehaviorFactory_Velocity;Velocity

--- a/Data/Tools/ezEditor/ShaderTemplates/Particle.ezShaderTemplate
+++ b/Data/Tools/ezEditor/ShaderTemplates/Particle.ezShaderTemplate
@@ -60,7 +60,7 @@ BOOL1(UseCustomTexture);
 // Most code is provided through the #included files.
 // The #defines configure that code and thus always must come before those #includes.
 
-#define CUSTOM_INTERPOLATOR float FogAmount : FOG;
+#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2; float2 ParticleUV : TEXCOORD3;
 #define USE_TEXCOORD0
 #define USE_COLOR0
 
@@ -93,7 +93,14 @@ struct PS_IN
   float2 TexCoord0 : TEXCOORD0;
   float4 Color0 : COLOR0;
   float FogAmount : FOG;
+  float Life : TEXCOORD1;
+  float Variation : TEXCOORD2;
+  float2 ParticleUV : TEXCOORD3;
 };
+
+Prefer the UV accessors over touching these fields directly:
+  GetParticleQuadUV()      - raw [0-1] across the particle, ignores the flipbook / variation atlas
+  GetParticleFlipbookUV()  - the atlas transformed coordinate, i.e. what ParticleTexture uses below
 
 Particle System constants can be accessed through the ezParticleSystemConstants buffer, see
   Data/Plugins/ParticlePlugin/Shaders/Particles/ParticleSystemConstants.h

--- a/Data/Tools/ezEditor/VisualShader/Inputs.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Inputs.ddl
@@ -64,7 +64,7 @@ Node %UV2
   }
 }
 
-Node %UV_Scroll
+Node %UVScroll
 {
   string %Category { "Input" }
   string %Color { "Green" }

--- a/Data/Tools/ezEditor/VisualShader/Output_QuadParticle.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Output_QuadParticle.ddl
@@ -26,7 +26,7 @@ PARTICLE_LIGHTING_MODE=PARTICLE_LIGHTING_MODE_FULLBRIGHT
   string %CodeRenderStates { "#include <Shaders/Particles/ParticleRenderState.h>" }
 
   string %CodeShaderShared { "
-#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2;
+#define CUSTOM_INTERPOLATOR float FogAmount : FOG; float Life : TEXCOORD1; float Variation : TEXCOORD2; float2 ParticleUV : TEXCOORD3;
 #ifndef USE_TEXCOORD0
 #define USE_TEXCOORD0
 #endif
@@ -83,6 +83,7 @@ float GetParticleOpacity()
     unsigned_int8 %Color { 200, 200, 200 }
     bool %Expose { true }
     string %DefaultValue { "1, 1, 1" }
+    string %Tooltip { "Final color of the particle.\n\nThe per-particle color from initializers and behaviors is NOT applied automatically - multiply in the 'Vertex Color' node if you want those to have an effect." }
   }
 
   // Pin 1
@@ -92,5 +93,6 @@ float GetParticleOpacity()
     string %Color { "Red" }
     bool %Expose { true }
     string %DefaultValue { "1" }
+    string %Tooltip { "Final opacity of the particle.\n\nThe per-particle alpha is NOT applied automatically - multiply in the 'Alpha' pin of the 'Vertex Color' node if you want behaviors such as 'Fade Out' to have an effect." }
   }
 }

--- a/Data/Tools/ezEditor/VisualShader/Particles.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Particles.ddl
@@ -33,4 +33,20 @@ Node %Particle
     string %Inline { "G.Input.Variation" }
     string %Tooltip { "Random variation value per particle." }
   }
+
+  OutputPin %QuadUV
+  {
+    string %Type { "float2" }
+    string %Color { "Teal" }
+    string %Inline { "GetParticleQuadUV()" }
+    string %Tooltip { "Raw [0-1] UV across the particle, unaffected by flipbook animations and random variations. Use this for textures that should not be chopped up by the flipbook, e.g. a pattern that a flipbook mask is blended with. On trails, X runs across the trail and Y along it." }
+  }
+
+  OutputPin %FlipbookUV
+  {
+    string %Type { "float2" }
+    string %Color { "Teal" }
+    string %Inline { "GetParticleFlipbookUV()" }
+    string %Tooltip { "UV transformed into the current flipbook animation / random variation frame. This is what texture nodes sample with by default." }
+  }
 }

--- a/Data/Tools/ezEditor/VisualShader/Utils.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Utils.ddl
@@ -1,3 +1,50 @@
+Node %ScrollFloat4
+{
+  string %Category { "Utils" }
+  string %Color { "Green" }
+  string %Docs { "Scrolls a float4 value (e.g. a UV coordinate) over time, using the world time." }
+  string %Title { "Scroll: {$in0}" }
+
+  InputPin %UV
+  {
+    string %Type { "float4" }
+    string %DefaultValue { "G.Input.TexCoord0" }
+    string %Tooltip { "The float4 value to scroll, e.g. a UV coordinate." }
+  }
+
+  InputPin %Speed
+  {
+    string %Type { "float4" }
+    bool %Expose { true }
+    string %DefaultValue { "1, 1, 1, 1" }
+    string %Tooltip { "Scroll speed along X, Y, Z and W." }
+  }
+
+  InputPin %Scale
+  {
+    string %Type { "float4" }
+    bool %Expose { true }
+    string %DefaultValue { "1, 1, 1, 1" }
+    string %Tooltip { "Scale applied to the input value before scrolling." }
+  }
+
+  InputPin %Offset
+  {
+    string %Type { "float4" }
+    bool %Expose { true }
+    string %DefaultValue { "0, 0, 0, 0" }
+    string %Tooltip { "Constant offset applied after scaling." }
+  }
+
+  OutputPin %UV
+  {
+    string %Type { "float4" }
+    string %Color { "Teal" }
+    string %Inline { "(ToFloat4Direction($in0) * $in2 + $in3) + frac(WorldTime * $in1)" }
+    string %Tooltip { "The scrolled value." }
+  }
+}
+
 Node %SceneColor
 {
   string %Category { "Utils" }


### PR DESCRIPTION
* Added txture rotation option for rotating textures left, right, up, down. Useful for textures that have a clear direction.
* Added access to raw particle UV coords in shaders. The main UVs contain the flipbook adjustment, the raw UV is needed when layering multiple textures.
* Fixed particle shader template.
* Added mode for random column flipbooks. Previously only supported flipbooks with random rows.
* Renamed Visual Shader UVScroll node such that it correctly shows up in the UI. Breaking change, you may need to adjust your visual shaders.
* Added ScrollFloat4 Visual Shader utility node.