### PR TITLE
Added 3D navigation functionality

### DIFF
--- a/Code/EnginePlugins/AiPlugin/AiPluginPCH.cpp
+++ b/Code/EnginePlugins/AiPlugin/AiPluginPCH.cpp
@@ -7,6 +7,11 @@ EZ_STATICLINK_LIBRARY(AiPlugin)
   if (bReturn)
     return;
 
+  EZ_STATICLINK_REFERENCE(AiPlugin_Navigation3D_Implementation_VoxelGridComponent);
+  EZ_STATICLINK_REFERENCE(AiPlugin_Navigation3D_Implementation_VoxelNavigationComponent);
+  EZ_STATICLINK_REFERENCE(AiPlugin_Navigation3D_Implementation_VoxelPathTestComponent);
+  EZ_STATICLINK_REFERENCE(AiPlugin_Navigation3D_Implementation_VoxelWorldModule);
+  EZ_STATICLINK_REFERENCE(AiPlugin_Navigation_Components_DetourCrowdAgentComponent);
   EZ_STATICLINK_REFERENCE(AiPlugin_Navigation_Components_NavMeshObstacleComponent);
   EZ_STATICLINK_REFERENCE(AiPlugin_Navigation_Components_NavMeshPathTestComponent);
   EZ_STATICLINK_REFERENCE(AiPlugin_Navigation_Components_NavigationComponent);

--- a/Code/EnginePlugins/AiPlugin/Navigation/Components/DetourCrowdAgentComponent.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Components/DetourCrowdAgentComponent.cpp
@@ -1,14 +1,15 @@
 #include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation/Components/DetourCrowdAgentComponent.h>
+#include <AiPlugin/Navigation/NavMeshWorldModule.h>
+#include <AiPlugin/Navigation/Navigation.h>
+#include <AiPlugin/Utils/RcMath.h>
 #include <Core/WorldSerializer/WorldReader.h>
 #include <Core/WorldSerializer/WorldWriter.h>
-#include <RendererCore/Debug/DebugRenderer.h>
 #include <DetourCrowd.h>
-#include <AiPlugin/Utils/RcMath.h>
-#include <AiPlugin/Navigation/Components/DetourCrowdAgentComponent.h>
-#include <AiPlugin/Navigation/Navigation.h>
-#include <AiPlugin/Navigation/NavMeshWorldModule.h>
 #include <Foundation/Configuration/CVar.h>
 #include <Foundation/Math/Rect.h>
+#include <RendererCore/Debug/DebugRenderer.h>
 
 ezCVarBool cvar_DetourCrowdVisAgents("DetourCrowd.Debug.VisAgents", false, ezCVarFlags::Default, "Draws DetourCrowd agents, if any");
 ezCVarBool cvar_DetourCrowdVisCorners("DetourCrowd.Debug.VisCorners", false, ezCVarFlags::Default, "Draws next few path corners of the DetourCrowd agents");
@@ -216,8 +217,7 @@ void ezDetourCrowdAgentComponentManager::FillDtCrowdAgentParams(const ezDetourCr
   out_params.maxSpeed = pAgent->GetMaxSpeed();
   out_params.collisionQueryRange = ezMath::Max(1.2f, 12.0f * out_params.radius);
   out_params.pathOptimizationRange = ezMath::Max(3.0f, 30.0f * out_params.radius);
-  out_params.updateFlags = DT_CROWD_ANTICIPATE_TURNS | DT_CROWD_OPTIMIZE_VIS | DT_CROWD_OPTIMIZE_TOPO
-    | DT_CROWD_OBSTACLE_AVOIDANCE | DT_CROWD_SEPARATION;
+  out_params.updateFlags = DT_CROWD_ANTICIPATE_TURNS | DT_CROWD_OPTIMIZE_VIS | DT_CROWD_OPTIMIZE_TOPO | DT_CROWD_OBSTACLE_AVOIDANCE | DT_CROWD_SEPARATION;
   out_params.obstacleAvoidanceType = 3;
   out_params.separationWeight = pAgent->GetPushiness();
   out_params.userData = reinterpret_cast<void*>(static_cast<std::uintptr_t>(pAgent->m_uiUniqueAgentId));
@@ -243,7 +243,8 @@ void ezDetourCrowdAgentComponentManager::AsyncUpdate(const UpdateContext& ctx)
   for (auto pair : m_CrowdPerNavMesh)
   {
     const ezAiNavMesh* pNavMesh = pNavMeshModule->GetNavMesh(pair.key);
-    if (!pNavMesh) continue;
+    if (!pNavMesh)
+      continue;
 
     if (pNavMesh->GetDetourNavMesh() != pair.value->getNavMeshQuery()->getAttachedNavMesh())
     {
@@ -549,3 +550,6 @@ void ezDetourCrowdAgentComponentManager::SyncTransforms(const UpdateContext& ctx
     }
   }
 }
+
+
+EZ_STATICLINK_FILE(AiPlugin, AiPlugin_Navigation_Components_DetourCrowdAgentComponent);

--- a/Code/EnginePlugins/AiPlugin/Navigation/Components/DetourCrowdAgentComponent.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Components/DetourCrowdAgentComponent.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <AiPlugin/AiPluginDLL.h>
 #include <Core/World/Component.h>
 #include <Core/World/World.h>
-#include <AiPlugin/AiPluginDLL.h>
 #include <Foundation/Containers/ArrayMap.h>
 
 class ezDetourCrowdAgentComponent;
+struct dtCrowdAgentParams;
+struct dtCrowdAgent;
+class dtCrowd;
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -126,7 +129,7 @@ public:
 protected:
   ezUInt8 m_uiDestinationChangedBit : 1;
   ezUInt8 m_uiHasDestinationBit : 1;
-  ezUInt8 m_uiSteeringFailedBit : 1;  ///< Set when pathfinding fails and AllowPartialPath is false.
+  ezUInt8 m_uiSteeringFailedBit : 1; ///< Set when pathfinding fails and AllowPartialPath is false.
   ezUInt8 m_uiParamsChangedBit : 1;
   ezUInt8 m_uiAllowPartialPathBit : 1;
 

--- a/Code/EnginePlugins/AiPlugin/Navigation/Implementation/SteeringUtils.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Implementation/SteeringUtils.cpp
@@ -1,0 +1,88 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation/SteeringUtils.h>
+#include <Foundation/Math/Mat3.h>
+
+namespace
+{
+  // Rebuilds qRotation from vForward alone, choosing right/up so that up is as close to world up
+  // (+Z) as geometrically possible - i.e. no roll. vForward is assumed to be normalized.
+  void MakeUprightOrientation(ezQuat& inout_qRotation, const ezVec3& vForward)
+  {
+    ezVec3 vRight = ezVec3::MakeAxisZ().CrossRH(vForward);
+    if (vRight.NormalizeIfNotZero(inout_qRotation * ezVec3::MakeAxisY()).Failed())
+    {
+      // vForward is ~parallel to world up (looking straight up/down) *and* the object's previous
+      // right vector happened to be too - fall back to a fixed axis rather than leaving it zero.
+      vRight.NormalizeIfNotZero(ezVec3::MakeAxisY()).IgnoreResult();
+    }
+
+    ezVec3 vUp = vForward.CrossRH(vRight);
+    vUp.NormalizeIfNotZero(ezVec3::MakeAxisZ()).IgnoreResult();
+
+    ezMat3 mRot = ezMat3::MakeIdentity();
+    mRot.SetColumn(0, vForward);
+    mRot.SetColumn(1, vRight);
+    mRot.SetColumn(2, vUp);
+
+    inout_qRotation = ezQuat::MakeFromMat3(mRot);
+  }
+} // namespace
+
+ezAngle ezAiSteeringUtils::TurnTowards(ezQuat& inout_qRotation, const ezVec3& vTargetDirection, ezAngle maxAngularSpeed, float fTimeDiff)
+{
+  const ezVec3 vCurrentForward = inout_qRotation * ezVec3::MakeAxisX();
+
+  ezVec3 vNewForward = vCurrentForward;
+  ezAngle remaining = ezAngle::MakeFromRadian(0);
+
+  ezVec3 vTargetDir = vTargetDirection;
+  if (vTargetDir.NormalizeIfNotZero(ezVec3::MakeZero()).Succeeded())
+  {
+    const ezAngle angleBetween = vCurrentForward.GetAngleBetween(vTargetDir);
+
+    if (angleBetween > ezAngle::MakeFromDegree(0.01f))
+    {
+      ezVec3 vRotAxis = vCurrentForward.CrossRH(vTargetDir);
+      // Handles the near-180-degree case (cross product is ~zero): fall back to the object's own
+      // up axis, so a full reversal turns around a sensible axis regardless of orientation.
+      vRotAxis.NormalizeIfNotZero(inout_qRotation * ezVec3::MakeAxisZ()).IgnoreResult();
+
+      const ezAngle maxStep = maxAngularSpeed * fTimeDiff;
+      const ezAngle toRotate = ezMath::Min(angleBetween, maxStep);
+
+      const ezQuat qDelta = ezQuat::MakeFromAxisAndAngle(vRotAxis, toRotate);
+      vNewForward = qDelta * vCurrentForward;
+
+      remaining = ezMath::Max(angleBetween - toRotate, ezAngle::MakeFromRadian(0));
+    }
+  }
+
+  // Always re-derive the orientation from the (possibly unchanged) forward direction, so the
+  // object stays upright / any existing roll is removed even when it isn't actively turning.
+  MakeUprightOrientation(inout_qRotation, vNewForward);
+
+  return remaining;
+}
+
+ezAngle ezAiSteeringUtils::GetAngleTowards(const ezQuat& qRotation, const ezVec3& vTargetDirection)
+{
+  ezVec3 vTargetDir = vTargetDirection;
+  if (vTargetDir.NormalizeIfNotZero(ezVec3::MakeZero()).Failed())
+    return ezAngle::MakeFromRadian(0);
+
+  const ezVec3 vCurrentForward = qRotation * ezVec3::MakeAxisX();
+  return vCurrentForward.GetAngleBetween(vTargetDir);
+}
+
+float ezAiSteeringUtils::ApplyAcceleration(float fCurrentSpeed, float fTargetSpeed, float fAcceleration, float fDeceleration, float fTimeDiff)
+{
+  if (fCurrentSpeed < fTargetSpeed)
+  {
+    return ezMath::Min(fCurrentSpeed + fAcceleration * fTimeDiff, fTargetSpeed);
+  }
+  else
+  {
+    return ezMath::Max(fCurrentSpeed - fDeceleration * fTimeDiff, fTargetSpeed);
+  }
+}

--- a/Code/EnginePlugins/AiPlugin/Navigation/SteeringUtils.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation/SteeringUtils.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <Foundation/Math/Angle.h>
+#include <Foundation/Math/Quat.h>
+#include <Foundation/Math/Vec3.h>
+
+/// Small, stateless steering math helpers shared by AI navigation components.
+///
+/// The forward direction convention matches the rest of the engine's AI code: the local +X axis
+/// is "forward" (see ezQuat::MakeShortestRotation(ezVec3::MakeAxisX(), ...) usage throughout
+/// AiPlugin).
+struct EZ_AIPLUGIN_DLL ezAiSteeringUtils
+{
+  /// Rotates inout_qRotation so its forward axis turns towards vTargetDirection, at most by
+  /// maxAngularSpeed * fTimeDiff.
+  ///
+  /// vTargetDirection does not need to be normalized. A zero vector leaves the forward direction
+  /// unchanged. The resulting orientation always has its local up axis (+Z) aligned as closely as
+  /// possible with world up (+Z) - i.e. it never rolls - regardless of whether a zero-angle target
+  /// was given, so this also re-levels any existing roll on inout_qRotation every time it is
+  /// called (callers that want banking need to apply additional roll themselves, see e.g.
+  /// ezAiVoxelNavigationComponent's path-following code).
+  ///
+  /// Returns the remaining angle between the new forward direction and vTargetDirection after the
+  /// clamped step (zero once fully turned), so callers can decide e.g. whether they are facing
+  /// closely enough towards the target to start moving.
+  static ezAngle TurnTowards(ezQuat& inout_qRotation, const ezVec3& vTargetDirection, ezAngle maxAngularSpeed, float fTimeDiff);
+
+  /// Peek-only companion to TurnTowards(): returns the angle between qRotation's forward axis and
+  /// vTargetDirection, without mutating anything.
+  static ezAngle GetAngleTowards(const ezQuat& qRotation, const ezVec3& vTargetDirection);
+
+  /// Moves fCurrentSpeed towards fTargetSpeed, using fAcceleration when speeding up and
+  /// fDeceleration when slowing down (both expected to be >= 0), clamped by fTimeDiff.
+  static float ApplyAcceleration(float fCurrentSpeed, float fTargetSpeed, float fAcceleration, float fDeceleration, float fTimeDiff);
+};

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelGrid.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelGrid.cpp
@@ -1,0 +1,376 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation3D/VoxelGrid.h>
+#include <Foundation/Math/Math.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+
+namespace
+{
+  /// SAT-based triangle-AABB overlap test (Tomas Akenine-Moller algorithm).
+  ///
+  /// Tests 13 potential separating axes: 3 box face normals, 1 triangle normal,
+  /// and 9 cross products of box edge directions with triangle edge directions.
+  bool TriangleBoxOverlap(const ezVec3& v0, const ezVec3& v1, const ezVec3& v2,
+    const ezVec3& vBoxCenter, float fBoxHalf)
+  {
+    // Translate triangle so box center is at origin
+    const ezVec3 a = v0 - vBoxCenter;
+    const ezVec3 b = v1 - vBoxCenter;
+    const ezVec3 c = v2 - vBoxCenter;
+    const float h = fBoxHalf;
+
+    // Test 3 AABB face normals
+    if (ezMath::Min(a.x, ezMath::Min(b.x, c.x)) > h || ezMath::Max(a.x, ezMath::Max(b.x, c.x)) < -h)
+      return false;
+    if (ezMath::Min(a.y, ezMath::Min(b.y, c.y)) > h || ezMath::Max(a.y, ezMath::Max(b.y, c.y)) < -h)
+      return false;
+    if (ezMath::Min(a.z, ezMath::Min(b.z, c.z)) > h || ezMath::Max(a.z, ezMath::Max(b.z, c.z)) < -h)
+      return false;
+
+    // Triangle edges
+    const ezVec3 f0 = b - a;
+    const ezVec3 f1 = c - b;
+    const ezVec3 f2 = a - c;
+
+    // 9 cross product axes: box_axis_i x triangle_edge_j
+    // For each axis, project all 3 vertices and check against box projection radius.
+    float p0, p1, p2, r;
+
+    // (1,0,0) x f0 = (0, -f0.z, f0.y)
+    p0 = -a.y * f0.z + a.z * f0.y;
+    p1 = -b.y * f0.z + b.z * f0.y;
+    p2 = -c.y * f0.z + c.z * f0.y;
+    r = h * (ezMath::Abs(f0.z) + ezMath::Abs(f0.y));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (1,0,0) x f1 = (0, -f1.z, f1.y)
+    p0 = -a.y * f1.z + a.z * f1.y;
+    p1 = -b.y * f1.z + b.z * f1.y;
+    p2 = -c.y * f1.z + c.z * f1.y;
+    r = h * (ezMath::Abs(f1.z) + ezMath::Abs(f1.y));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (1,0,0) x f2 = (0, -f2.z, f2.y)
+    p0 = -a.y * f2.z + a.z * f2.y;
+    p1 = -b.y * f2.z + b.z * f2.y;
+    p2 = -c.y * f2.z + c.z * f2.y;
+    r = h * (ezMath::Abs(f2.z) + ezMath::Abs(f2.y));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (0,1,0) x f0 = (f0.z, 0, -f0.x)
+    p0 = a.x * f0.z - a.z * f0.x;
+    p1 = b.x * f0.z - b.z * f0.x;
+    p2 = c.x * f0.z - c.z * f0.x;
+    r = h * (ezMath::Abs(f0.z) + ezMath::Abs(f0.x));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (0,1,0) x f1 = (f1.z, 0, -f1.x)
+    p0 = a.x * f1.z - a.z * f1.x;
+    p1 = b.x * f1.z - b.z * f1.x;
+    p2 = c.x * f1.z - c.z * f1.x;
+    r = h * (ezMath::Abs(f1.z) + ezMath::Abs(f1.x));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (0,1,0) x f2 = (f2.z, 0, -f2.x)
+    p0 = a.x * f2.z - a.z * f2.x;
+    p1 = b.x * f2.z - b.z * f2.x;
+    p2 = c.x * f2.z - c.z * f2.x;
+    r = h * (ezMath::Abs(f2.z) + ezMath::Abs(f2.x));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (0,0,1) x f0 = (-f0.y, f0.x, 0)
+    p0 = -a.x * f0.y + a.y * f0.x;
+    p1 = -b.x * f0.y + b.y * f0.x;
+    p2 = -c.x * f0.y + c.y * f0.x;
+    r = h * (ezMath::Abs(f0.y) + ezMath::Abs(f0.x));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (0,0,1) x f1 = (-f1.y, f1.x, 0)
+    p0 = -a.x * f1.y + a.y * f1.x;
+    p1 = -b.x * f1.y + b.y * f1.x;
+    p2 = -c.x * f1.y + c.y * f1.x;
+    r = h * (ezMath::Abs(f1.y) + ezMath::Abs(f1.x));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // (0,0,1) x f2 = (-f2.y, f2.x, 0)
+    p0 = -a.x * f2.y + a.y * f2.x;
+    p1 = -b.x * f2.y + b.y * f2.x;
+    p2 = -c.x * f2.y + c.y * f2.x;
+    r = h * (ezMath::Abs(f2.y) + ezMath::Abs(f2.x));
+    if (ezMath::Min(p0, ezMath::Min(p1, p2)) > r || ezMath::Max(p0, ezMath::Max(p1, p2)) < -r)
+      return false;
+
+    // Triangle normal
+    const ezVec3 normal = f0.CrossRH(f1);
+    const float d = normal.Dot(a);
+    r = h * (ezMath::Abs(normal.x) + ezMath::Abs(normal.y) + ezMath::Abs(normal.z));
+    if (ezMath::Abs(d) > r)
+      return false;
+
+    return true;
+  }
+} // namespace
+
+ezVoxelGrid::ezVoxelGrid() = default;
+ezVoxelGrid::~ezVoxelGrid() = default;
+
+void ezVoxelGrid::Initialize(const ezVec3U32& vDimensions, const ezVec3& vCenter, float fVoxelSize)
+{
+  EZ_ASSERT_DEV(fVoxelSize > 0.0f, "Voxel size must be positive");
+
+  m_vDimensions.x = ezMath::Max(4u, vDimensions.x);
+  m_vDimensions.y = ezMath::Max(4u, vDimensions.y);
+  m_vDimensions.z = ezMath::Max(4u, vDimensions.z);
+
+  m_vNumBlocks.x = (m_vDimensions.x + 3u) / 4u;
+  m_vNumBlocks.y = (m_vDimensions.y + 3u) / 4u;
+  m_vNumBlocks.z = (m_vDimensions.z + 3u) / 4u;
+
+  // Round dims up to block boundaries
+  m_vDimensions.x = m_vNumBlocks.x * 4u;
+  m_vDimensions.y = m_vNumBlocks.y * 4u;
+  m_vDimensions.z = m_vNumBlocks.z * 4u;
+
+  m_Blocks.Clear();
+  m_Blocks.SetCount(m_vNumBlocks.x * m_vNumBlocks.y * m_vNumBlocks.z);
+
+  m_vCenter = vCenter;
+  m_fVoxelSize = fVoxelSize;
+  m_fInvVoxelSize = 1.0f / fVoxelSize;
+
+  const ezVec3 vHalfExtents(
+    m_vDimensions.x * 0.5f * m_fVoxelSize,
+    m_vDimensions.y * 0.5f * m_fVoxelSize,
+    m_vDimensions.z * 0.5f * m_fVoxelSize);
+
+  m_vOrigin = m_vCenter - vHalfExtents;
+}
+
+void ezVoxelGrid::ClearData()
+{
+  ezMemoryUtils::ZeroFill(m_Blocks.GetData(), m_Blocks.GetCount());
+}
+
+void ezVoxelGrid::SetVoxel(const ezVec3I32& vCoord, bool bSolid)
+{
+  EZ_ASSERT_DEBUG(IsCoordValid(vCoord), "Invalid coordinate");
+
+  const ezUInt32 uiX = (ezUInt32)vCoord.x;
+  const ezUInt32 uiY = (ezUInt32)vCoord.y;
+  const ezUInt32 uiZ = (ezUInt32)vCoord.z;
+
+  const ezUInt32 uiBlockIdx = GetBlockIndex(uiX / 4u, uiY / 4u, uiZ / 4u);
+  const ezUInt32 uiBit = GetBitIndex(uiX % 4u, uiY % 4u, uiZ % 4u);
+  const ezUInt64 uiMask = 1ull << uiBit;
+
+  if (bSolid)
+  {
+    m_Blocks[uiBlockIdx] |= uiMask;
+  }
+  else
+  {
+    m_Blocks[uiBlockIdx] &= ~uiMask;
+  }
+}
+
+bool ezVoxelGrid::IsVoxelSet(const ezVec3I32& vCoord) const
+{
+  EZ_ASSERT_DEBUG(IsCoordValid(vCoord), "Invalid coordinate");
+
+  const ezUInt32 uiX = (ezUInt32)vCoord.x;
+  const ezUInt32 uiY = (ezUInt32)vCoord.y;
+  const ezUInt32 uiZ = (ezUInt32)vCoord.z;
+
+  const ezUInt32 uiBlockIdx = GetBlockIndex(uiX / 4u, uiY / 4u, uiZ / 4u);
+  const ezUInt64 uiBlock = m_Blocks[uiBlockIdx];
+
+  if (uiBlock == 0ull)
+    return false;
+
+  const ezUInt32 uiBit = GetBitIndex(uiX % 4u, uiY % 4u, uiZ % 4u);
+  const ezUInt64 uiMask = 1ull << uiBit;
+
+  return (uiBlock & uiMask) != 0ull;
+}
+
+void ezVoxelGrid::SetVoxelsOnTriangle(const ezVec3& v0, const ezVec3& v1, const ezVec3& v2, bool bSet /*= true*/)
+{
+  // Triangle AABB in world space
+  ezVec3 triMin;
+  triMin.x = ezMath::Min(v0.x, ezMath::Min(v1.x, v2.x));
+  triMin.y = ezMath::Min(v0.y, ezMath::Min(v1.y, v2.y));
+  triMin.z = ezMath::Min(v0.z, ezMath::Min(v1.z, v2.z));
+
+  ezVec3 triMax;
+  triMax.x = ezMath::Max(v0.x, ezMath::Max(v1.x, v2.x));
+  triMax.y = ezMath::Max(v0.y, ezMath::Max(v1.y, v2.y));
+  triMax.z = ezMath::Max(v0.z, ezMath::Max(v1.z, v2.z));
+
+  // Convert to voxel coordinates and clamp to grid bounds
+  ezVec3I32 coordMin = WorldToCoord(triMin);
+  ezVec3I32 coordMax = WorldToCoord(triMax);
+
+  coordMin.x = ezMath::Max(coordMin.x, 0);
+  coordMin.y = ezMath::Max(coordMin.y, 0);
+  coordMin.z = ezMath::Max(coordMin.z, 0);
+  coordMax.x = ezMath::Min(coordMax.x, (ezInt32)GetDimensions().x - 1);
+  coordMax.y = ezMath::Min(coordMax.y, (ezInt32)GetDimensions().y - 1);
+  coordMax.z = ezMath::Min(coordMax.z, (ezInt32)GetDimensions().z - 1);
+
+  if (coordMin.x > coordMax.x || coordMin.y > coordMax.y || coordMin.z > coordMax.z)
+    return;
+
+  const float fHalfSize = GetVoxelSize() * 0.5f;
+
+  for (ezInt32 z = coordMin.z; z <= coordMax.z; ++z)
+  {
+    for (ezInt32 y = coordMin.y; y <= coordMax.y; ++y)
+    {
+      for (ezInt32 x = coordMin.x; x <= coordMax.x; ++x)
+      {
+        const ezVec3I32 vCoord(x, y, z);
+
+        if (IsVoxelSet(vCoord) == bSet)
+          continue;
+
+        const ezVec3 voxelCenter = CoordToWorld(vCoord);
+
+        if (TriangleBoxOverlap(v0, v1, v2, voxelCenter, fHalfSize))
+        {
+          SetVoxel(vCoord, bSet);
+        }
+      }
+    }
+  }
+}
+
+bool ezVoxelGrid::CheckLineOfSight(const ezVec3I32& vStart, const ezVec3I32& vGoal) const
+{
+  const ezInt32 dx = vGoal.x - vStart.x;
+  const ezInt32 dy = vGoal.y - vStart.y;
+  const ezInt32 dz = vGoal.z - vStart.z;
+
+  const ezInt32 iSteps = ezMath::Max(ezMath::Abs(dx), ezMath::Max(ezMath::Abs(dy), ezMath::Abs(dz)));
+
+  if (iSteps == 0)
+    return true;
+
+  const float fInvSteps = 1.0f / (float)iSteps;
+  const float fXIncr = (float)dx * fInvSteps;
+  const float fYIncr = (float)dy * fInvSteps;
+  const float fZIncr = (float)dz * fInvSteps;
+
+  float fX = (float)vStart.x;
+  float fY = (float)vStart.y;
+  float fZ = (float)vStart.z;
+
+  for (ezInt32 i = 0; i < iSteps; ++i)
+  {
+    const ezVec3I32 vCoord(
+      (ezInt32)ezMath::Round(fX),
+      (ezInt32)ezMath::Round(fY),
+      (ezInt32)ezMath::Round(fZ));
+
+    if (vCoord.x == vGoal.x && vCoord.y == vGoal.y && vCoord.z == vGoal.z)
+      return true;
+
+    if (IsVoxelSet(vCoord))
+      return false;
+
+    fX += fXIncr;
+    fY += fYIncr;
+    fZ += fZIncr;
+  }
+
+  return true;
+}
+
+ezBoundingBox ezVoxelGrid::GetAABB() const
+{
+  const ezVec3 vHalfExtents(
+    m_vDimensions.x * 0.5f * m_fVoxelSize,
+    m_vDimensions.y * 0.5f * m_fVoxelSize,
+    m_vDimensions.z * 0.5f * m_fVoxelSize);
+
+  return ezBoundingBox::MakeFromCenterAndHalfExtents(m_vCenter, vHalfExtents);
+}
+
+ezUInt64 ezVoxelGrid::GetHeapMemoryUsage() const
+{
+  return m_Blocks.GetHeapMemoryUsage();
+}
+
+void ezVoxelGrid::DebugDraw(const ezDebugRendererContext& context, const ezColor& color) const
+{
+  if (m_Blocks.IsEmpty())
+    return;
+
+  // Shrink boxes slightly so individual voxels are visually distinguishable
+  const float fHalf = m_fVoxelSize * 0.48f;
+  const ezVec3 vHalfExtents(fHalf, fHalf, fHalf);
+
+  for (ezUInt32 bz = 0; bz < m_vNumBlocks.z; ++bz)
+  {
+    for (ezUInt32 by = 0; by < m_vNumBlocks.y; ++by)
+    {
+      for (ezUInt32 bx = 0; bx < m_vNumBlocks.x; ++bx)
+      {
+        const ezUInt32 uiBlockIdx = GetBlockIndex(bx, by, bz);
+        ezUInt64 uiBlock = m_Blocks[uiBlockIdx];
+
+        if (uiBlock == 0ull)
+          continue;
+
+        while (uiBlock != 0ull)
+        {
+          const ezUInt32 uiBit = ezMath::FirstBitLow(uiBlock);
+          uiBlock ^= (1ull << uiBit);
+
+          const ezUInt32 lx = uiBit % 4u;
+          const ezUInt32 ly = (uiBit / 4u) % 4u;
+          const ezUInt32 lz = uiBit / 16u;
+
+          const ezVec3I32 vGlobalCoord(
+            (ezInt32)(bx * 4u + lx),
+            (ezInt32)(by * 4u + ly),
+            (ezInt32)(bz * 4u + lz));
+
+          // Only draw surface voxels (at least one free neighbor)
+          bool bIsSurface = false;
+          const ezVec3I32 vNeighbors[] = {
+            {vGlobalCoord.x - 1, vGlobalCoord.y, vGlobalCoord.z},
+            {vGlobalCoord.x + 1, vGlobalCoord.y, vGlobalCoord.z},
+            {vGlobalCoord.x, vGlobalCoord.y - 1, vGlobalCoord.z},
+            {vGlobalCoord.x, vGlobalCoord.y + 1, vGlobalCoord.z},
+            {vGlobalCoord.x, vGlobalCoord.y, vGlobalCoord.z - 1},
+            {vGlobalCoord.x, vGlobalCoord.y, vGlobalCoord.z + 1},
+          };
+
+          for (const auto& vNeighbor : vNeighbors)
+          {
+            if (!IsCoordValid(vNeighbor) || !IsVoxelSet(vNeighbor))
+            {
+              bIsSurface = true;
+              break;
+            }
+          }
+
+          if (bIsSurface)
+          {
+            const ezVec3 vWorldPos = CoordToWorld(vGlobalCoord);
+            const ezBoundingBox voxelBox = ezBoundingBox::MakeFromCenterAndHalfExtents(vWorldPos, vHalfExtents);
+            ezDebugRenderer::DrawLineBox(context, voxelBox, color);
+          }
+        }
+      }
+    }
+  }
+}

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelGridComponent.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelGridComponent.cpp
@@ -1,0 +1,148 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation3D/VoxelGridComponent.h>
+#include <AiPlugin/Navigation3D/VoxelWorldModule.h>
+#include <Core/Interfaces/NavmeshGeoWorldModule.h>
+#include <Core/World/World.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+
+// clang-format off
+EZ_BEGIN_COMPONENT_TYPE(ezAiVoxelGridComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Size", GetSize, SetSize)->AddAttributes(new ezDefaultValueAttribute(ezVec3(32)), new ezClampValueAttribute(ezVec3(4), ezVec3(1024))),
+    EZ_ACCESSOR_PROPERTY("VoxelSize", GetVoxelSize, SetVoxelSize)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.1f, 10.0f)),
+    EZ_ACCESSOR_PROPERTY("CollisionLayer", GetCollisionLayer, SetCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
+    EZ_MEMBER_PROPERTY("Visualize", m_bVisualize),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgUpdateLocalBounds, OnMsgUpdateLocalBounds)
+  }
+  EZ_END_MESSAGEHANDLERS;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("AI/Navigation"),
+    new ezBoxVisualizerAttribute("Size", 1.0f, ezColorScheme::LightUI(ezColorScheme::Green), nullptr),
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezSpatialData::Category ezAiVoxelGridComponent::SpatialDataCategory = ezSpatialData::RegisterCategory("AiVoxelGrid", ezSpatialData::Flags::None);
+
+ezAiVoxelGridComponent::ezAiVoxelGridComponent() = default;
+ezAiVoxelGridComponent::~ezAiVoxelGridComponent() = default;
+
+void ezAiVoxelGridComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+  auto& s = inout_stream.GetStream();
+
+  s << m_vSize;
+  s << m_fVoxelSize;
+  s << m_uiCollisionLayer;
+  s << m_bVisualize;
+}
+
+void ezAiVoxelGridComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  auto& s = inout_stream.GetStream();
+
+  s >> m_vSize;
+  s >> m_fVoxelSize;
+  s >> m_uiCollisionLayer;
+  s >> m_bVisualize;
+}
+
+void ezAiVoxelGridComponent::OnActivated()
+{
+  SUPER::OnActivated();
+
+  GetOwner()->UpdateLocalBounds();
+}
+
+void ezAiVoxelGridComponent::OnDeactivated()
+{
+  GetOwner()->UpdateLocalBounds();
+
+  SUPER::OnDeactivated();
+}
+
+void ezAiVoxelGridComponent::OnMsgUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const
+{
+  msg.AddBounds(ezBoundingBoxSphere::MakeFromBox(ezBoundingBox::MakeFromCenterAndHalfExtents(ezVec3::MakeZero(), m_vSize * 0.5f)), SpatialDataCategory);
+}
+
+void ezAiVoxelGridComponent::SetSize(const ezVec3& vSize)
+{
+  if (m_vSize != vSize)
+  {
+    m_vSize = vSize;
+    m_bNeedsVoxelization = true;
+
+    if (IsActiveAndInitialized())
+    {
+      GetOwner()->UpdateLocalBounds();
+    }
+  }
+}
+
+void ezAiVoxelGridComponent::SetVoxelSize(float fValue)
+{
+  if (m_fVoxelSize != fValue)
+  {
+    m_fVoxelSize = fValue;
+    m_bNeedsVoxelization = true;
+  }
+}
+
+void ezAiVoxelGridComponent::SetCollisionLayer(ezUInt32 uiValue)
+{
+  if (m_uiCollisionLayer != uiValue)
+  {
+    m_uiCollisionLayer = uiValue;
+    m_bNeedsVoxelization = true;
+  }
+}
+
+void ezAiVoxelGridComponent::VoxelizeWorld()
+{
+  if (!m_bNeedsVoxelization)
+    return;
+
+  // retrieve collision geometry and rasterize triangles
+  auto* pGeoModule = GetWorld()->GetOrCreateModule<ezNavmeshGeoWorldModuleInterface>();
+  if (pGeoModule == nullptr)
+    return;
+
+  m_bNeedsVoxelization = false;
+
+  ezVec3U32 res;
+  res.x = ezMath::CeilToInt(m_vSize.x / m_fVoxelSize);
+  res.y = ezMath::CeilToInt(m_vSize.y / m_fVoxelSize);
+  res.z = ezMath::CeilToInt(m_vSize.z / m_fVoxelSize);
+
+  ezVec3 vGridCenter = GetOwner()->GetGlobalPosition();
+
+  m_StaticGrid.Initialize(res, vGridCenter, m_fVoxelSize);
+
+  const ezBoundingBox gridAABB = m_StaticGrid.GetAABB();
+
+  ezDynamicArray<ezNavmeshTriangle> triangles;
+  pGeoModule->RetrieveGeometryInArea(m_uiCollisionLayer, gridAABB, triangles);
+
+  for (const auto& tri : triangles)
+  {
+    m_StaticGrid.SetVoxelsOnTriangle(tri.m_Vertices[0], tri.m_Vertices[1], tri.m_Vertices[2]);
+  }
+}
+
+
+EZ_STATICLINK_FILE(AiPlugin, AiPlugin_Navigation3D_Implementation_VoxelGridComponent);

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelNavigation.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelNavigation.cpp
@@ -1,0 +1,738 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation3D/VoxelGrid.h>
+#include <AiPlugin/Navigation3D/VoxelNavigation.h>
+#include <Foundation/Containers/HashTable.h>
+#include <Foundation/Math/Math.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+
+ezAiVoxelNavigation::ezAiVoxelNavigation() = default;
+ezAiVoxelNavigation::~ezAiVoxelNavigation() = default;
+
+// How many voxels FindPathToTarget()/FindPathToExit() search around a blocked start coordinate
+// before giving up. 2 voxels covers the common case of the immediate neighbor also being blocked
+// (e.g. a tight corner), without letting recovery silently teleport the object very far.
+static const ezUInt32 s_uiStartRecoveryRadiusVoxels = 2;
+
+bool ezAiVoxelNavigation::FindNearbyValidCoord(const ezVoxelGrid& grid, const ezVec3I32& vCoord, ezUInt32 uiMaxRadius, ezVec3I32& out_vValidCoord)
+{
+  // Exhaustive search of the (2*uiMaxRadius+1)^3 cube around vCoord, keeping the closest valid,
+  // non-solid coordinate found (squared voxel-offset distance is monotonic with physical distance
+  // since a grid's voxels are uniform in size, so this doesn't need to convert to world space).
+  // uiMaxRadius is expected to stay small (a handful of voxels) - this is meant for local recovery,
+  // not long-range searches.
+  const ezInt32 iMaxRadius = (ezInt32)uiMaxRadius;
+  ezInt32 iBestDistSqr = ezMath::MaxValue<ezInt32>();
+  bool bFound = false;
+
+  for (ezInt32 dz = -iMaxRadius; dz <= iMaxRadius; ++dz)
+  {
+    for (ezInt32 dy = -iMaxRadius; dy <= iMaxRadius; ++dy)
+    {
+      for (ezInt32 dx = -iMaxRadius; dx <= iMaxRadius; ++dx)
+      {
+        if (dx == 0 && dy == 0 && dz == 0)
+          continue;
+
+        const ezInt32 iDistSqr = dx * dx + dy * dy + dz * dz;
+        if (iDistSqr >= iBestDistSqr)
+          continue;
+
+        const ezVec3I32 vNeighbor = vCoord + ezVec3I32(dx, dy, dz);
+        if (!grid.IsCoordValid(vNeighbor) || grid.IsVoxelSet(vNeighbor))
+          continue;
+
+        iBestDistSqr = iDistSqr;
+        out_vValidCoord = vNeighbor;
+        bFound = true;
+      }
+    }
+  }
+
+  return bFound;
+}
+
+namespace
+{
+  struct AStarNode
+  {
+    EZ_DECLARE_POD_TYPE();
+
+    float fGCost = ezMath::MaxValue<float>();
+    float fFCost = ezMath::MaxValue<float>();
+    ezUInt32 uiParent = ezInvalidIndex;
+    bool bClosed = false;
+  };
+
+  EZ_FORCE_INLINE ezUInt32 PackCoord(const ezVec3I32& vCoord, ezUInt32 uiDimX, ezUInt32 uiDimY)
+  {
+    return (ezUInt32)vCoord.z * uiDimX * uiDimY + (ezUInt32)vCoord.y * uiDimX + (ezUInt32)vCoord.x;
+  }
+
+  EZ_FORCE_INLINE ezVec3I32 UnpackCoord(ezUInt32 uiIndex, ezUInt32 uiDimX, ezUInt32 uiDimY)
+  {
+    const ezInt32 z = (ezInt32)(uiIndex / (uiDimX * uiDimY));
+    const ezUInt32 uiRemaining = uiIndex - (ezUInt32)z * uiDimX * uiDimY;
+    const ezInt32 y = (ezInt32)(uiRemaining / uiDimX);
+    const ezInt32 x = (ezInt32)(uiRemaining % uiDimX);
+    return ezVec3I32(x, y, z);
+  }
+
+  EZ_FORCE_INLINE bool IsBoundaryCoord(const ezVec3I32& vCoord, const ezVec3U32& vDims)
+  {
+    return vCoord.x == 0 || vCoord.y == 0 || vCoord.z == 0 ||
+           (ezUInt32)vCoord.x == vDims.x - 1 || (ezUInt32)vCoord.y == vDims.y - 1 || (ezUInt32)vCoord.z == vDims.z - 1;
+  }
+
+  /// Returns the (unnormalized) outward-facing normal of the grid boundary at vCoord, i.e. the sum
+  /// of the outward unit vectors of every face vCoord touches (nonzero only where IsBoundaryCoord is true).
+  EZ_FORCE_INLINE ezVec3 GetBoundaryOutwardNormal(const ezVec3I32& vCoord, const ezVec3U32& vDims)
+  {
+    ezVec3 vNormal = ezVec3::MakeZero();
+
+    if (vCoord.x == 0)
+      vNormal.x -= 1.0f;
+    if ((ezUInt32)vCoord.x == vDims.x - 1)
+      vNormal.x += 1.0f;
+
+    if (vCoord.y == 0)
+      vNormal.y -= 1.0f;
+    if ((ezUInt32)vCoord.y == vDims.y - 1)
+      vNormal.y += 1.0f;
+
+    if (vCoord.z == 0)
+      vNormal.z -= 1.0f;
+    if ((ezUInt32)vCoord.z == vDims.z - 1)
+      vNormal.z += 1.0f;
+
+    return vNormal;
+  }
+
+  /// Whether exiting the grid at vCoord (which must satisfy IsBoundaryCoord) actually leads away
+  /// from the grid, towards vTargetCoord - i.e. leaving through this particular voxel doesn't just
+  /// walk straight back into the same grid. vTargetCoord may lie outside the grid.
+  bool IsUsableExit(const ezVec3I32& vCoord, const ezVec3U32& vDims, const ezVec3I32& vTargetCoord)
+  {
+    const ezVec3 vNormal = GetBoundaryOutwardNormal(vCoord, vDims);
+
+    const ezVec3 vToTarget(
+      (float)(vTargetCoord.x - vCoord.x),
+      (float)(vTargetCoord.y - vCoord.y),
+      (float)(vTargetCoord.z - vCoord.z));
+
+    if (vToTarget.IsZero(0.001f))
+      return true; // no clear direction to check against, don't reject
+
+    return vNormal.Dot(vToTarget) > 0.0f;
+  }
+
+  /// Grids are not supposed to overlap, but in case they do, reject exit voxels that fall inside a
+  /// solid voxel of another grid - that world position wouldn't actually be reachable.
+  bool IsCoordFreeInOtherGrids(const ezVoxelGrid& grid, const ezVec3I32& vCoord, ezArrayPtr<const ezVoxelGrid* const> otherGrids)
+  {
+    if (otherGrids.IsEmpty())
+      return true;
+
+    const ezVec3 vWorldPos = grid.CoordToWorld(vCoord);
+
+    for (const ezVoxelGrid* pOther : otherGrids)
+    {
+      if (pOther == &grid)
+        continue;
+
+      if (!pOther->GetAABB().Contains(vWorldPos))
+        continue;
+
+      const ezVec3I32 vOtherCoord = pOther->WorldToCoord(vWorldPos);
+      if (pOther->IsCoordValid(vOtherCoord) && pOther->IsVoxelSet(vOtherCoord))
+        return false;
+    }
+
+    return true;
+  }
+
+  // Admissible heuristic for 6-connected (face-neighbor only) movement: the minimum number of
+  // axis-aligned unit steps needed, which is exactly the Manhattan distance.
+  float ManhattanHeuristic(const ezVec3I32& vA, const ezVec3I32& vB)
+  {
+    return (float)(ezMath::Abs(vA.x - vB.x) + ezMath::Abs(vA.y - vB.y) + ezMath::Abs(vA.z - vB.z));
+  }
+
+  // Minimal binary min-heap for A* open set
+  struct OpenSetEntry
+  {
+    EZ_DECLARE_POD_TYPE();
+
+    ezUInt32 uiIndex;
+    float fFCost;
+  };
+
+  void HeapPush(ezDynamicArray<OpenSetEntry>& ref_heap, ezUInt32 uiIndex, float fFCost)
+  {
+    OpenSetEntry entry;
+    entry.uiIndex = uiIndex;
+    entry.fFCost = fFCost;
+    ref_heap.PushBack(entry);
+
+    // Sift up
+    ezUInt32 i = ref_heap.GetCount() - 1;
+    while (i > 0)
+    {
+      const ezUInt32 uiParent = (i - 1) / 2;
+      if (ref_heap[uiParent].fFCost > ref_heap[i].fFCost)
+      {
+        ezMath::Swap(ref_heap[uiParent], ref_heap[i]);
+        i = uiParent;
+      }
+      else
+      {
+        break;
+      }
+    }
+  }
+
+  OpenSetEntry HeapPop(ezDynamicArray<OpenSetEntry>& ref_heap)
+  {
+    OpenSetEntry top = ref_heap[0];
+    ref_heap[0] = ref_heap[ref_heap.GetCount() - 1];
+    ref_heap.PopBack();
+
+    // Sift down
+    ezUInt32 i = 0;
+    const ezUInt32 uiCount = ref_heap.GetCount();
+    while (true)
+    {
+      ezUInt32 uiSmallest = i;
+      const ezUInt32 uiLeft = 2 * i + 1;
+      const ezUInt32 uiRight = 2 * i + 2;
+
+      if (uiLeft < uiCount && ref_heap[uiLeft].fFCost < ref_heap[uiSmallest].fFCost)
+        uiSmallest = uiLeft;
+      if (uiRight < uiCount && ref_heap[uiRight].fFCost < ref_heap[uiSmallest].fFCost)
+        uiSmallest = uiRight;
+
+      if (uiSmallest != i)
+      {
+        ezMath::Swap(ref_heap[i], ref_heap[uiSmallest]);
+        i = uiSmallest;
+      }
+      else
+      {
+        break;
+      }
+    }
+
+    return top;
+  }
+} // namespace
+
+// Shared A* core, used both to search for an exact target coordinate inside a grid, and to search
+// for a way out of a grid (any voxel on its boundary), biased towards vTargetCoord.
+//
+// vStartCoord must be a valid, non-solid coordinate in grid. If bExitSearch is false, vTargetCoord
+// must also be a valid, non-solid coordinate in grid and is searched for exactly. If bExitSearch is
+// true, vTargetCoord is only used to bias the search heuristic and may lie outside grid; the search
+// stops at the first voxel reached that lies on the boundary of grid.
+static ezAiVoxelNavigation::State RunGridAStar(const ezVoxelGrid& grid, const ezVec3I32& vStartCoord, const ezVec3I32& vTargetCoord,
+  bool bExitSearch, ezArrayPtr<const ezVoxelGrid* const> otherGrids, ezUInt32 uiMaxIterations, ezDynamicArray<ezVec3>& out_waypoints)
+{
+  using State = ezAiVoxelNavigation::State;
+
+  const ezUInt32 uiDimX = grid.GetDimensions().x;
+  const ezUInt32 uiDimY = grid.GetDimensions().y;
+  const ezVec3U32 vDims = grid.GetDimensions();
+
+  const ezUInt32 uiStartPacked = PackCoord(vStartCoord, uiDimX, uiDimY);
+  const ezUInt32 uiTargetPacked = PackCoord(vTargetCoord, uiDimX, uiDimY);
+
+  ezHashTable<ezUInt32, AStarNode> nodes;
+  ezDynamicArray<OpenSetEntry> openSet;
+
+  // Initialize start node
+  {
+    AStarNode startNode;
+    startNode.fGCost = 0.0f;
+    startNode.fFCost = ManhattanHeuristic(vStartCoord, vTargetCoord);
+    startNode.uiParent = ezInvalidIndex;
+    nodes.Insert(uiStartPacked, startNode);
+    HeapPush(openSet, uiStartPacked, startNode.fFCost);
+  }
+
+  // 6-connected (face) neighbor offsets. Diagonal (26-connected) movement was removed: it lets a
+  // path cut across a corner between two solid voxels that only touch edge-to-edge or corner-to-
+  // corner, squeezing through a gap that isn't actually open.
+  struct Neighbor
+  {
+    ezInt32 dx, dy, dz;
+  };
+
+  static const Neighbor neighbors[6] = {
+    {-1, 0, 0},
+    {1, 0, 0},
+    {0, -1, 0},
+    {0, 1, 0},
+    {0, 0, -1},
+    {0, 0, 1},
+  };
+  const ezUInt32 uiNeighborCount = 6;
+
+  ezUInt32 uiIterations = 0;
+  ezUInt32 uiGoalPacked = ezInvalidIndex;
+
+  while (!openSet.IsEmpty() && uiIterations < uiMaxIterations)
+  {
+    ++uiIterations;
+
+    const OpenSetEntry current = HeapPop(openSet);
+
+    AStarNode* pCurrentNode = nullptr;
+    nodes.TryGetValue(current.uiIndex, pCurrentNode);
+
+    if (pCurrentNode == nullptr || pCurrentNode->bClosed)
+      continue;
+
+    pCurrentNode->bClosed = true;
+
+    const ezVec3I32 vCurrentCoord = UnpackCoord(current.uiIndex, uiDimX, uiDimY);
+
+    const bool bIsGoal = bExitSearch
+                           ? (IsBoundaryCoord(vCurrentCoord, vDims) && IsUsableExit(vCurrentCoord, vDims, vTargetCoord) &&
+                               IsCoordFreeInOtherGrids(grid, vCurrentCoord, otherGrids))
+                           : current.uiIndex == uiTargetPacked;
+
+    if (bIsGoal)
+    {
+      uiGoalPacked = current.uiIndex;
+      break;
+    }
+
+    const float fCurrentG = pCurrentNode->fGCost;
+
+    for (ezUInt32 n = 0; n < uiNeighborCount; ++n)
+    {
+      const ezVec3I32 vNeighborCoord(
+        vCurrentCoord.x + neighbors[n].dx,
+        vCurrentCoord.y + neighbors[n].dy,
+        vCurrentCoord.z + neighbors[n].dz);
+
+      if (!grid.IsCoordValid(vNeighborCoord))
+        continue;
+
+      if (grid.IsVoxelSet(vNeighborCoord))
+        continue;
+
+      const ezUInt32 uiNeighborPacked = PackCoord(vNeighborCoord, uiDimX, uiDimY);
+      const float fTentativeG = fCurrentG + 1.0f;
+
+      AStarNode* pNeighborNode = nullptr;
+      if (!nodes.TryGetValue(uiNeighborPacked, pNeighborNode))
+      {
+        AStarNode newNode;
+        newNode.fGCost = fTentativeG;
+        newNode.fFCost = fTentativeG + ManhattanHeuristic(vNeighborCoord, vTargetCoord);
+        newNode.uiParent = current.uiIndex;
+        nodes.Insert(uiNeighborPacked, newNode);
+        HeapPush(openSet, uiNeighborPacked, newNode.fFCost);
+      }
+      else if (!pNeighborNode->bClosed && fTentativeG < pNeighborNode->fGCost)
+      {
+        pNeighborNode->fGCost = fTentativeG;
+        pNeighborNode->fFCost = fTentativeG + ManhattanHeuristic(vNeighborCoord, vTargetCoord);
+        pNeighborNode->uiParent = current.uiIndex;
+        // Re-insert into open set (lazy deletion handles stale entries)
+        HeapPush(openSet, uiNeighborPacked, pNeighborNode->fFCost);
+      }
+    }
+  }
+
+  if (uiGoalPacked == ezInvalidIndex)
+    return State::NoPathFound;
+
+  // Back-trace path
+  ezDynamicArray<ezVec3> rawPath;
+  ezUInt32 uiCurrent = uiGoalPacked;
+
+  while (uiCurrent != ezInvalidIndex)
+  {
+    const ezVec3I32 vCoord = UnpackCoord(uiCurrent, uiDimX, uiDimY);
+    rawPath.PushBack(grid.CoordToWorld(vCoord));
+
+    AStarNode* pNode = nullptr;
+    if (nodes.TryGetValue(uiCurrent, pNode))
+    {
+      uiCurrent = pNode->uiParent;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // Reverse to get start-to-target order
+  for (ezUInt32 i = 0; i < rawPath.GetCount() / 2; ++i)
+  {
+    ezMath::Swap(rawPath[i], rawPath[rawPath.GetCount() - 1 - i]);
+  }
+
+  out_waypoints = std::move(rawPath);
+  return State::PathFound;
+}
+
+ezAiVoxelNavigation::State ezAiVoxelNavigation::FindPathToTarget(const ezVoxelGrid& grid, const ezVec3& vStart, const ezVec3& vTarget,
+  ezUInt32 uiMaxIterations, ezDynamicArray<ezVec3>& out_waypoints) const
+{
+  out_waypoints.Clear();
+
+  ezVec3I32 vStartCoord = grid.WorldToCoord(vStart);
+  const ezVec3I32 vTargetCoord = grid.WorldToCoord(vTarget);
+
+  if (!grid.IsCoordValid(vStartCoord) || grid.IsVoxelSet(vStartCoord))
+  {
+    // The exact start voxel is blocked or out of bounds - before giving up, try to recover by
+    // stepping into a free voxel immediately next to it (e.g. the object got pushed into a voxel
+    // that turned solid after it last pathed).
+    ezVec3I32 vRecoveredCoord;
+    if (!FindNearbyValidCoord(grid, vStartCoord, s_uiStartRecoveryRadiusVoxels, vRecoveredCoord))
+      return State::InvalidStartPosition;
+
+    vStartCoord = vRecoveredCoord;
+  }
+
+  if (!grid.IsCoordValid(vTargetCoord) || grid.IsVoxelSet(vTargetCoord))
+    return State::InvalidTargetPosition;
+
+  const State result = RunGridAStar(grid, vStartCoord, vTargetCoord, false, ezArrayPtr<const ezVoxelGrid* const>(), uiMaxIterations, out_waypoints);
+
+  if (result == State::PathFound)
+  {
+    SmoothPath(grid, out_waypoints);
+  }
+
+  return result;
+}
+
+ezAiVoxelNavigation::State ezAiVoxelNavigation::FindPathToExit(const ezVoxelGrid& grid, const ezVec3& vStart, const ezVec3& vRealTarget,
+  ezArrayPtr<const ezVoxelGrid* const> otherGrids, ezUInt32 uiMaxIterations, ezDynamicArray<ezVec3>& out_waypoints) const
+{
+  out_waypoints.Clear();
+
+  ezVec3I32 vStartCoord = grid.WorldToCoord(vStart);
+  const ezVec3I32 vTargetCoord = grid.WorldToCoord(vRealTarget); // may lie outside grid, only used for the heuristic
+
+  if (!grid.IsCoordValid(vStartCoord) || grid.IsVoxelSet(vStartCoord))
+  {
+    ezVec3I32 vRecoveredCoord;
+    if (!FindNearbyValidCoord(grid, vStartCoord, s_uiStartRecoveryRadiusVoxels, vRecoveredCoord))
+      return State::InvalidStartPosition;
+
+    vStartCoord = vRecoveredCoord;
+  }
+
+  const State result = RunGridAStar(grid, vStartCoord, vTargetCoord, true, otherGrids, uiMaxIterations, out_waypoints);
+
+  if (result == State::PathFound)
+  {
+    SmoothPath(grid, out_waypoints);
+  }
+
+  return result;
+}
+
+ezAiVoxelNavigation::State ezAiVoxelNavigation::FindPath(const ezVec3& vStart, const ezVec3& vTarget, const ezAiVoxelGridFinder& gridFinder,
+  float fSearchMargin, ezUInt32 uiMaxIterationsPerHop, ezUInt32 uiMaxHops)
+{
+  m_Waypoints.Clear();
+  m_SegmentInsideGrid.Clear();
+  m_uiCurrentWaypoint = 0;
+  m_Waypoints.PushBack(vStart);
+
+  ezVec3 vCurrent = vStart;
+
+  for (ezUInt32 uiHop = 0; uiHop < uiMaxHops; ++uiHop)
+  {
+    if ((vTarget - vCurrent).GetLengthSquared() < 0.0001f)
+    {
+      m_State = State::PathFound;
+      return m_State;
+    }
+
+    ezBoundingBox searchBox = ezBoundingBox::MakeInvalid();
+    searchBox.ExpandToInclude(vCurrent);
+    searchBox.ExpandToInclude(vTarget);
+    searchBox.Grow(ezVec3(fSearchMargin));
+
+    ezDynamicArray<const ezVoxelGrid*> grids;
+    gridFinder(searchBox, grids);
+
+    const ezVoxelGrid* pGrid = nullptr;
+    ezVec3 vEntry = vCurrent;
+    float fBestEnter = ezMath::HighValue<float>();
+
+    for (const ezVoxelGrid* pCandidate : grids)
+    {
+      const ezBoundingBox box = pCandidate->GetAABB();
+
+      if (box.Contains(vCurrent))
+      {
+        pGrid = pCandidate;
+        vEntry = vCurrent;
+        break;
+      }
+
+      float fEnter;
+      if (box.GetLineSegmentIntersection(vCurrent, vTarget, &fEnter) && fEnter > 0.0001f && fEnter < fBestEnter)
+      {
+        fBestEnter = fEnter;
+        pGrid = pCandidate;
+
+        // The intersection point lies exactly on the grid's boundary surface. Nudge it a tiny bit
+        // further along the segment, into the grid's interior: a point exactly on the max-corner
+        // face would otherwise floor to a voxel coordinate one past the last valid index (an
+        // off-by-one at the boundary), making the grid falsely look unreachable.
+        const ezVec3 vTravelDir = (vTarget - vCurrent).GetNormalized();
+        vEntry = ezMath::Lerp(vCurrent, vTarget, fEnter) + vTravelDir * (pCandidate->GetVoxelSize() * 0.1f);
+      }
+    }
+
+    if (pGrid == nullptr)
+    {
+      // Rest of the way is free space (not covered by any grid)
+      m_Waypoints.PushBack(vTarget);
+      m_SegmentInsideGrid.PushBack(false);
+      m_State = State::PathFound;
+      return m_State;
+    }
+
+    if (!vEntry.IsEqual(vCurrent, 0.0001f))
+    {
+      m_Waypoints.PushBack(vEntry);
+      m_SegmentInsideGrid.PushBack(false);
+    }
+
+    const bool bTargetInside = pGrid->GetAABB().Contains(vTarget);
+
+    ezDynamicArray<ezVec3> hopWaypoints;
+    const State hopState = bTargetInside
+                             ? FindPathToTarget(*pGrid, vEntry, vTarget, uiMaxIterationsPerHop, hopWaypoints)
+                             : FindPathToExit(*pGrid, vEntry, vTarget, grids, uiMaxIterationsPerHop, hopWaypoints);
+
+    if (hopState != State::PathFound)
+    {
+      m_State = hopState;
+      return m_State;
+    }
+
+    for (ezUInt32 i = 0; i < hopWaypoints.GetCount(); ++i)
+    {
+      if (i == 0 && !m_Waypoints.IsEmpty() && hopWaypoints[i].IsEqual(m_Waypoints.PeekBack(), 0.0001f))
+        continue;
+
+      m_Waypoints.PushBack(hopWaypoints[i]);
+      m_SegmentInsideGrid.PushBack(true);
+    }
+
+    vCurrent = m_Waypoints.PeekBack();
+
+    if (bTargetInside)
+    {
+      m_State = State::PathFound;
+      return m_State;
+    }
+
+    // vCurrent is the center of the boundary voxel the exit search stopped at, which is only up to
+    // half a voxel away from the grid's true edge - not actually outside the grid yet. Push it out
+    // along the boundary face normal of that voxel (not the direction from the grid's center through
+    // the exit point - for non-cubic grids that vector is dominated by whichever axis the exit point
+    // is farthest from center on, which usually isn't the axis of the face that was actually crossed).
+    // A full voxel step guarantees clearing the boundary even when exiting through a corner or edge,
+    // where the face normal is not axis-aligned.
+    const ezVec3I32 vExitCoord = pGrid->WorldToCoord(vCurrent);
+    const ezVec3 vOutward = GetBoundaryOutwardNormal(vExitCoord, pGrid->GetDimensions());
+    if (!vOutward.IsZero(0.0001f))
+    {
+      vCurrent += vOutward.GetNormalized() * pGrid->GetVoxelSize();
+    }
+  }
+
+  m_State = State::NoPathFound;
+  return m_State;
+}
+
+void ezAiVoxelNavigation::SmoothPath(const ezVoxelGrid& grid, ezDynamicArray<ezVec3>& inout_waypoints) const
+{
+  if (inout_waypoints.GetCount() <= 2)
+    return;
+
+  ezDynamicArray<ezVec3> smoothed;
+  smoothed.PushBack(inout_waypoints[0]);
+
+  ezUInt32 uiCurrent = 0;
+
+  while (uiCurrent < inout_waypoints.GetCount() - 1)
+  {
+    ezUInt32 uiFarthestVisible = uiCurrent + 1;
+
+    for (ezUInt32 i = inout_waypoints.GetCount() - 1; i > uiCurrent + 1; --i)
+    {
+      ezVec3I32 vCoordA = grid.WorldToCoord(inout_waypoints[uiCurrent]);
+      ezVec3I32 vCoordB = grid.WorldToCoord(inout_waypoints[i]);
+
+      if (grid.IsCoordValid(vCoordA) &&
+          grid.IsCoordValid(vCoordB) &&
+          grid.CheckLineOfSight(vCoordA, vCoordB))
+      {
+        uiFarthestVisible = i;
+        break;
+      }
+    }
+
+    smoothed.PushBack(inout_waypoints[uiFarthestVisible]);
+    uiCurrent = uiFarthestVisible;
+  }
+
+  inout_waypoints = std::move(smoothed);
+}
+
+bool ezAiVoxelNavigation::AdvanceWaypoint()
+{
+  if (m_uiCurrentWaypoint + 1 < m_Waypoints.GetCount())
+  {
+    ++m_uiCurrentWaypoint;
+    return true;
+  }
+  return false;
+}
+
+ezVec3 ezAiVoxelNavigation::GetNextWaypoint() const
+{
+  if (m_Waypoints.IsEmpty())
+    return ezVec3::MakeZero();
+
+  if (m_uiCurrentWaypoint < m_Waypoints.GetCount())
+    return m_Waypoints[m_uiCurrentWaypoint];
+
+  return m_Waypoints[m_Waypoints.GetCount() - 1];
+}
+
+bool ezAiVoxelNavigation::IsPathComplete() const
+{
+  return m_Waypoints.IsEmpty() || m_uiCurrentWaypoint >= m_Waypoints.GetCount();
+}
+
+ezVec3 ezAiVoxelNavigation::WalkPathForward(const ezVec3& vCurrentPos, float fDistance, ezUInt32& inout_uiIndex) const
+{
+  ezVec3 vFrom = vCurrentPos;
+  ezVec3 vTo = m_Waypoints[inout_uiIndex];
+  float fRemaining = ezMath::Max(fDistance, 0.0f);
+
+  while (true)
+  {
+    const ezVec3 vSeg = vTo - vFrom;
+    const float fSegLen = vSeg.GetLength();
+
+    if (fSegLen > 0.0001f)
+    {
+      if (fSegLen >= fRemaining)
+        return vFrom + vSeg * (fRemaining / fSegLen);
+
+      fRemaining -= fSegLen;
+    }
+
+    if (inout_uiIndex + 1 >= m_Waypoints.GetCount())
+      return vTo;
+
+    vFrom = vTo;
+    ++inout_uiIndex;
+    vTo = m_Waypoints[inout_uiIndex];
+  }
+}
+
+ezVec3 ezAiVoxelNavigation::GetLookAheadPoint(const ezVec3& vCurrentPos, float fLookAheadDistance) const
+{
+  if (IsPathComplete())
+    return vCurrentPos;
+
+  ezUInt32 uiIndex = m_uiCurrentWaypoint; // local copy - peek only, does not advance the path
+  return WalkPathForward(vCurrentPos, fLookAheadDistance, uiIndex);
+}
+
+ezVec3 ezAiVoxelNavigation::AdvanceAlongPath(const ezVec3& vCurrentPos, float fDistance)
+{
+  if (IsPathComplete())
+    return vCurrentPos;
+
+  return WalkPathForward(vCurrentPos, fDistance, m_uiCurrentWaypoint); // mutates the current waypoint index directly
+}
+
+void ezAiVoxelNavigation::SetDirectPath(const ezVec3& vStart, const ezVec3& vTarget)
+{
+  m_Waypoints.Clear();
+  m_SegmentInsideGrid.Clear();
+  m_uiCurrentWaypoint = 0;
+
+  m_Waypoints.PushBack(vStart);
+  m_Waypoints.PushBack(vTarget);
+  m_SegmentInsideGrid.PushBack(false);
+
+  m_State = State::PathFound;
+}
+
+void ezAiVoxelNavigation::CancelNavigation()
+{
+  m_Waypoints.Clear();
+  m_SegmentInsideGrid.Clear();
+  m_uiCurrentWaypoint = 0;
+  m_State = State::Idle;
+}
+
+void ezAiVoxelNavigation::DebugDrawPath(const ezDebugRendererContext& context, const ezColor& color) const
+{
+  if (m_Waypoints.GetCount() < 2)
+    return;
+
+  ezDynamicArray<ezDebugRendererLine> lines;
+  lines.Reserve(m_Waypoints.GetCount() - 1);
+
+  for (ezUInt32 i = 0; i + 1 < m_Waypoints.GetCount(); ++i)
+  {
+    auto& line = lines.ExpandAndGetRef();
+    line.m_start = m_Waypoints[i];
+    line.m_end = m_Waypoints[i + 1];
+
+    if (i < m_uiCurrentWaypoint)
+    {
+      line.m_startColor = ezColor::Grey;
+      line.m_endColor = ezColor::Grey;
+    }
+    else
+    {
+      line.m_startColor = color;
+      line.m_endColor = color;
+    }
+  }
+
+  ezDebugRenderer::DrawLines(context, lines, color);
+}
+
+void ezAiVoxelNavigation::DebugDrawPathSegments(const ezDebugRendererContext& context, const ezColor& insideGridColor,
+  const ezColor& freeSpaceColor) const
+{
+  if (m_Waypoints.GetCount() < 2)
+    return;
+
+  ezDynamicArray<ezDebugRendererLine> lines;
+  lines.Reserve(m_Waypoints.GetCount() - 1);
+
+  for (ezUInt32 i = 0; i + 1 < m_Waypoints.GetCount(); ++i)
+  {
+    auto& line = lines.ExpandAndGetRef();
+    line.m_start = m_Waypoints[i];
+    line.m_end = m_Waypoints[i + 1];
+
+    const ezColor& color = m_SegmentInsideGrid[i] ? insideGridColor : freeSpaceColor;
+    line.m_startColor = color;
+    line.m_endColor = color;
+  }
+
+  ezDebugRenderer::DrawLines(context, lines, ezColor::White);
+}

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelNavigationComponent.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelNavigationComponent.cpp
@@ -1,0 +1,650 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation/SteeringUtils.h>
+#include <AiPlugin/Navigation3D/VoxelGridComponent.h>
+#include <AiPlugin/Navigation3D/VoxelNavigationComponent.h>
+#include <AiPlugin/Navigation3D/VoxelWorldModule.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+
+// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_BITFLAGS(ezAiVoxelNavigationDebugFlags, 1)
+  EZ_BITFLAGS_CONSTANTS(ezAiVoxelNavigationDebugFlags::PrintState, ezAiVoxelNavigationDebugFlags::VisPath)
+EZ_END_STATIC_REFLECTED_BITFLAGS;
+
+EZ_BEGIN_STATIC_REFLECTED_ENUM(ezAiVoxelNavigationComponentState, 1)
+  EZ_ENUM_CONSTANTS(ezAiVoxelNavigationComponentState::Idle, ezAiVoxelNavigationComponentState::Moving, ezAiVoxelNavigationComponentState::Failed)
+EZ_END_STATIC_REFLECTED_ENUM;
+
+EZ_BEGIN_COMPONENT_TYPE(ezAiVoxelNavigationComponent, 1, ezComponentMode::Dynamic)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("NavigationTarget", DummyGetter, SetNavigationTargetReference)->AddAttributes(new ezGameObjectReferenceAttribute()),
+    EZ_MEMBER_PROPERTY("Speed", m_fSpeed)->AddAttributes(new ezDefaultValueAttribute(5.0f)),
+    EZ_MEMBER_PROPERTY("Acceleration", m_fAcceleration)->AddAttributes(new ezDefaultValueAttribute(3.0f)),
+    EZ_MEMBER_PROPERTY("Deceleration", m_fDeceleration)->AddAttributes(new ezDefaultValueAttribute(8.0f)),
+    EZ_MEMBER_PROPERTY("ReachedDistance", m_fReachedDistance)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 10.0f)),
+    EZ_MEMBER_PROPERTY("ApplySteering", m_bApplySteering)->AddAttributes(new ezDefaultValueAttribute(true)),
+    EZ_MEMBER_PROPERTY("LookAheadDistance", m_fLookAheadDistance)->AddAttributes(new ezDefaultValueAttribute(3.0f), new ezClampValueAttribute(0.1f, ezVariant())),
+    EZ_MEMBER_PROPERTY("MaxPathOffset", m_fMaxPathOffset)->AddAttributes(new ezDefaultValueAttribute(3.0f), new ezClampValueAttribute(0.1f, ezVariant())),
+    EZ_MEMBER_PROPERTY("CorridorCorrectionRate", m_fCorridorCorrectionRate)->AddAttributes(new ezDefaultValueAttribute(8.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_MEMBER_PROPERTY("MaxAngularSpeed", m_MaxAngularSpeed)->AddAttributes(new ezDefaultValueAttribute(ezAngle::MakeFromDegree(180.0f)), new ezClampValueAttribute(ezAngle::MakeFromDegree(0.0f), ezVariant())),
+    EZ_MEMBER_PROPERTY("BankAmount", m_fBankAmount)->AddAttributes(new ezDefaultValueAttribute(3.0f)),
+    EZ_MEMBER_PROPERTY("MaxBankAngle", m_MaxBankAngle)->AddAttributes(new ezDefaultValueAttribute(ezAngle::MakeFromDegree(30.0f)), new ezClampValueAttribute(ezAngle::MakeFromDegree(0.0f), ezAngle::MakeFromDegree(90.0f))),
+    EZ_BITFLAGS_MEMBER_PROPERTY("DebugFlags", ezAiVoxelNavigationDebugFlags, m_DebugFlags),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("AI/Navigation"),
+  }
+  EZ_END_ATTRIBUTES;
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetDestination, In, "Destination"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetDestinationDirect, In, "Destination"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetNavigationTarget, In, "Object"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(CancelNavigation),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetState),
+    EZ_SCRIPT_FUNCTION_PROPERTY(TurnTowards, In, "Direction"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetTurnAngleTowards, In, "Direction"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(IsNavigating),
+    EZ_SCRIPT_FUNCTION_PROPERTY(IsApproachingDestination),
+    EZ_SCRIPT_FUNCTION_PROPERTY(FindRandomPointAroundSphere, In, "Center", In, "Radius", In, "MaxAttempts", Out, "Point"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetValidCellNearby, In, "Start", In, "SearchRadius", Out, "Point"),
+  }
+  EZ_END_FUNCTIONS;
+}
+EZ_END_COMPONENT_TYPE
+// clang-format on
+
+ezAiVoxelNavigationComponent::ezAiVoxelNavigationComponent() = default;
+ezAiVoxelNavigationComponent::~ezAiVoxelNavigationComponent() = default;
+
+void ezAiVoxelNavigationComponent::SetNavigationTargetReference(const char* szReference)
+{
+  auto resolver = GetWorld()->GetGameObjectReferenceResolver();
+
+  if (!resolver.IsValid())
+    return;
+
+  SetNavigationTarget(resolver(szReference, GetHandle(), "NavigationTarget"));
+}
+
+void ezAiVoxelNavigationComponent::SetNavigationTarget(ezGameObjectHandle hObject)
+{
+  m_hNavigationTarget = hObject;
+}
+
+void ezAiVoxelNavigationComponent::OnSimulationStarted()
+{
+  SUPER::OnSimulationStarted();
+
+  m_uiSkipNextFrames = 3;
+  m_vSteerPosition = GetOwner()->GetGlobalPosition();
+  m_vPathPosition = GetOwner()->GetGlobalPosition(); // placeholder until the first SetDestination()/SetDestinationDirect() snaps it to a valid voxel
+  m_bPathPositionInitialized = false;
+  m_fPathSpeed = 0.0f;
+  m_qSteerRotation = GetOwner()->GetGlobalRotation();
+  m_vVelocity = ezVec3::MakeZero();
+}
+
+void ezAiVoxelNavigationComponent::SetDestination(const ezVec3& vGlobalPos)
+{
+  auto* pVoxelModule = GetWorld()->GetOrCreateModule<ezAiVoxelWorldModule>();
+  if (pVoxelModule == nullptr || !pVoxelModule->IsReady())
+  {
+    // Grid not ready yet, don't treat as failure - caller can retry
+    return;
+  }
+
+  // Track the actual voxel size of the grid we're in, so the runtime thresholds derived from it
+  // (arrival/repath distances in Update()) scale with the grid instead of a fixed assumption.
+  {
+    ezTempHybridArray<ezAiVoxelGridComponent*, 8> grids;
+    pVoxelModule->FindGridsInBox(ezBoundingBox::MakeFromCenterAndHalfExtents(GetOwner()->GetGlobalPosition(), ezVec3(0.01f)), grids);
+    if (!grids.IsEmpty())
+      m_fVoxelSize = grids[0]->GetVoxelSize();
+  }
+
+  if (!m_bPathPositionInitialized)
+  {
+    ezVec3 vSnapped;
+    if (GetValidCellNearby(GetOwner()->GetGlobalPosition(), 5.0f, vSnapped))
+      m_vPathPosition = vSnapped;
+    else
+      m_vPathPosition = GetOwner()->GetGlobalPosition(); // best effort; FindPath() reports InvalidStartPosition below if this is still bad
+
+    m_bPathPositionInitialized = true;
+  }
+
+  const ezVec3 vCurrentPos = m_vPathPosition;
+
+  m_vLastPathTargetPos = vGlobalPos;
+
+  const ezAiVoxelGridFinder gridFinder = [pVoxelModule](const ezBoundingBox& searchBox, ezDynamicArray<const ezVoxelGrid*>& out_grids)
+  {
+    ezHybridArray<ezAiVoxelGridComponent*, 4> gridComponents;
+    pVoxelModule->FindGridsInBox(searchBox, gridComponents);
+
+    out_grids.Clear();
+    for (const ezAiVoxelGridComponent* pGridComponent : gridComponents)
+      out_grids.PushBack(&pGridComponent->GetStaticVoxelGrid());
+  };
+
+  const auto result = m_Navigation.FindPath(vCurrentPos, vGlobalPos, gridFinder);
+
+  switch (result)
+  {
+    case ezAiVoxelNavigation::State::PathFound:
+      m_State = ezAiVoxelNavigationComponentState::Moving;
+      // Deliberately not resetting m_vVelocity here: rerouting an already-moving object (e.g.
+      // repathing towards a moving target) should carry momentum over smoothly instead of
+      // stuttering to a stop and re-accelerating on every reroute.
+      break;
+
+    case ezAiVoxelNavigation::State::InvalidStartPosition:
+    case ezAiVoxelNavigation::State::InvalidTargetPosition:
+    default:
+      // Failure reason is available via m_Navigation.GetState() if the caller needs to
+      // distinguish InvalidStartPosition/InvalidTargetPosition/NoPathFound.
+      m_State = ezAiVoxelNavigationComponentState::Failed;
+      break;
+  }
+}
+
+void ezAiVoxelNavigationComponent::SetDestinationDirect(const ezVec3& vGlobalPos)
+{
+  if (!m_bPathPositionInitialized)
+  {
+    ezVec3 vSnapped;
+    if (GetValidCellNearby(GetOwner()->GetGlobalPosition(), 5.0f, vSnapped))
+      m_vPathPosition = vSnapped;
+    else
+      m_vPathPosition = GetOwner()->GetGlobalPosition();
+
+    m_bPathPositionInitialized = true;
+  }
+
+  const ezVec3 vCurrentPos = m_vPathPosition;
+
+  m_vLastPathTargetPos = vGlobalPos;
+  m_Navigation.SetDirectPath(vCurrentPos, vGlobalPos);
+
+  // Deliberately not resetting m_vVelocity here, same reasoning as SetDestination().
+  m_State = ezAiVoxelNavigationComponentState::Moving;
+}
+
+void ezAiVoxelNavigationComponent::CancelNavigation()
+{
+  m_Navigation.CancelNavigation();
+  m_State = ezAiVoxelNavigationComponentState::Idle;
+
+  // Deliberately not resetting m_vVelocity here: Update() decelerates to a stop gracefully via
+  // DecelerateToStop() instead of coming to an instant halt.
+
+  // Otherwise Update() would immediately re-navigate towards the tracked target again.
+  m_hNavigationTarget.Invalidate();
+}
+
+ezAngle ezAiVoxelNavigationComponent::TurnTowards(const ezVec3& vDirection)
+{
+  const float fTimeDiff = GetWorld()->GetClock().GetTimeDiff().AsFloatInSeconds();
+  const ezAngle remaining = ezAiSteeringUtils::TurnTowards(m_qSteerRotation, vDirection, m_MaxAngularSpeed, fTimeDiff);
+
+  if (m_bApplySteering)
+  {
+    GetOwner()->SetGlobalRotation(m_qSteerRotation);
+  }
+
+  return remaining;
+}
+
+ezAngle ezAiVoxelNavigationComponent::GetTurnAngleTowards(const ezVec3& vDirection) const
+{
+  return ezAiSteeringUtils::GetAngleTowards(m_qSteerRotation, vDirection);
+}
+
+float ezAiVoxelNavigationComponent::GetRemainingDistance() const
+{
+  if (m_State != ezAiVoxelNavigationComponentState::Moving)
+    return 0.0f;
+
+  const auto& waypoints = m_Navigation.GetWaypoints();
+  const ezUInt32 uiCurrent = m_Navigation.GetCurrentWaypointIndex();
+
+  if (uiCurrent >= waypoints.GetCount())
+    return 0.0f;
+
+  float fDist = (waypoints[uiCurrent] - m_vPathPosition).GetLength();
+
+  for (ezUInt32 i = uiCurrent; i + 1 < waypoints.GetCount(); ++i)
+  {
+    fDist += (waypoints[i + 1] - waypoints[i]).GetLength();
+  }
+
+  return fDist;
+}
+
+bool ezAiVoxelNavigationComponent::IsApproachingDestination() const
+{
+  if (m_State != ezAiVoxelNavigationComponentState::Moving)
+    return false;
+
+  const float fBrakingDistance = ComputeBrakingDistance(m_fSpeed);
+  return fBrakingDistance > 0.0f && GetRemainingDistance() < fBrakingDistance;
+}
+
+bool ezAiVoxelNavigationComponent::FindRandomPointAroundSphere(const ezVec3& vCenter, float fRadius, ezUInt32 uiMaxAttempts, ezVec3& out_vPoint)
+{
+  auto* pVoxelModule = GetWorld()->GetModule<ezAiVoxelWorldModule>();
+  if (pVoxelModule == nullptr || !pVoxelModule->IsReady())
+    return false;
+
+  const ezBoundingBox searchBox = ezBoundingBox::MakeFromCenterAndHalfExtents(vCenter, ezVec3(fRadius));
+  ezTempHybridArray<ezAiVoxelGridComponent*, 8> grids;
+  pVoxelModule->FindGridsInBox(searchBox, grids);
+
+  ezRandom& rng = GetWorld()->GetRandomNumberGenerator();
+
+  for (ezUInt32 i = 0; i < uiMaxAttempts; ++i)
+  {
+    const ezVec3 vCandidate = vCenter + ezVec3::MakeRandomPointInSphere(rng) * fRadius;
+
+    bool bBlocked = false;
+
+    for (const ezAiVoxelGridComponent* pGridComponent : grids)
+    {
+      const ezVoxelGrid& grid = pGridComponent->GetStaticVoxelGrid();
+
+      const ezVec3I32 vCoord = grid.WorldToCoord(vCandidate);
+      if (!grid.IsCoordValid(vCoord))
+      {
+        // outside this grid -> check the next one
+        continue;
+      }
+
+      // Covered by a grid: solid means try another candidate, free means this point is good.
+      bBlocked = grid.IsVoxelSet(vCoord);
+      break;
+    }
+
+    // Accepted if free within its covering grid, or not covered by any grid at all (space outside
+    // all grids is free, same convention as pathfinding and GetValidCellNearby()).
+    if (!bBlocked)
+    {
+      out_vPoint = vCandidate;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool ezAiVoxelNavigationComponent::GetValidCellNearby(const ezVec3& vStart, float fSearchRadius, ezVec3& out_vPoint) const
+{
+  auto* pVoxelModule = GetWorld()->GetModule<ezAiVoxelWorldModule>();
+  if (pVoxelModule == nullptr || !pVoxelModule->IsReady())
+    return false;
+
+  const ezBoundingBox searchBox = ezBoundingBox::MakeFromCenterAndHalfExtents(vStart, ezVec3(fSearchRadius));
+  ezTempHybridArray<ezAiVoxelGridComponent*, 8> grids;
+  pVoxelModule->FindGridsInBox(searchBox, grids);
+
+  // Find which grid (if any) actually covers vStart - only that grid's occupancy is relevant to
+  // whether vStart, and its neighborhood, are free.
+  const ezAiVoxelGridComponent* pOwningGrid = nullptr;
+  ezVec3I32 vStartCoord;
+
+  for (const ezAiVoxelGridComponent* pGridComponent : grids)
+  {
+    const ezVoxelGrid& grid = pGridComponent->GetStaticVoxelGrid();
+    const ezVec3I32 vCoord = grid.WorldToCoord(vStart);
+
+    if (grid.IsCoordValid(vCoord))
+    {
+      pOwningGrid = pGridComponent;
+      vStartCoord = vCoord;
+      break;
+    }
+  }
+
+  if (pOwningGrid == nullptr)
+  {
+    // Not covered by any nearby grid -> free space, same convention as pathfinding.
+    out_vPoint = vStart;
+    return true;
+  }
+
+  const ezVoxelGrid& grid = pOwningGrid->GetStaticVoxelGrid();
+
+  if (!grid.IsVoxelSet(vStartCoord))
+  {
+    out_vPoint = vStart;
+    return true;
+  }
+
+  // vStart is blocked - scan every voxel within fSearchRadius and keep the physically closest free
+  // one found. Simple exhaustive scan rather than an expanding-shell search: fSearchRadius is
+  // expected to stay small (this is meant for local recovery, not long-range searches).
+  const float fVoxelSize = grid.GetVoxelSize();
+  const ezInt32 iMaxSteps = ezMath::Max(1, (ezInt32)ezMath::Ceil(fSearchRadius / fVoxelSize));
+
+  float fBestDistSqr = fSearchRadius * fSearchRadius;
+  bool bFound = false;
+
+  for (ezInt32 dz = -iMaxSteps; dz <= iMaxSteps; ++dz)
+  {
+    for (ezInt32 dy = -iMaxSteps; dy <= iMaxSteps; ++dy)
+    {
+      for (ezInt32 dx = -iMaxSteps; dx <= iMaxSteps; ++dx)
+      {
+        if (dx == 0 && dy == 0 && dz == 0)
+          continue;
+
+        const ezVec3I32 vCoord = vStartCoord + ezVec3I32(dx, dy, dz);
+        if (!grid.IsCoordValid(vCoord) || grid.IsVoxelSet(vCoord))
+          continue;
+
+        const ezVec3 vCandidate = grid.CoordToWorld(vCoord);
+        const float fDistSqr = (vCandidate - vStart).GetLengthSquared();
+
+        if (fDistSqr < fBestDistSqr)
+        {
+          fBestDistSqr = fDistSqr;
+          out_vPoint = vCandidate;
+          bFound = true;
+        }
+      }
+    }
+  }
+
+  return bFound;
+}
+
+void ezAiVoxelNavigationComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+  ezStreamWriter& s = inout_stream.GetStream();
+
+  s << m_fSpeed;
+  s << m_fAcceleration;
+  s << m_fDeceleration;
+  s << m_fReachedDistance;
+  s << m_bApplySteering;
+  s << m_DebugFlags;
+  inout_stream.WriteGameObjectHandle(m_hNavigationTarget);
+  s << m_fLookAheadDistance;
+  s << m_MaxAngularSpeed;
+  s << m_fBankAmount;
+  s << m_MaxBankAngle;
+  s << m_fMaxPathOffset;
+  s << m_fCorridorCorrectionRate;
+}
+
+void ezAiVoxelNavigationComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  ezStreamReader& s = inout_stream.GetStream();
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+
+  s >> m_fSpeed;
+  s >> m_fAcceleration;
+  s >> m_fDeceleration;
+  s >> m_fReachedDistance;
+  s >> m_bApplySteering;
+  s >> m_DebugFlags;
+  m_hNavigationTarget = inout_stream.ReadGameObjectHandle();
+  s >> m_fLookAheadDistance;
+  s >> m_MaxAngularSpeed;
+  s >> m_fBankAmount;
+  s >> m_MaxBankAngle;
+  s >> m_fMaxPathOffset;
+  s >> m_fCorridorCorrectionRate;
+}
+
+void ezAiVoxelNavigationComponent::Update()
+{
+  if (m_uiSkipNextFrames > 0)
+  {
+    m_uiSkipNextFrames--;
+    return;
+  }
+
+  const float tDiff = GetWorld()->GetClock().GetTimeDiff().AsFloatInSeconds();
+
+  // If a navigation target is set, keep the path aimed at its current position
+  if (!m_hNavigationTarget.IsInvalidated())
+  {
+    ezGameObject* pTarget = nullptr;
+    if (GetWorld()->TryGetObject(m_hNavigationTarget, pTarget))
+    {
+      const ezVec3 vTargetPos = pTarget->GetGlobalPosition();
+      const float fDistToTarget = (vTargetPos - m_vPathPosition).GetLength();
+
+      // Only re-navigate if we're not already at the target
+      const float fArrivalThreshold = ezMath::Max(m_fReachedDistance, m_fVoxelSize * 0.5f);
+
+      if (m_State == ezAiVoxelNavigationComponentState::Idle)
+      {
+        if (fDistToTarget > fArrivalThreshold)
+        {
+          SetDestination(vTargetPos);
+        }
+      }
+      else if (m_State == ezAiVoxelNavigationComponentState::Moving)
+      {
+        // Target keeps moving while we're already following a path towards it - periodically
+        // recompute the path so it doesn't go stale (e.g. prey changing direction mid-chase).
+        m_fRepathCooldown -= tDiff;
+
+        const float fRepathThreshold = ezMath::Max(m_fVoxelSize * 2.0f, 1.0f);
+        if (m_fRepathCooldown <= 0.0f && (vTargetPos - m_vLastPathTargetPos).GetLength() > fRepathThreshold)
+        {
+          SetDestination(vTargetPos);
+          m_fRepathCooldown = 0.5f;
+        }
+      }
+    }
+  }
+
+  if (m_State == ezAiVoxelNavigationComponentState::Moving)
+  {
+    MoveAlongPath(tDiff);
+  }
+  else if (!m_vVelocity.IsZero(0.0001f))
+  {
+    DecelerateToStop(tDiff);
+  }
+
+  if (m_DebugFlags.IsAnyFlagSet())
+  {
+    if (m_DebugFlags.IsSet(ezAiVoxelNavigationDebugFlags::PrintState))
+    {
+      const ezVec3 vPosition = GetOwner()->GetGlobalPosition() + ezVec3(0, 0, 1.5f);
+
+      switch (m_State)
+      {
+        case ezAiVoxelNavigationComponentState::Idle:
+          ezDebugRenderer::Draw3DText(GetWorld(), "Idle", vPosition, ezColor::Grey);
+          break;
+        case ezAiVoxelNavigationComponentState::Moving:
+          ezDebugRenderer::Draw3DText(GetWorld(), "Moving", vPosition, ezColor::Yellow);
+          break;
+        case ezAiVoxelNavigationComponentState::Failed:
+          ezDebugRenderer::Draw3DText(GetWorld(), "Failed", vPosition, ezColor::Red);
+          break;
+      }
+    }
+
+    if (m_DebugFlags.IsSet(ezAiVoxelNavigationDebugFlags::VisPath))
+    {
+      m_Navigation.DebugDrawPath(GetWorld(), ezColor::DeepSkyBlue);
+    }
+  }
+}
+
+void ezAiVoxelNavigationComponent::MoveAlongPath(float fTimeDiff)
+{
+  if (m_Navigation.IsPathComplete())
+  {
+    m_State = ezAiVoxelNavigationComponentState::Idle;
+    // Leave m_vVelocity as-is - DecelerateToStop() picks it up next frame.
+    return;
+  }
+
+  const ezVec3 vFinalWaypoint = m_Navigation.GetWaypoints().PeekBack();
+  const float fRemainingDist = GetRemainingDistance();
+  const float fBrakingDistance = ComputeBrakingDistance(m_fSpeed);
+
+  // How well the ship is currently facing where it needs to go, measured against a look-ahead
+  // point from the path position *before* advancing it this frame. Drives the speed of both the
+  // ground-truth path advance and the visual steering below: a ship that still has to turn around
+  // (e.g. a reversed destination) should brake to a near-stop and wait for its heading to catch up
+  // rather than let the path position race ahead of it - otherwise the visual position, which can
+  // only move nose-first, falls far behind and either has to be yanked back into the corridor or
+  // silently lags, both of which look wrong.
+  const ezVec3 vLookAheadForTurn = m_Navigation.GetLookAheadPoint(m_vPathPosition, m_fLookAheadDistance);
+  ezVec3 vDesiredDir = vLookAheadForTurn - m_vSteerPosition;
+  if (vDesiredDir.IsZero(0.0001f))
+  {
+    vDesiredDir = m_qSteerRotation * ezVec3::MakeAxisX();
+  }
+
+  const ezAngle angleToTarget = ezAiSteeringUtils::GetAngleTowards(m_qSteerRotation, vDesiredDir);
+  SteerAndBank(vDesiredDir, fTimeDiff);
+
+  const float fTurnFactor = ezMath::Clamp(1.0f - (angleToTarget / ezAngle::MakeFromDegree(90.0f)), 0.05f, 1.0f);
+
+  // --- Ground-truth path progress: an arc-length walk along the path polyline, which is
+  // guaranteed clear (A*'d through free voxels, then string-pulled) - no runtime voxel validation
+  // needed here, unlike the free-form visual steering below. Waypoint advancement is a side effect
+  // of AdvanceAlongPath(), replacing the old per-waypoint plane-crossing loop entirely. Throttled by
+  // fTurnFactor so it can't outrun the visual position while the ship is still turning to face it.
+  float fPathTargetSpeed = m_fSpeed * fTurnFactor;
+  if (fBrakingDistance > 0.0f && fRemainingDist < fBrakingDistance)
+  {
+    fPathTargetSpeed = ezMath::Max(fPathTargetSpeed * (fRemainingDist / fBrakingDistance), 0.5f);
+  }
+
+  m_fPathSpeed = ezAiSteeringUtils::ApplyAcceleration(m_fPathSpeed, fPathTargetSpeed, m_fAcceleration, m_fDeceleration, fTimeDiff);
+  m_vPathPosition = m_Navigation.AdvanceAlongPath(m_vPathPosition, m_fPathSpeed * fTimeDiff);
+
+  if ((m_vPathPosition - vFinalWaypoint).GetLength() <= m_fReachedDistance)
+  {
+    m_State = ezAiVoxelNavigationComponentState::Idle;
+    // Fall through - still steer the visual position towards the final point this frame instead
+    // of snapping/stopping abruptly.
+  }
+
+  // --- Visual (nose-first) steering: free-form, chases a look-ahead point on the path. Explicitly
+  // not voxel-validated - it may lag or stray from the path, corrected by the corridor clamp below
+  // rather than by blocking movement outright. This is what actually gets applied to the transform.
+  // Target speed: base speed, reduced for sharp turns (nose-first movement can't move fast while
+  // turning hard) and for braking near the end of the path - same fTurnFactor as the path speed
+  // above, so both ease off together instead of the path racing ahead of what's actually turning.
+  float fVisualTargetSpeed = m_fSpeed * fTurnFactor;
+  if (fBrakingDistance > 0.0f && fRemainingDist < fBrakingDistance)
+  {
+    fVisualTargetSpeed = ezMath::Max(fVisualTargetSpeed * (fRemainingDist / fBrakingDistance), 0.5f);
+  }
+
+  // Nose-first speed integration: velocity always points in the current facing direction.
+  const float fNewSpeed = ezAiSteeringUtils::ApplyAcceleration(m_vVelocity.GetLength(), fVisualTargetSpeed, m_fAcceleration, m_fDeceleration, fTimeDiff);
+  m_vVelocity = (m_qSteerRotation * ezVec3::MakeAxisX()) * fNewSpeed;
+
+  ezVec3 vNewSteerPosition = m_vSteerPosition + m_vVelocity * fTimeDiff;
+  vNewSteerPosition = ApplyCorridorClamp(vNewSteerPosition, fTimeDiff);
+
+  m_vSteerPosition = vNewSteerPosition;
+
+  if (m_bApplySteering)
+  {
+    GetOwner()->SetGlobalPosition(m_vSteerPosition);
+    GetOwner()->SetGlobalRotation(m_qSteerRotation);
+  }
+}
+
+float ezAiVoxelNavigationComponent::ComputeBrakingDistance(float fSpeed) const
+{
+  return (fSpeed * fSpeed) / (2.0f * m_fDeceleration);
+}
+
+ezVec3 ezAiVoxelNavigationComponent::ApplyCorridorClamp(const ezVec3& vCandidate, float fTimeDiff) const
+{
+  const ezVec3 vOffset = vCandidate - m_vPathPosition;
+  const float fOffsetDist = vOffset.GetLength();
+  if (fOffsetDist <= m_fMaxPathOffset)
+    return vCandidate;
+
+  // Soft pull toward the corridor boundary (not all the way to the path position), proportional to
+  // how far outside the corridor the point is - avoids a visible kink/snap when first crossing
+  // MaxPathOffset, and lets the object visibly hug the outside of a tight corner rather than being
+  // sucked onto the path's exact line.
+  const float fPullAlpha = 1.0f - ezMath::Exp(-m_fCorridorCorrectionRate * fTimeDiff);
+  const ezVec3 vCorridorEdge = m_vPathPosition + vOffset * (m_fMaxPathOffset / fOffsetDist);
+  return ezMath::Lerp(vCandidate, vCorridorEdge, fPullAlpha);
+}
+
+void ezAiVoxelNavigationComponent::DecelerateToStop(float fTimeDiff)
+{
+  const float fCurrentSpeed = m_vVelocity.GetLength();
+  const ezVec3 vDir = m_vVelocity / fCurrentSpeed; // safe: only called when velocity is non-zero
+  const float fNewSpeed = ezAiSteeringUtils::ApplyAcceleration(fCurrentSpeed, 0.0f, m_fAcceleration, m_fDeceleration, fTimeDiff);
+
+  m_vVelocity = vDir * fNewSpeed;
+
+  // Braking glide (e.g. after CancelNavigation() mid-turn) is free-form, visual-only movement, same
+  // as MoveAlongPath()'s visual step - not voxel-validated, just kept within the path corridor.
+  m_vSteerPosition = ApplyCorridorClamp(m_vSteerPosition + m_vVelocity * fTimeDiff, fTimeDiff);
+
+  // Keep facing the direction it was already moving/braking in - but still relax back to level
+  // (and decay any leftover bank) since nothing is actively steering it anymore.
+  SteerAndBank(vDir, fTimeDiff);
+
+  if (m_bApplySteering)
+  {
+    GetOwner()->SetGlobalPosition(m_vSteerPosition);
+    GetOwner()->SetGlobalRotation(m_qSteerRotation);
+  }
+}
+
+void ezAiVoxelNavigationComponent::SteerAndBank(const ezVec3& vDesiredDir, float fTimeDiff)
+{
+  const ezVec3 vOldForward = m_qSteerRotation * ezVec3::MakeAxisX();
+
+  // Also re-levels any existing roll, even if vDesiredDir == vOldForward (no actual turn).
+  ezAiSteeringUtils::TurnTowards(m_qSteerRotation, vDesiredDir, m_MaxAngularSpeed, fTimeDiff);
+  m_qSteerRotation.Normalize();
+
+  const ezVec3 vNewForward = m_qSteerRotation * ezVec3::MakeAxisX();
+  const ezAngle turnStepAngle = vOldForward.GetAngleBetween(vNewForward);
+
+  ezAngle bankTarget = ezAngle::MakeFromRadian(0.0f);
+  if (turnStepAngle > ezAngle::MakeFromDegree(0.01f) && m_fBankAmount != 0.0f)
+  {
+    // Negative BankAmount flips which way the ship leans into a turn (some visuals read better
+    // banking "outward" rather than "into" the curve) - clamp the magnitude to MaxBankAngle
+    // regardless of sign, then apply the turn direction and the user-chosen bank direction together.
+    const float fTurnSign = ezMath::Sign(vOldForward.CrossRH(vNewForward).Dot(ezVec3::MakeAxisZ()));
+    const float fBankSign = ezMath::Sign(m_fBankAmount);
+    const ezAngle tiltMagnitude = ezMath::Min(turnStepAngle * ezMath::Abs(m_fBankAmount), m_MaxBankAngle);
+    bankTarget = tiltMagnitude * fTurnSign * fBankSign;
+  }
+
+  // Smooth the bank angle over time so it eases in/out instead of snapping, and decays back to
+  // level (0) once the turn ends. Frame-rate independent exponential smoothing (same form as the
+  // corridor clamp); the rate is tuned to retain ~0.85 of the previous angle per frame at 60 Hz.
+  const float fBankSmoothingRate = 10.0f;
+  const float fBankAlpha = 1.0f - ezMath::Exp(-fBankSmoothingRate * fTimeDiff);
+  m_BankAngle = ezMath::Lerp(m_BankAngle, bankTarget, fBankAlpha);
+
+  if (m_BankAngle.GetRadian() != 0.0f)
+  {
+    m_qSteerRotation = m_qSteerRotation * ezQuat::MakeFromAxisAndAngle(ezVec3::MakeAxisX(), m_BankAngle);
+  }
+}
+
+EZ_STATICLINK_FILE(AiPlugin, AiPlugin_Navigation3D_Implementation_VoxelNavigationComponent);

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelPathTestComponent.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelPathTestComponent.cpp
@@ -1,0 +1,137 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation3D/VoxelGridComponent.h>
+#include <AiPlugin/Navigation3D/VoxelPathTestComponent.h>
+#include <AiPlugin/Navigation3D/VoxelWorldModule.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+
+// clang-format off
+EZ_BEGIN_COMPONENT_TYPE(ezAiVoxelPathTestComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("PathEnd", DummyGetter, SetPathEndReference)->AddAttributes(new ezGameObjectReferenceAttribute()),
+
+    EZ_MEMBER_PROPERTY("VisualizeSmoothedPath", m_bVisualizeSmoothedPath)->AddAttributes(new ezDefaultValueAttribute(true)),
+    EZ_MEMBER_PROPERTY("VisualizePathState", m_bVisualizePathState)->AddAttributes(new ezDefaultValueAttribute(true)),
+
+    EZ_MEMBER_PROPERTY("SearchMargin", m_fSearchMargin)->AddAttributes(new ezDefaultValueAttribute(5.0f)),
+    EZ_MEMBER_PROPERTY("MaxIterationsPerHop", m_uiMaxIterationsPerHop)->AddAttributes(new ezDefaultValueAttribute(10000)),
+    EZ_MEMBER_PROPERTY("MaxHops", m_uiMaxHops)->AddAttributes(new ezDefaultValueAttribute(16)),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("AI/Navigation"),
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_COMPONENT_TYPE
+// clang-format on
+
+ezAiVoxelPathTestComponent::ezAiVoxelPathTestComponent() = default;
+ezAiVoxelPathTestComponent::~ezAiVoxelPathTestComponent() = default;
+
+void ezAiVoxelPathTestComponent::SetPathEndReference(const char* szReference)
+{
+  auto resolver = GetWorld()->GetGameObjectReferenceResolver();
+
+  if (!resolver.IsValid())
+    return;
+
+  SetPathEnd(resolver(szReference, GetHandle(), "PathEnd"));
+}
+
+void ezAiVoxelPathTestComponent::SetPathEnd(ezGameObjectHandle hObject)
+{
+  m_hPathEnd = hObject;
+}
+
+void ezAiVoxelPathTestComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+  ezStreamWriter& s = inout_stream.GetStream();
+
+  inout_stream.WriteGameObjectHandle(m_hPathEnd);
+  s << m_bVisualizeSmoothedPath;
+  s << m_bVisualizePathState;
+  s << m_fSearchMargin;
+  s << m_uiMaxIterationsPerHop;
+  s << m_uiMaxHops;
+}
+
+void ezAiVoxelPathTestComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  ezStreamReader& s = inout_stream.GetStream();
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+
+  m_hPathEnd = inout_stream.ReadGameObjectHandle();
+  s >> m_bVisualizeSmoothedPath;
+  s >> m_bVisualizePathState;
+  s >> m_fSearchMargin;
+  s >> m_uiMaxIterationsPerHop;
+  s >> m_uiMaxHops;
+}
+
+void ezAiVoxelPathTestComponent::Update()
+{
+  if (m_hPathEnd.IsInvalidated())
+    return;
+
+  ezGameObject* pEnd = nullptr;
+  if (!GetWorld()->TryGetObject(m_hPathEnd, pEnd))
+    return;
+
+  auto* pVoxelModule = GetWorld()->GetOrCreateModule<ezAiVoxelWorldModule>();
+  if (pVoxelModule == nullptr || !pVoxelModule->IsReady())
+    return;
+
+  const ezVec3 vStart = GetOwner()->GetGlobalPosition();
+  const ezVec3 vTarget = pEnd->GetGlobalPosition();
+
+  const ezAiVoxelGridFinder gridFinder = [pVoxelModule](const ezBoundingBox& searchBox, ezDynamicArray<const ezVoxelGrid*>& out_grids)
+  {
+    ezHybridArray<ezAiVoxelGridComponent*, 4> gridComponents;
+    pVoxelModule->FindGridsInBox(searchBox, gridComponents);
+
+    out_grids.Clear();
+    for (const ezAiVoxelGridComponent* pGridComponent : gridComponents)
+      out_grids.PushBack(&pGridComponent->GetStaticVoxelGrid());
+  };
+
+  const auto state = m_Navigation.FindPath(vStart, vTarget, gridFinder, m_fSearchMargin, m_uiMaxIterationsPerHop, m_uiMaxHops);
+
+  if (m_bVisualizeSmoothedPath)
+  {
+    m_Navigation.DebugDrawPathSegments(GetWorld(), ezColor::DeepSkyBlue, ezColor::Yellow);
+  }
+
+  if (m_bVisualizePathState)
+  {
+    const ezVec3 vTextPos = GetOwner()->GetGlobalPosition() + ezVec3(0, 0, 0.5f);
+
+    switch (state)
+    {
+      case ezAiVoxelNavigation::State::Idle:
+        ezDebugRenderer::Draw3DText(GetWorld(), "Idle", vTextPos, ezColor::Grey);
+        break;
+      case ezAiVoxelNavigation::State::PathFound:
+        ezDebugRenderer::Draw3DText(GetWorld(), "Path Found", vTextPos, ezColor::LawnGreen);
+        break;
+      case ezAiVoxelNavigation::State::NoPathFound:
+        ezDebugRenderer::Draw3DText(GetWorld(), "No Path Found", vTextPos, ezColor::IndianRed);
+        break;
+      case ezAiVoxelNavigation::State::InvalidStartPosition:
+        ezDebugRenderer::Draw3DText(GetWorld(), "Invalid Start Position", vTextPos, ezColor::IndianRed);
+        break;
+      case ezAiVoxelNavigation::State::InvalidTargetPosition:
+        ezDebugRenderer::Draw3DText(GetWorld(), "Invalid Target Position", vTextPos, ezColor::IndianRed);
+        break;
+    }
+  }
+}
+
+EZ_STATICLINK_FILE(AiPlugin, AiPlugin_Navigation3D_Implementation_VoxelPathTestComponent);

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelWorldModule.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/Implementation/VoxelWorldModule.cpp
@@ -1,0 +1,99 @@
+#include <AiPlugin/AiPluginPCH.h>
+
+#include <AiPlugin/Navigation3D/VoxelGridComponent.h>
+#include <AiPlugin/Navigation3D/VoxelWorldModule.h>
+#include <Core/Interfaces/NavmeshGeoWorldModule.h>
+#include <Core/Interfaces/PhysicsWorldModule.h>
+#include <Core/World/SpatialSystem.h>
+#include <Core/World/World.h>
+#include <Foundation/Configuration/CVar.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+
+ezCVarBool cvar_VoxelGridVisualize("AI.VoxelGrid.Visualize", false, ezCVarFlags::None, "Visualize the voxel grid. Use AI.VoxelGrid.Visualize=true in the console to enable.");
+
+// clang-format off
+EZ_IMPLEMENT_WORLD_MODULE(ezAiVoxelWorldModule);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAiVoxelWorldModule, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezAiVoxelWorldModule::ezAiVoxelWorldModule(ezWorld* pWorld)
+  : ezWorldModule(pWorld)
+{
+}
+
+ezAiVoxelWorldModule::~ezAiVoxelWorldModule() = default;
+
+void ezAiVoxelWorldModule::Initialize()
+{
+  SUPER::Initialize();
+
+  {
+    auto updateDesc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezAiVoxelWorldModule::Update, this);
+    updateDesc.m_Phase = ezWorldUpdatePhase::PostTransform;
+    updateDesc.m_bOnlyUpdateWhenSimulating = true;
+
+    RegisterUpdateFunction(updateDesc);
+  }
+}
+
+void ezAiVoxelWorldModule::Update(const UpdateContext& ctxt)
+{
+  if (m_uiUpdateDelay > 0)
+  {
+    --m_uiUpdateDelay;
+    return;
+  }
+
+  auto* pGridManager = GetWorld()->GetComponentManager<ezAiVoxelGridComponentManager>();
+  if (pGridManager == nullptr)
+    return;
+
+  for (auto it = pGridManager->GetComponents(); it.IsValid(); it.Next())
+  {
+    it->VoxelizeWorld();
+  }
+
+  m_bIsReady = true;
+
+  for (auto it = pGridManager->GetComponents(); it.IsValid(); it.Next())
+  {
+    if (it->m_bVisualize || cvar_VoxelGridVisualize)
+    {
+      const ezVoxelGrid& grid = it->GetStaticVoxelGrid();
+      grid.DebugDraw(GetWorld(), ezColor::LimeGreen.WithAlpha(0.1f));
+
+      const ezVec3U32 dim = grid.GetDimensions();
+      const ezUInt64 uiMemUsage = grid.GetHeapMemoryUsage();
+
+      ezDebugRenderer::Draw3DText(GetWorld(), ezFmt("Voxel Grid\nCells: {} x {} x {}\nMemory: {}", dim.x, dim.y, dim.z, ezArgFileSize(uiMemUsage)), grid.GetCenter(), ezColor::White);
+    }
+  }
+}
+
+void ezAiVoxelWorldModule::FindGridsInBox(const ezBoundingBox& box, ezDynamicArray<ezAiVoxelGridComponent*>& out_grids) const
+{
+  out_grids.Clear();
+
+  const ezSpatialSystem* pSpatialSystem = GetWorld()->GetSpatialSystem();
+  if (pSpatialSystem == nullptr)
+    return;
+
+  ezSpatialSystem::QueryParams queryParams;
+  queryParams.m_uiCategoryBitmask = ezAiVoxelGridComponent::SpatialDataCategory.GetBitmask();
+
+  ezDynamicArray<ezGameObject*> objects;
+  pSpatialSystem->FindObjectsInBox(box, queryParams, objects);
+
+  for (ezGameObject* pObject : objects)
+  {
+    ezAiVoxelGridComponent* pGridComponent = nullptr;
+    if (pObject->TryGetComponentOfBaseType(pGridComponent))
+    {
+      out_grids.PushBack(pGridComponent);
+    }
+  }
+}
+
+
+EZ_STATICLINK_FILE(AiPlugin, AiPlugin_Navigation3D_Implementation_VoxelWorldModule);

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelGrid.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelGrid.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Math/BoundingBox.h>
+#include <Foundation/Math/BoundingSphere.h>
+#include <Foundation/Math/Vec3.h>
+
+class ezDebugRendererContext;
+
+/// Stores a 3D voxel grid using packed 4x4x4 bit blocks.
+///
+/// Each block is stored as a single ezUInt64 (64 bits = 4*4*4 voxels).
+/// A set bit means the voxel is occupied (solid). A cleared bit means the voxel is free (passable).
+///
+/// The grid has a fixed resolution and is centered at a configurable world position.
+/// Use WorldToCoord / CoordToWorld to convert between world space and voxel coordinates.
+/// Use InjectBox / InjectSphere to mark voxels as occupied based on world-space shapes.
+class EZ_AIPLUGIN_DLL ezVoxelGrid
+{
+public:
+  ezVoxelGrid();
+  ~ezVoxelGrid();
+
+  /// Initializes the grid with the given resolution (in voxels).
+  ///
+  /// Each dimension is rounded up to a multiple of 4 internally.
+  /// The grid is cleared to all-free after init.
+  void Initialize(const ezVec3U32& vDimensions, const ezVec3& vCenter, float fVoxelSize);
+
+  /// Clears all voxel data (sets everything to free). Keeps allocated memory.
+  void ClearData();
+
+  /// Converts a world-space position to integer voxel coordinates.
+  EZ_FORCE_INLINE ezVec3I32 WorldToCoord(const ezVec3& vWorldPos) const
+  {
+    const ezVec3 vLocal = (vWorldPos - m_vOrigin) * m_fInvVoxelSize;
+    return {ezMath::FloorToInt(vLocal.x), ezMath::FloorToInt(vLocal.y), ezMath::FloorToInt(vLocal.z)};
+  }
+
+  /// Converts integer voxel coordinates to the world-space center of that voxel.
+  EZ_FORCE_INLINE ezVec3 CoordToWorld(const ezVec3I32& vCoord) const
+  {
+    return m_vOrigin + ezVec3((vCoord.x + 0.5f) * m_fVoxelSize, (vCoord.y + 0.5f) * m_fVoxelSize, (vCoord.z + 0.5f) * m_fVoxelSize);
+  }
+
+  /// Returns true if the coordinate is inside the grid bounds.
+  EZ_FORCE_INLINE bool IsCoordValid(const ezVec3I32& vCoord) const
+  {
+    return vCoord.x >= 0 && vCoord.y >= 0 && vCoord.z >= 0 &&
+           (ezUInt32)vCoord.x < m_vDimensions.x &&
+           (ezUInt32)vCoord.y < m_vDimensions.y &&
+           (ezUInt32)vCoord.z < m_vDimensions.z;
+  }
+
+  /// Sets a voxel to occupied (true) or free (false).
+  void SetVoxel(const ezVec3I32& vCoord, bool bSolid);
+
+  /// Returns whether the voxel at the given coordinate is occupied.
+  bool IsVoxelSet(const ezVec3I32& vCoord) const;
+
+  /// Rasterizes a world-space triangle into the grid, setting (or clearing) every voxel it overlaps.
+  ///
+  /// Cost scales with the triangle's voxel-space bounding box, so rasterizing geometry that is large
+  /// relative to the voxel size is expensive. Parts of the triangle outside the grid are ignored.
+  void SetVoxelsOnTriangle(const ezVec3& v0, const ezVec3& v1, const ezVec3& v2, bool bSet = true);
+
+  /// Ray-march visibility test between two grid-space coordinates.
+  ///
+  /// Returns true if no occupied voxel blocks the line of sight.
+  bool CheckLineOfSight(const ezVec3I32& vStart, const ezVec3I32& vGoal) const;
+
+  /// Returns the world-space AABB of the entire grid.
+  ezBoundingBox GetAABB() const;
+
+  /// Returns the approximate memory usage in bytes.
+  ezUInt64 GetHeapMemoryUsage() const;
+
+  /// Draws a debug visualization of occupied surface voxels.
+  void DebugDraw(const ezDebugRendererContext& context, const ezColor& color) const;
+
+  ezVec3U32 GetDimensions() const { return m_vDimensions; }
+  float GetVoxelSize() const { return m_fVoxelSize; }
+  const ezVec3& GetOrigin() const { return m_vOrigin; }
+  const ezVec3& GetCenter() const { return m_vCenter; }
+
+private:
+  EZ_FORCE_INLINE ezUInt32 GetBlockIndex(ezUInt32 uiBlockX, ezUInt32 uiBlockY, ezUInt32 uiBlockZ) const
+  {
+    return uiBlockZ * (m_vNumBlocks.x * m_vNumBlocks.y) + uiBlockY * m_vNumBlocks.x + uiBlockX;
+  }
+
+  EZ_FORCE_INLINE static ezUInt32 GetBitIndex(ezUInt32 uiLocalX, ezUInt32 uiLocalY, ezUInt32 uiLocalZ)
+  {
+    return uiLocalZ * 16u + uiLocalY * 4u + uiLocalX;
+  }
+
+  ezVec3U32 m_vDimensions;
+  ezVec3U32 m_vNumBlocks;
+
+  float m_fVoxelSize = 1.0f;
+  float m_fInvVoxelSize = 1.0f;
+  ezVec3 m_vCenter = ezVec3::MakeZero();
+  ezVec3 m_vOrigin = ezVec3::MakeZero();
+
+  ezDynamicArray<ezUInt64> m_Blocks;
+};

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelGridComponent.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelGridComponent.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <AiPlugin/Navigation3D/VoxelGrid.h>
+#include <Core/Messages/UpdateLocalBoundsMessage.h>
+#include <Core/World/ComponentManager.h>
+#include <Core/World/SpatialData.h>
+
+using ezAiVoxelGridComponentManager = ezComponentManager<class ezAiVoxelGridComponent, ezBlockStorageType::Compact>;
+
+/// Drop this component into a scene to add a 3D voxel navigation grid.
+///
+/// The grid is centered on this component's game object position.
+class EZ_AIPLUGIN_DLL ezAiVoxelGridComponent : public ezComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezAiVoxelGridComponent, ezComponent, ezAiVoxelGridComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+protected:
+  virtual void OnActivated() override;
+  virtual void OnDeactivated() override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezAiVoxelGridComponent
+
+public:
+  ezAiVoxelGridComponent();
+  ~ezAiVoxelGridComponent();
+
+  const ezVec3& GetSize() const { return m_vSize; }
+  void SetSize(const ezVec3& vSize);
+
+  float GetVoxelSize() const { return m_fVoxelSize; }               // [ property ]
+  void SetVoxelSize(float fValue);                                  // [ property ]
+
+  ezUInt32 GetCollisionLayer() const { return m_uiCollisionLayer; } // [ property ]
+  void SetCollisionLayer(ezUInt32 uiValue);                         // [ property ]
+
+  /// If true, or if the AI.VoxelGrid.Visualize CVar is set, the grid is drawn using the debug renderer.
+  bool m_bVisualize = false; // [ property ]
+
+  void VoxelizeWorld();
+
+  const ezVoxelGrid& GetStaticVoxelGrid() const { return m_StaticGrid; }
+
+  /// Spatial data category used to register grid components with the world's spatial system.
+  ///
+  /// Used by ezAiVoxelWorldModule::FindGridsInBox() to efficiently query grid components in an area.
+  static ezSpatialData::Category SpatialDataCategory;
+
+protected:
+  void OnMsgUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const; // [ msg handler ]
+
+private:
+  ezVec3 m_vSize = ezVec3(32.0f);
+  float m_fVoxelSize = 0.5f;
+  ezUInt32 m_uiCollisionLayer = 0;
+
+  ezVoxelGrid m_StaticGrid;
+
+  bool m_bNeedsVoxelization = true;
+};

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelNavigation.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelNavigation.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Math/BoundingBox.h>
+#include <Foundation/Math/Vec3.h>
+#include <Foundation/Types/Delegate.h>
+
+class ezVoxelGrid;
+class ezDebugRendererContext;
+
+/// Called by ezAiVoxelNavigation to find all voxel grids overlapping a search box.
+using ezAiVoxelGridFinder = ezDelegate<void(const ezBoundingBox& searchBox, ezDynamicArray<const ezVoxelGrid*>& out_grids)>;
+
+/// A* pathfinding through one or more ezVoxelGrid instances.
+///
+/// Uses 6-connected (face) neighbors only - no diagonal moves. Diagonal movement would let a path
+/// cut across a corner between two solid voxels that only touch edge-to-edge or corner-to-corner,
+/// squeezing through a gap that isn't actually open.
+/// After finding a raw voxel path, applies line-of-sight string-pulling
+/// to remove unnecessary waypoints.
+///
+/// A single search may span multiple, disjoint voxel grids: pathfinding is always
+/// performed within one grid at a time. If the target lies outside the grid that is
+/// currently being searched, the search only looks for a way out of that grid (any
+/// reachable voxel on its boundary), then continues from there in the next grid found
+/// on the way to the target. Space that is not covered by any grid is assumed to be free
+/// (no obstacles).
+class EZ_AIPLUGIN_DLL ezAiVoxelNavigation
+{
+public:
+  ezAiVoxelNavigation();
+  ~ezAiVoxelNavigation();
+
+  enum class State
+  {
+    Idle,
+    PathFound,
+    NoPathFound,
+    InvalidStartPosition,
+    InvalidTargetPosition,
+  };
+
+  /// Computes a path from vStart to vTarget, potentially through multiple voxel grids.
+  ///
+  /// gridFinder is called (potentially multiple times) to find the voxel grids relevant for the
+  /// next hop of the search, given a search box around the current position and vTarget.
+  /// fSearchMargin is added around that box.
+  /// uiMaxIterationsPerHop limits the A* node expansion within a single grid, to prevent frame stalls.
+  /// uiMaxHops limits how many grids the path may pass through, as a safety net against infinite loops.
+  State FindPath(const ezVec3& vStart, const ezVec3& vTarget, const ezAiVoxelGridFinder& gridFinder,
+    float fSearchMargin = 5.0f, ezUInt32 uiMaxIterationsPerHop = 10000, ezUInt32 uiMaxHops = 16);
+
+  /// Sets a trivial, single-segment path straight from vStart to vTarget, bypassing pathfinding and
+  /// occlusion checks entirely. Useful for emergency recovery (e.g. moving out of a voxel that
+  /// turned solid) or any other case where a straight line is known to be fine.
+  void SetDirectPath(const ezVec3& vStart, const ezVec3& vTarget);
+
+  const ezDynamicArray<ezVec3>& GetWaypoints() const { return m_Waypoints; }
+
+  /// One entry per segment of GetWaypoints() (GetWaypoints().GetCount() - 1 entries). True if the
+  /// segment [i, i + 1] runs through a voxel grid, false if it is a straight line through free space.
+  const ezDynamicArray<bool>& GetSegmentInsideGrid() const { return m_SegmentInsideGrid; }
+
+  ezUInt32 GetCurrentWaypointIndex() const { return m_uiCurrentWaypoint; }
+
+  /// Advances to the next waypoint. Returns true if there are more waypoints.
+  bool AdvanceWaypoint();
+
+  /// Returns the next waypoint to move towards.
+  ezVec3 GetNextWaypoint() const;
+
+  /// Returns true if the end of the path has been reached.
+  bool IsPathComplete() const;
+
+  /// Walks the remaining path polyline starting from vCurrentPos (which does not need to lie
+  /// exactly on the path), accumulating distance up to fLookAheadDistance. Returns the point at
+  /// that distance along the path, or the final waypoint if the remaining path is shorter.
+  /// Returns vCurrentPos itself if the path is already complete.
+  ///
+  /// Pure query - does not affect GetCurrentWaypointIndex(). See AdvanceAlongPath() for the
+  /// mutating equivalent.
+  ezVec3 GetLookAheadPoint(const ezVec3& vCurrentPos, float fLookAheadDistance) const;
+
+  /// Advances a position by fDistance along the remaining path polyline, starting from vCurrentPos
+  /// (which does not need to lie exactly on the path). Unlike GetLookAheadPoint(), this consumes
+  /// (advances past) any waypoints crossed along the way, i.e. GetCurrentWaypointIndex() moves
+  /// forward as a side effect. Returns the resulting point, clamped at the final waypoint once the
+  /// path end is reached, or vCurrentPos itself if the path is already complete.
+  ezVec3 AdvanceAlongPath(const ezVec3& vCurrentPos, float fDistance);
+
+  void CancelNavigation();
+
+  State GetState() const { return m_State; }
+
+  /// Draws the path as a line strip.
+  void DebugDrawPath(const ezDebugRendererContext& context, const ezColor& color) const;
+
+  /// Draws the path, coloring each segment by whether it runs inside a voxel grid or crosses free
+  /// space in a straight line.
+  void DebugDrawPathSegments(const ezDebugRendererContext& context, const ezColor& insideGridColor,
+    const ezColor& freeSpaceColor) const;
+
+private:
+  /// Searches for a path from vStart to vTarget, with both positions required to be inside grid.
+  ///
+  /// out_waypoints receives the A* path after string-pulling smoothing.
+  State FindPathToTarget(const ezVoxelGrid& grid, const ezVec3& vStart, const ezVec3& vTarget, ezUInt32 uiMaxIterations,
+    ezDynamicArray<ezVec3>& out_waypoints) const;
+
+  /// Searches for a path from vStart to any voxel on the boundary of grid, biased towards vRealTarget.
+  ///
+  /// vRealTarget may lie outside grid; it is only used to bias the search heuristic.
+  /// otherGrids are checked to reject exit voxels that fall inside a solid voxel of another, overlapping
+  /// grid (grids are not supposed to overlap, but this guards against it regardless).
+  /// out_waypoints receives the A* path after string-pulling smoothing.
+  State FindPathToExit(const ezVoxelGrid& grid, const ezVec3& vStart, const ezVec3& vRealTarget,
+    ezArrayPtr<const ezVoxelGrid* const> otherGrids, ezUInt32 uiMaxIterations, ezDynamicArray<ezVec3>& out_waypoints) const;
+
+  void SmoothPath(const ezVoxelGrid& grid, ezDynamicArray<ezVec3>& inout_waypoints) const;
+
+  /// Shared arc-length walk used by GetLookAheadPoint() (peek, local index copy) and
+  /// AdvanceAlongPath() (mutates m_uiCurrentWaypoint via inout_uiIndex). Walks forward from
+  /// vCurrentPos along the path polyline starting at m_Waypoints[inout_uiIndex], accumulating
+  /// distance up to fDistance, advancing inout_uiIndex across any waypoints crossed along the way.
+  ezVec3 WalkPathForward(const ezVec3& vCurrentPos, float fDistance, ezUInt32& inout_uiIndex) const;
+
+  /// Searches all coordinates within uiMaxRadius voxels of vCoord for the closest valid, non-solid
+  /// coordinate. Used to recover a search that would otherwise fail immediately because its exact
+  /// start voxel is solid or out of bounds (e.g. a moving object ending up inside a voxel that
+  /// turned solid after it last pathed, or momentum having carried it slightly past one).
+  static bool FindNearbyValidCoord(const ezVoxelGrid& grid, const ezVec3I32& vCoord, ezUInt32 uiMaxRadius, ezVec3I32& out_vValidCoord);
+
+  State m_State = State::Idle;
+  ezDynamicArray<ezVec3> m_Waypoints;
+  ezDynamicArray<bool> m_SegmentInsideGrid;
+  ezUInt32 m_uiCurrentWaypoint = 0;
+};

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelNavigationComponent.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelNavigationComponent.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <AiPlugin/Navigation3D/VoxelNavigation.h>
+#include <Core/World/Component.h>
+#include <Core/World/World.h>
+#include <Foundation/Math/Angle.h>
+
+EZ_DECLARE_FLAGS(ezUInt32, ezAiVoxelNavigationDebugFlags, PrintState, VisPath);
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_AIPLUGIN_DLL, ezAiVoxelNavigationDebugFlags);
+
+/// Describes the different states a voxel-navigating object may be in.
+struct ezAiVoxelNavigationComponentState
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    Idle,   ///< Currently not navigating.
+    Moving, ///< Moving along a computed 3D path.
+    Failed, ///< Path could not be found.
+
+    Default = Idle
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_AIPLUGIN_DLL, ezAiVoxelNavigationComponentState);
+
+using ezAiVoxelNavigationComponentManager = ezComponentManagerSimple<class ezAiVoxelNavigationComponent, ezComponentUpdateType::WhenSimulating>;
+
+/// Navigates a game object through 3D space using a voxel grid.
+///
+/// Suitable for flying creatures, underwater movement, or space navigation.
+/// Call SetDestination() with a world-space target. The component computes
+/// a 3D A* path through free voxels and steers the game object along that path.
+///
+/// Tracks two separate positions. The path position is the ground truth: it always lies exactly
+/// on the computed path (which is guaranteed clear - A*'d and string-pulled through free voxels)
+/// and advances along it by arc length every frame; it is only ever voxel-validated once, when a
+/// path is computed (SetDestination()/SetDestinationDirect()), never at runtime while moving.
+/// The steering position is the visual position actually applied to the game object: it free-form
+/// steers nose-first towards a look-ahead point on the path (LookAheadDistance) rather than
+/// snapping onto waypoints or the path position, and is explicitly not voxel-validated - it may
+/// lag or stray from the path, but is pulled back smoothly (CorridorCorrectionRate) once it
+/// strays further than MaxPathOffset (a "path corridor").
+///
+/// Because the ground truth can never leave the cleared path, following it can never get stuck:
+/// the Failed state is only reachable from SetDestination()/SetDestinationDirect() failing to find
+/// a path at all (unreachable target), never from runtime movement.
+///
+/// Turning is rate-limited (MaxAngularSpeed) and speed is reduced while turning sharply and while
+/// approaching the end of the path (Speed/Acceleration/Deceleration).
+///
+/// The object generally stays upright (local +Z towards world +Z); while turning it banks/tilts
+/// into the curve (BankAmount, clamped by MaxBankAngle), relaxing back to level once it stops
+/// turning.
+class EZ_AIPLUGIN_DLL ezAiVoxelNavigationComponent : public ezComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezAiVoxelNavigationComponent, ezComponent, ezAiVoxelNavigationComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+protected:
+  virtual void OnSimulationStarted() override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezAiVoxelNavigationComponent
+
+public:
+  ezAiVoxelNavigationComponent();
+  ~ezAiVoxelNavigationComponent();
+
+  /// Sets the target position to navigate towards.
+  void SetDestination(const ezVec3& vGlobalPos); ///< [ scriptable ]
+
+  /// Sets the target position to fly straight towards, bypassing pathfinding and occlusion checks
+  /// entirely - it just turns and moves in a straight line, using the same speed/acceleration/
+  /// turning behavior as regular path-following.
+  ///
+  /// Useful for emergency recovery (e.g. the object ended up inside an occupied voxel and regular
+  /// SetDestination() fails with InvalidStartPosition) or any other case where flying straight to a
+  /// known-clear point is preferable to pathfinding. Combine with GetValidCellNearby() to first find
+  /// a safe point to recover to.
+  void SetDestinationDirect(const ezVec3& vGlobalPos); ///< [ scriptable ]
+
+  /// Stops all navigation.
+  void CancelNavigation(); ///< [ scriptable ]
+
+  /// Returns the current navigation state.
+  ezEnum<ezAiVoxelNavigationComponentState> GetState() const { return m_State; } ///< [ scriptable ]
+
+  void SetNavigationTargetReference(const char* szReference);                    // [ property ]
+  void SetNavigationTarget(ezGameObjectHandle hObject);                          ///< [ scriptable ]
+
+  float m_fSpeed = 5.0f;                                                         ///< [ property ] Target movement speed.
+  float m_fAcceleration = 3.0f;                                                  ///< [ property ] How fast to gain speed.
+  float m_fDeceleration = 8.0f;                                                  ///< [ property ] How fast to brake.
+  float m_fReachedDistance = 1.0f;                                               ///< [ property ] Distance at which destination is considered reached.
+  bool m_bApplySteering = true;                                                  ///< [ property ] Whether to apply movement to the game object.
+  float m_fLookAheadDistance = 3.0f;                                             ///< [ property ] How far ahead along the path to steer towards, instead of snapping onto waypoints.
+  float m_fMaxPathOffset = 3.0f;                                                 ///< [ property ] Max distance the visual position may stray from the path before being pulled back.
+  float m_fCorridorCorrectionRate = 8.0f;                                        ///< [ property ] How fast the visual position is pulled back into the corridor once it exceeds MaxPathOffset.
+  ezAngle m_MaxAngularSpeed = ezAngle::MakeFromDegree(180.0f);                   ///< [ property ] Maximum turning speed, used both while path-following and by TurnTowards().
+  float m_fBankAmount = 3.0f;                                                    ///< [ property ] How strongly to bank/tilt into turns while path-following. 0 disables banking; negative flips the bank direction.
+  ezAngle m_MaxBankAngle = ezAngle::MakeFromDegree(30.0f);                       ///< [ property ] Maximum bank/tilt angle while turning.
+
+  ezBitflags<ezAiVoxelNavigationDebugFlags> m_DebugFlags;                        ///< [ property ]
+
+  /// Rotates the object to face vDirection, turning at most by MaxAngularSpeed this frame.
+  ///
+  /// Independent of any active path-following (typically used while Idle, e.g. to face a
+  /// direction before deciding to call SetDestination()). If a path is currently being followed,
+  /// this has no lasting effect: the path-following steering runs later in the same frame and
+  /// will overwrite the rotation again next update.
+  ///
+  /// Returns the remaining angle to face vDirection exactly (zero once fully turned), so script
+  /// logic can decide e.g. whether it is facing closely enough to start moving now.
+  ezAngle TurnTowards(const ezVec3& vDirection); ///< [ scriptable ]
+
+  /// Peek-only companion to TurnTowards(): how much the object would have to turn to face
+  /// vDirection, without changing anything.
+  ezAngle GetTurnAngleTowards(const ezVec3& vDirection) const; ///< [ scriptable ]
+
+  /// Returns true if the component is currently navigating along a path.
+  bool IsNavigating() const { return m_State == ezAiVoxelNavigationComponentState::Moving; } ///< [ scriptable ]
+
+  /// Returns true if the component is navigating and the remaining path distance has entered the
+  /// braking distance for Speed (i.e. it would start slowing down this frame if not redirected).
+  ///
+  /// Useful for objects that should keep moving continuously (never actually decelerate to a
+  /// stop): call SetDestination()/SetNavigationTarget() with a new target once this turns true,
+  /// instead of waiting for IsNavigating() to become false.
+  bool IsApproachingDestination() const; ///< [ scriptable ]
+
+  /// Attempts to find a random navigable point within a sphere around vCenter.
+  ///
+  /// A sampled point counts as navigable if it is a free voxel in its covering grid, or lies
+  /// outside all grids entirely (space not covered by any grid is treated as free, same convention
+  /// as pathfinding). Returns false if the voxel grid is not ready or no navigable point was found
+  /// after uiMaxAttempts random samples.
+  bool FindRandomPointAroundSphere(const ezVec3& vCenter, float fRadius, ezUInt32 uiMaxAttempts, ezVec3& out_vPoint); ///< [ scriptable ]
+
+  /// Finds a navigable (free) point at or near vStart, preferring points that are physically closer
+  /// to vStart. If vStart itself is already free (or not covered by any voxel grid at all), returns
+  /// it unchanged. Otherwise searches for the closest free voxel within fSearchRadius.
+  ///
+  /// Intended for recovering from an occupied start position - e.g. combine with
+  /// SetDestinationDirect() to move out of a voxel that turned solid - but can also be used to
+  /// nudge an arbitrary destination onto a valid cell before calling SetDestination().
+  ///
+  /// Returns false if the voxel grid is not ready, or no free voxel was found within fSearchRadius.
+  bool GetValidCellNearby(const ezVec3& vStart, float fSearchRadius, ezVec3& out_vPoint) const; ///< [ scriptable ]
+
+protected:
+  void Update();
+  void MoveAlongPath(float fTimeDiff);
+  void DecelerateToStop(float fTimeDiff);
+
+  /// Turns m_qSteerRotation towards vDesiredDir (see ezAiSteeringUtils::TurnTowards - this also
+  /// re-levels any existing roll), then banks/tilts it into the turn by up to MaxBankAngle,
+  /// smoothed via m_BankAngle so it relaxes back to level once the turn ends.
+  void SteerAndBank(const ezVec3& vDesiredDir, float fTimeDiff);
+
+  /// Distance needed to brake from fSpeed down to zero at m_fDeceleration.
+  float ComputeBrakingDistance(float fSpeed) const;
+
+  /// Approximate remaining distance along the current path, or 0 if not navigating.
+  float GetRemainingDistance() const;
+
+  /// Pulls vCandidate back towards m_vPathPosition if it is further away than m_fMaxPathOffset,
+  /// smoothly (rate m_fCorridorCorrectionRate) rather than snapping - the "path corridor" that
+  /// keeps the free-form visual position from straying arbitrarily far from the path.
+  ezVec3 ApplyCorridorClamp(const ezVec3& vCandidate, float fTimeDiff) const;
+
+  ezAiVoxelNavigation m_Navigation;
+  ezEnum<ezAiVoxelNavigationComponentState> m_State;
+  ezGameObjectHandle m_hNavigationTarget;
+
+  ezVec3 m_vVelocity = ezVec3::MakeZero();
+  ezVec3 m_vSteerPosition = ezVec3::MakeZero();
+  ezQuat m_qSteerRotation = ezQuat::MakeIdentity();
+
+  ezVec3 m_vPathPosition = ezVec3::MakeZero(); ///< Ground truth: always on the path, always in a free voxel.
+  float m_fPathSpeed = 0.0f;                   ///< Accel/decel-smoothed scalar speed for m_vPathPosition.
+  bool m_bPathPositionInitialized = false;     ///< Not serialized; re-snapped to a valid voxel on first navigation each sim run.
+
+  float m_fVoxelSize = 0.5f;                   ///< Cached voxel size of the grid being navigated; refreshed on each SetDestination(). Not serialized. The initial value is only a fallback used before the first successful path.
+
+  /// Warm-up counter: Update() early-returns while this is > 0 (set in OnSimulationStarted()). Delays
+  /// the first few updates after simulation start so the object's initial transform has settled
+  /// (spawn/prefab instantiation, physics placement) and the voxel grid has become ready before the
+  /// component starts driving the transform and pathfinding.
+  ezUInt8 m_uiSkipNextFrames = 0;
+
+  ezVec3 m_vLastPathTargetPos = ezVec3::MakeZero();
+  float m_fRepathCooldown = 0.0f;
+
+  ezAngle m_BankAngle = ezAngle::MakeFromRadian(0.0f);
+
+private:
+  const char* DummyGetter() const { return nullptr; }
+};

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelPathTestComponent.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelPathTestComponent.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <AiPlugin/Navigation3D/VoxelNavigation.h>
+#include <Core/World/Component.h>
+#include <Core/World/World.h>
+
+using ezAiVoxelPathTestComponentManager = ezComponentManagerSimple<class ezAiVoxelPathTestComponent, ezComponentUpdateType::WhenSimulating>;
+
+/// Used to test path-finding through voxel grids.
+///
+/// The component takes a reference to another game object as the destination and recomputes a path
+/// towards it every frame using ezAiVoxelNavigation. The path can be visualized, coloring segments
+/// that go through a voxel grid differently from straight-line segments that cross free space not
+/// covered by any grid.
+///
+/// Repathing every frame is intentionally wasteful - this is a debugging aid, not something to run
+/// in a shipping scene.
+///
+/// This component should be used in the editor, to test whether the scene's voxel grids produce the
+/// desired paths.
+class EZ_AIPLUGIN_DLL ezAiVoxelPathTestComponent : public ezComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezAiVoxelPathTestComponent, ezComponent, ezAiVoxelPathTestComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+  //////////////////////////////////////////////////////////////////////////
+  //  ezAiVoxelPathTestComponent
+
+public:
+  ezAiVoxelPathTestComponent();
+  ~ezAiVoxelPathTestComponent();
+
+  void SetPathEndReference(const char* szReference); // [ property ]
+  void SetPathEnd(ezGameObjectHandle hObject);
+
+  /// Render the smoothed path, i.e. the one actually used for navigation.
+  bool m_bVisualizeSmoothedPath = true; // [ property ]
+
+  /// Render text describing the path search result.
+  bool m_bVisualizePathState = true; // [ property ]
+
+  /// Passed through to ezAiVoxelNavigation::FindPath().
+  float m_fSearchMargin = 5.0f; // [ property ]
+
+  /// Passed through to ezAiVoxelNavigation::FindPath().
+  ezUInt32 m_uiMaxIterationsPerHop = 10000; // [ property ]
+
+  /// Passed through to ezAiVoxelNavigation::FindPath().
+  ezUInt32 m_uiMaxHops = 16; // [ property ]
+
+protected:
+  void Update();
+
+  ezGameObjectHandle m_hPathEnd;
+  ezAiVoxelNavigation m_Navigation;
+
+private:
+  const char* DummyGetter() const { return nullptr; }
+};

--- a/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelWorldModule.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation3D/VoxelWorldModule.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <AiPlugin/AiPluginDLL.h>
+#include <AiPlugin/Navigation3D/VoxelGrid.h>
+#include <Core/World/WorldModule.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Math/BoundingBox.h>
+
+class ezAiVoxelGridComponent;
+
+/// World module that manages the voxel grids used for 3D navigation.
+///
+/// Access it via GetWorld()->GetOrCreateModule<ezAiVoxelWorldModule>().
+class EZ_AIPLUGIN_DLL ezAiVoxelWorldModule final : public ezWorldModule
+{
+  EZ_DECLARE_WORLD_MODULE();
+  EZ_ADD_DYNAMIC_REFLECTION(ezAiVoxelWorldModule, ezWorldModule);
+
+public:
+  ezAiVoxelWorldModule(ezWorld* pWorld);
+  ~ezAiVoxelWorldModule();
+
+  virtual void Initialize() override;
+
+  /// Returns true once the grid has been voxelized and is ready for pathfinding.
+  bool IsReady() const { return m_bIsReady; }
+
+  /// Finds all ezAiVoxelGridComponent instances whose bounds overlap the given AABB.
+  void FindGridsInBox(const ezBoundingBox& box, ezDynamicArray<ezAiVoxelGridComponent*>& out_grids) const;
+
+private:
+  void Update(const UpdateContext& ctxt);
+
+  bool m_bIsReady = false;
+
+  /// Number of PostTransform updates to wait after simulation start before the first voxelization
+  /// (and thus before IsReady() returns true). Gives the collision geometry - physics bodies and
+  /// spawned/streamed objects - time to settle so the static grid rasterizes the final world state.
+  ezUInt32 m_uiUpdateDelay = 10;
+};

--- a/Data/Samples/Testing Chambers/AI/AiVoxel/AiShipBase.as
+++ b/Data/Samples/Testing Chambers/AI/AiVoxel/AiShipBase.as
@@ -1,0 +1,71 @@
+// Shared behavior for the voxel-navigation AI sample ships (Hunter and Prey).
+//
+// Holds the boilerplate common to both: taking damage / dying, recovering when pathfinding fails,
+// and picking a random wander destination. The predator/prey behavior itself lives in the derived
+// classes. Derived classes set m_vHomePos / m_fWanderRadius / m_fLife in their OnSimulationStarted().
+abstract class AiShipBase : ezAngelScriptClass
+{
+    bool ShowDebugInfo = false;
+
+    protected ezVec3 m_vHomePos = ezVec3(0);
+    protected float m_fWanderRadius = 150.0f;
+    protected float m_fLife = 10.0f;
+
+    // Last navigation destination set via SetNavDestination(), kept for debug visualization.
+    protected ezVec3 m_vDestination = ezVec3(0);
+    protected bool m_bHasDestination = false;
+
+    void OnMsgDamage(ezMsgDamage@ msg)
+    {
+        m_fLife -= msg.Damage;
+
+        if (m_fLife < 0.0f)
+        {
+            ezPrefabs::SpawnPrefab("{ c1165a59-f3ff-4abf-858c-9d358fb2359a }", GetOwner().GetGlobalTransform());
+            GetWorld().DeleteObjectDelayed(GetOwner().GetHandle());
+        }
+    }
+
+    /// If navigation ended up in the Failed state (SetDestination()/SetDestinationDirect() could
+    /// not find a path to the target at all, e.g. it's unreachable), tries to recover by flying
+    /// straight to the nearest valid cell nearby. Returns true if navigation was in the Failed
+    /// state this frame (whether or not recovery succeeded) - the caller should skip its normal
+    /// logic in that case and let recovery play out.
+    ///
+    /// Note: the navigation component's ground-truth path position can no longer end up stuck
+    /// inside a blocked voxel at runtime (it never leaves the computed, voxel-clear path), so this
+    /// is only reachable from genuine pathfinding failures now, not from "ran into an obstacle".
+    bool TryRecoverFromFailedState(ezAiVoxelNavigationComponent@ navComp, ezVec3 vOwnPos)
+    {
+        if (navComp.GetState() != ezAiVoxelNavigationComponentState::Failed)
+            return false;
+
+        ezVec3 vSafePoint;
+        if (navComp.GetValidCellNearby(vOwnPos, 5.0f, vSafePoint))
+        {
+            navComp.SetDestinationDirect(vSafePoint);
+        }
+
+        return true;
+    }
+
+    /// Sets the navigation destination and records it (m_vDestination / m_bHasDestination) so it
+    /// can be visualized.
+    void SetNavDestination(ezAiVoxelNavigationComponent@ navComp, ezVec3 vPoint)
+    {
+        navComp.SetDestination(vPoint);
+        m_vDestination = vPoint;
+        m_bHasDestination = true;
+    }
+
+    /// Picks a random navigable point within m_fWanderRadius of the home position and heads there.
+    void PickWanderDestination(ezAiVoxelNavigationComponent@ navComp)
+    {
+        ezVec3 vPoint;
+
+        if (navComp.FindRandomPointAroundSphere(m_vHomePos, m_fWanderRadius, 32, vPoint))
+        {
+            SetNavDestination(navComp, vPoint);
+        }
+    }
+}

--- a/Data/Samples/Testing Chambers/AI/AiVoxel/Hunter.as
+++ b/Data/Samples/Testing Chambers/AI/AiVoxel/Hunter.as
@@ -1,0 +1,242 @@
+#include "AiShipBase.as"
+
+enum HunterState
+{
+    Wandering, // no prey in range, exploring randomly
+    Pursuing,  // prey in sight, navigating towards it
+    Tracking,  // lost sight of prey, heading to its last known position
+    TooClose,  // prey is within catch distance, stop and just rotate towards it
+}
+
+class Hunter : AiShipBase
+{
+    ezString PreyMarker = "Prey";
+
+    private HunterState m_State = HunterState::Wandering;
+    private ezGameObjectHandle m_hTrackedPrey;
+    private ezVec3 m_vLastKnownPreyPos;
+    private bool m_bHasLastKnownPos = false;
+
+    private float m_fDetectionRange = 40.0f;
+    private float m_fCatchDistance = 5.0f;
+
+    void OnSimulationStarted()
+    {
+        GetOwner().MakeDynamic();
+        m_vHomePos = GetOwner().GetGlobalPosition();
+        m_fWanderRadius = 150.0f;
+        m_fLife = 10.0f;
+        SetUpdateInterval(ezTime::Milliseconds(60));
+    }
+
+    void Update(ezTime deltaTime)
+    {
+        ezAiVoxelNavigationComponent@ navComp;
+        if (!GetOwner().TryGetComponentOfBaseType(@navComp))
+            return;
+
+        ezVec3 vOwnPos    = GetOwner().GetGlobalPosition();
+        ezVec3 vStatusPos = vOwnPos + ezVec3(0, 0, 2.2f);
+
+        if (TryRecoverFromFailedState(navComp, vOwnPos))
+            return;
+
+        // Re-check the prey we're already committed to (if any) - as long as it stays in
+        // range, keep pursuing it exclusively, even if another prey gets closer meanwhile.
+        ezGameObject@ trackedObj;
+        if (!m_hTrackedPrey.IsInvalidated())
+        {
+            GetWorld().TryGetObject(m_hTrackedPrey, @trackedObj);
+        }
+
+        if (@trackedObj != null)
+        {
+            float fDist = vOwnPos.GetDistanceTo(trackedObj.GetGlobalPosition());
+
+            if (fDist > m_fDetectionRange)
+            {
+                // Too far away to keep direct pursuit - remember where it was and switch to tracking.
+                m_vLastKnownPreyPos = trackedObj.GetGlobalPosition();
+                m_bHasLastKnownPos  = true;
+                m_hTrackedPrey.Invalidate();
+                navComp.CancelNavigation();
+                @trackedObj = null;
+            }
+        }
+        else if (!m_hTrackedPrey.IsInvalidated())
+        {
+            // Object got deleted while we were tracking it - it's gone for good, no point
+            // in heading to its last known position.
+            m_hTrackedPrey.Invalidate();
+            m_bHasLastKnownPos = false;
+            m_State = HunterState::Wandering;
+            navComp.CancelNavigation();
+        }
+
+        if (@trackedObj != null)
+        {
+            m_vLastKnownPreyPos = trackedObj.GetGlobalPosition();
+            m_bHasLastKnownPos  = true;
+
+            float fDist = vOwnPos.GetDistanceTo(m_vLastKnownPreyPos);
+
+            if (fDist <= m_fCatchDistance)
+            {
+                // Close enough - stop moving and just rotate towards the prey.
+                m_State = HunterState::TooClose;
+                navComp.CancelNavigation();
+            }
+            else
+            {
+                m_State = HunterState::Pursuing;
+                // Let the component continuously track and re-path towards the prey object
+                navComp.SetNavigationTarget(trackedObj.GetHandle());
+            }
+
+            if (ShowDebugInfo)
+            {
+                ezDebug::DrawLine(vOwnPos, m_vLastKnownPreyPos, ezColor::OrangeRed, ezColor::Orange);
+            }
+        }
+        else if (m_bHasLastKnownPos)
+        {
+            bool bJustLostSight = (m_State != HunterState::Tracking);
+            m_State = HunterState::Tracking;
+
+            float fDist = vOwnPos.GetDistanceTo(m_vLastKnownPreyPos);
+            if (fDist <= m_fCatchDistance + 0.5f)
+            {
+                // Reached the last known spot, prey is truly gone - give up and wander off
+                m_bHasLastKnownPos = false;
+                m_State = HunterState::Wandering;
+                PickWanderDestination(navComp);
+            }
+            else if (bJustLostSight)
+            {
+                // Head to its last known position, just once - the component keeps moving
+                // there on its own, no continuous target-tracking involved.
+                navComp.SetDestination(m_vLastKnownPreyPos);
+            }
+            else if (!navComp.IsNavigating())
+            {
+                // Somehow ended up idle without reaching the last known position (e.g. the path
+                // finished short of the catch-distance threshold, or pathfinding failed and
+                // recovery placed us somewhere that doesn't retry on its own) - don't sit there
+                // forever, give up tracking and fall back to wandering instead.
+                m_bHasLastKnownPos = false;
+                m_State = HunterState::Wandering;
+                PickWanderDestination(navComp);
+            }
+
+            if (ShowDebugInfo)
+            {
+                ezDebug::DrawLine(vOwnPos, m_vLastKnownPreyPos, ezColor::Yellow, ezColor::OrangeRed);
+            }
+
+            // No longer directly pursuing anyone - look for a new, reachable prey to commit to.
+            TryAcquireNewPrey(navComp, vOwnPos);
+        }
+        else
+        {
+            m_State = HunterState::Wandering;
+
+            if (!TryAcquireNewPrey(navComp, vOwnPos) && (!navComp.IsNavigating() || navComp.IsApproachingDestination()))
+            {
+                PickWanderDestination(navComp);
+            }
+        }
+
+        if (m_State == HunterState::TooClose && m_bHasLastKnownPos)
+        {
+            RotateTowards(vOwnPos, m_vLastKnownPreyPos);
+        }
+
+        if (ShowDebugInfo)
+        {
+            DrawDebugState(vStatusPos, vOwnPos);
+        }
+
+        UpdateGun(vOwnPos);
+    }
+
+    /// Enables the "Gun" child object while we have a target and it is within 30 degrees
+    /// of our forward axis, disables it otherwise.
+    void UpdateGun(ezVec3 vOwnPos)
+    {
+        ezGameObject@ gunObj = GetOwner().FindChildByName("Gun");
+        if (@gunObj == null)
+            return;
+
+        bool bAimedAtTarget = false;
+
+        if (m_bHasLastKnownPos)
+        {
+            ezVec3 dirToTarget = m_vLastKnownPreyPos - vOwnPos;
+            dirToTarget.Normalize();
+
+            bAimedAtTarget = dirToTarget.Dot(GetOwner().GetGlobalDirForwards()) > ezMath::Cos(ezAngle::MakeFromDegree(30));
+        }
+
+        gunObj.SetActiveFlag(bAimedAtTarget);
+    }
+
+    /// Center of the prey-detection sphere. Pushed half the detection range forward along the
+    /// hunter's facing, so it mostly sees prey ahead of it and barely notices prey directly behind.
+    ezVec3 GetDetectionCenter(ezVec3 vOwnPos)
+    {
+        return vOwnPos + GetOwner().GetGlobalDirForwards() * (m_fDetectionRange * 0.5f);
+    }
+
+    /// Looks for the closest prey in range and, if found, commits to pursuing it. Returns true if a
+    /// prey was acquired.
+    bool TryAcquireNewPrey(ezAiVoxelNavigationComponent@ navComp, ezVec3 vOwnPos)
+    {
+        ezGameObject@ preyObj = ezSpatial::FindClosestObjectInSphere(PreyMarker, GetDetectionCenter(vOwnPos), m_fDetectionRange);
+        if (@preyObj == null)
+            return false;
+
+        m_hTrackedPrey      = preyObj.GetHandle();
+        m_vLastKnownPreyPos = preyObj.GetGlobalPosition();
+        m_bHasLastKnownPos  = true;
+        m_State             = HunterState::Pursuing;
+        navComp.SetNavigationTarget(preyObj.GetHandle());
+        return true;
+    }
+
+    /// Rotates the owner towards vTargetPos, without moving.
+    void RotateTowards(ezVec3 vOwnPos, ezVec3 vTargetPos)
+    {
+        ezVec3 dirToTarget = vTargetPos - vOwnPos;
+        if (dirToTarget.GetLength() < 0.01f)
+            return;
+
+        dirToTarget.Normalize();
+
+        ezQuat targetRotation = ezQuat::MakeShortestRotation(ezVec3::MakeAxisX(), dirToTarget);
+        ezQuat newRotation    = ezQuat::MakeSlerp(GetOwner().GetGlobalRotation(), targetRotation, 0.1f);
+
+        GetOwner().SetGlobalRotation(newRotation);
+    }
+
+    void DrawDebugState(ezVec3 vTextPos, ezVec3 vOwnPos)
+    {
+        if (m_State == HunterState::Wandering)
+        {
+            ezDebug::Draw3DText("Hunter: Wandering", vTextPos, ezColor::LightGrey, 24);
+        }
+        else if (m_State == HunterState::Pursuing)
+        {
+            ezDebug::Draw3DText("Hunter: Pursuing!", vTextPos, ezColor::OrangeRed, 28);
+        }
+        else if (m_State == HunterState::Tracking)
+        {
+            ezDebug::Draw3DText("Hunter: Tracking...", vTextPos, ezColor::Yellow, 28);
+        }
+        else
+        {
+            ezDebug::Draw3DText("Hunter: Too Close!", vTextPos, ezColor::Red, 36);
+        }
+
+        ezDebug::DrawLineSphere(GetDetectionCenter(vOwnPos), m_fDetectionRange, ezColor(1, 0.3f, 0, 0.3f));
+    }
+}

--- a/Data/Samples/Testing Chambers/AI/AiVoxel/Prey.as
+++ b/Data/Samples/Testing Chambers/AI/AiVoxel/Prey.as
@@ -1,0 +1,159 @@
+#include "AiShipBase.as"
+
+enum PreyState
+{
+    Wandering, // no threat nearby
+    Fleeing,   // hunter detected, actively evading
+    Cornered,  // hunter got within panic range, emergency escape
+}
+
+class Prey : AiShipBase
+{
+    ezString HunterMarker = "Hunter";
+
+    private PreyState m_State = PreyState::Wandering;
+    private PreyState m_PrevState = PreyState::Wandering;
+
+    private float m_fAwarenessRange = 30.0f;
+    private float m_fFleeDistance = 100.0f;   // how far to run when fleeing
+    private float m_fPanicRange = 8.0f;      // emergency flee if hunter this close
+
+    void OnSimulationStarted()
+    {
+        m_vHomePos = GetOwner().GetGlobalPosition();
+        m_fWanderRadius = 200.0f;
+        m_fLife = 30.0f;
+        SetUpdateInterval(ezTime::Milliseconds(80));
+    }
+
+    void Update(ezTime deltaTime)
+    {
+        ezAiVoxelNavigationComponent@ navComp;
+        if (!GetOwner().TryGetComponentOfBaseType(@navComp))
+            return;
+
+        ezVec3 vOwnPos    = GetOwner().GetGlobalPosition();
+        ezVec3 vStatusPos = vOwnPos + ezVec3(0, 0, 2.2f);
+
+        if (TryRecoverFromFailedState(navComp, vOwnPos))
+            return;
+
+        // Detect nearest hunter
+        ezGameObject@ hunterObj = ezSpatial::FindClosestObjectInSphere(HunterMarker, vOwnPos, m_fAwarenessRange);
+
+        if (@hunterObj != null)
+        {
+            ezVec3 vHunterPos = hunterObj.GetGlobalPosition();
+            float fDistToHunter = vOwnPos.GetDistanceTo(vHunterPos);
+
+            m_State = (fDistToHunter < m_fPanicRange) ? PreyState::Cornered : PreyState::Fleeing;
+
+            bool bNeedsNewDestination = false;
+
+            if (m_PrevState == PreyState::Wandering)
+            {
+                navComp.CancelNavigation();
+                m_bHasDestination = false;
+                bNeedsNewDestination = true;
+            }
+            else if (!navComp.IsNavigating() || navComp.IsApproachingDestination())
+            {
+                bNeedsNewDestination = true;
+            }
+
+            if (bNeedsNewDestination)
+            {
+                if (fDistToHunter < m_fPanicRange)
+                {
+                    PickFleeDestinationRandom(navComp, vOwnPos);
+                }
+                else
+                {
+                    ezVec3 vAwayDir = vOwnPos - vHunterPos;
+                    float fLen = vAwayDir.GetLength();
+
+                    if (fLen > 0.01f)
+                    {
+                        vAwayDir = vAwayDir * (1.0f / fLen); // normalize manually
+
+                        // pull back towards home, stronger the further away we already are
+                        ezVec3 vHomeDir = m_vHomePos - vOwnPos;
+                        float fHomeDist = vHomeDir.GetLength();
+                        float fHomeWeight = ezMath::Clamp(fHomeDist / m_fWanderRadius, 0.0f, 1.5f);
+                        if (fHomeDist > 0.01f)
+                            vHomeDir = vHomeDir * (1.0f / fHomeDist);
+
+                        // always add some randomness so multiple prey don't all flee the same way
+                        ezRandom@ rng = GetWorld().GetRandomNumberGenerator();
+                        float lateralBias = rng.FloatMinMax(-0.6f, 0.6f);
+                        ezVec3 vSide = vAwayDir.GetOrthogonalVector();
+
+                        ezVec3 vFleeDir = vAwayDir + vSide * lateralBias + vHomeDir * fHomeWeight;
+
+                        if (vFleeDir.GetLength() > 0.01f)
+                            vAwayDir = vFleeDir.GetNormalized();
+
+                        SetNavDestination(navComp, vOwnPos + vAwayDir * m_fFleeDistance);
+                    }
+                    else
+                    {
+                        PickFleeDestinationRandom(navComp, vOwnPos);
+                    }
+                }
+            }
+
+            if (ShowDebugInfo)
+                ezDebug::DrawLine(vOwnPos, vHunterPos, ezColor::Yellow, ezColor::OrangeRed);
+        }
+        else
+        {
+            m_State = PreyState::Wandering;
+
+            if (!navComp.IsNavigating() || navComp.IsApproachingDestination())
+            {
+                PickWanderDestination(navComp);
+            }
+        }
+
+        m_PrevState = m_State;
+
+        if (ShowDebugInfo)
+        {
+            DrawDebugState(vStatusPos, vOwnPos);
+
+            if (m_bHasDestination)
+            {
+                ezDebug::DrawLine(vOwnPos, m_vDestination, ezColor::Cyan, ezColor::Cyan);
+            }
+        }
+    }
+
+    void PickFleeDestinationRandom(ezAiVoxelNavigationComponent@ navComp, ezVec3 vOwnPos)
+    {
+        ezVec3 vPoint;
+
+        if (navComp.FindRandomPointAroundSphere(vOwnPos, m_fFleeDistance, 32, vPoint))
+        {
+            SetNavDestination(navComp, vPoint);
+        }
+    }
+
+    void DrawDebugState(ezVec3 vTextPos, ezVec3 vOwnPos)
+    {
+        if (m_State == PreyState::Wandering)
+        {
+            ezDebug::Draw3DText("Prey: Wandering", vTextPos, ezColor::Green, 24);
+        }
+        else if (m_State == PreyState::Fleeing)
+        {
+            ezDebug::Draw3DText("Prey: FLEEING!", vTextPos, ezColor::Yellow, 28);
+        }
+        else
+        {
+            ezDebug::Draw3DText("Prey: Cornered!", vTextPos, ezColor::Orange, 28);
+        }
+
+        // Visualize awareness sphere
+        ezDebug::DrawLineSphere(vOwnPos, m_fAwarenessRange, ezColor(0, 1, 0, 0.25f));
+    }
+}

--- a/Data/Samples/Testing Chambers/AI/AiVoxel/VoxelHunter.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/AI/AiVoxel/VoxelHunter.ezAngelScriptAsset
@@ -1,0 +1,244 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{4477411779512872614,4816567077569846753}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"AngelScript"}
+		VarArray %Dependencies
+		{
+			s{"AI/AiVoxel/AiShipBase.as"}
+			s{"AI/AiVoxel/Hunter.as"}
+		}
+		Uuid %DocumentID{u4{4477411779512872614,4816567077569846753}}
+		u4 %Hash{2460796346568425079}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{11160300980943884973,5800247240220378925}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps{}
+		VarArray %References
+		{
+			s{"AI/AiVoxel/Hunter.as"}
+		}
+		s %Tags{""}
+	}
+}
+o
+{
+	Uuid %id{u4{11160300980943884973,5800247240220378925}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters
+		{
+			Uuid{u4{17694108185283463139,10739575193649461046}}
+			Uuid{u4{13469171791519920180,15030080879531058212}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17694108185283463139,10739575193649461046}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		b %DefaultValue{0}
+		s %Name{"ShowDebugInfo"}
+		s %Type{""}
+	}
+}
+o
+{
+	Uuid %id{u4{13469171791519920180,15030080879531058212}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %DefaultValue{"Prey"}
+		s %Name{"PreyMarker"}
+		s %Type{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{12277280903518145436,4703652856138638606}}
+	s %t{"ezAngelScriptAssetProperties"}
+	u3 %v{1}
+	p
+	{
+		s %ClassName{"Hunter"}
+		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"AI/AiVoxel/AiShipBase.as"}
+		}
+		VarArray %Parameters
+		{
+			Uuid{u4{16257500559242563514,5441105960596442815}}
+			Uuid{u4{4716690432393827216,5474968294148061199}}
+		}
+		s %Source{"ezAngelScriptCodeMode::FromFile"}
+		s %SourceFile{"AI/AiVoxel/Hunter.as"}
+	}
+}
+o
+{
+	Uuid %id{u4{16257500559242563514,5441105960596442815}}
+	s %t{"ezAngelScriptParameter"}
+	u3 %v{1}
+	p
+	{
+		s %Declaration{"bool ShowDebugInfo = false"}
+		b %DefaultValue{0}
+		b %Expose{1}
+		s %Name{"ShowDebugInfo"}
+	}
+}
+o
+{
+	Uuid %id{u4{4716690432393827216,5474968294148061199}}
+	s %t{"ezAngelScriptParameter"}
+	u3 %v{1}
+	p
+	{
+		s %Declaration{"ezString PreyMarker = Prey"}
+		s %DefaultValue{"Prey"}
+		b %Expose{1}
+		s %Name{"PreyMarker"}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{12277280903518145436,4703652856138638606}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{8509943957974801055,7464388984120343662}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAngelScript"}
+		VarArray %Properties{}
+		s %TypeName{"ezAngelScriptAssetProperties"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13231494322839441943,7887324119527060122}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAngelScript"}
+		VarArray %Properties{}
+		s %TypeName{"ezAngelScriptCodeMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14234517193980461100,14716562946791027194}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAngelScript"}
+		VarArray %Properties{}
+		s %TypeName{"ezAngelScriptParameter"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/AI/AiVoxel/VoxelPrey.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/AI/AiVoxel/VoxelPrey.ezAngelScriptAsset
@@ -1,0 +1,244 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{14129143427010252435,5436779011875301964}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"AngelScript"}
+		VarArray %Dependencies
+		{
+			s{"AI/AiVoxel/AiShipBase.as"}
+			s{"AI/AiVoxel/Prey.as"}
+		}
+		Uuid %DocumentID{u4{14129143427010252435,5436779011875301964}}
+		u4 %Hash{7288291499515836939}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{11352326903704187980,7829818942004979762}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps{}
+		VarArray %References
+		{
+			s{"AI/AiVoxel/Prey.as"}
+		}
+		s %Tags{""}
+	}
+}
+o
+{
+	Uuid %id{u4{11352326903704187980,7829818942004979762}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters
+		{
+			Uuid{u4{3706592079900527171,14946241538592463600}}
+			Uuid{u4{14616137844290134430,17961642303453911503}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3706592079900527171,14946241538592463600}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		b %DefaultValue{0}
+		s %Name{"ShowDebugInfo"}
+		s %Type{""}
+	}
+}
+o
+{
+	Uuid %id{u4{14616137844290134430,17961642303453911503}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %DefaultValue{"Hunter"}
+		s %Name{"HunterMarker"}
+		s %Type{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{5258481545961029542,4662021905774376158}}
+	s %t{"ezAngelScriptAssetProperties"}
+	u3 %v{1}
+	p
+	{
+		s %ClassName{"Prey"}
+		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"AI/AiVoxel/AiShipBase.as"}
+		}
+		VarArray %Parameters
+		{
+			Uuid{u4{14497158815208314007,4828848645421544983}}
+			Uuid{u4{4435675966572945574,4726217919976810015}}
+		}
+		s %Source{"ezAngelScriptCodeMode::FromFile"}
+		s %SourceFile{"AI/AiVoxel/Prey.as"}
+	}
+}
+o
+{
+	Uuid %id{u4{4435675966572945574,4726217919976810015}}
+	s %t{"ezAngelScriptParameter"}
+	u3 %v{1}
+	p
+	{
+		s %Declaration{"ezString HunterMarker = Hunter"}
+		s %DefaultValue{"Hunter"}
+		b %Expose{1}
+		s %Name{"HunterMarker"}
+	}
+}
+o
+{
+	Uuid %id{u4{14497158815208314007,4828848645421544983}}
+	s %t{"ezAngelScriptParameter"}
+	u3 %v{1}
+	p
+	{
+		s %Declaration{"bool ShowDebugInfo = false"}
+		b %DefaultValue{0}
+		b %Expose{1}
+		s %Name{"ShowDebugInfo"}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{5258481545961029542,4662021905774376158}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{8509943957974801055,7464388984120343662}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAngelScript"}
+		VarArray %Properties{}
+		s %TypeName{"ezAngelScriptAssetProperties"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13231494322839441943,7887324119527060122}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAngelScript"}
+		VarArray %Properties{}
+		s %TypeName{"ezAngelScriptCodeMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14234517193980461100,14716562946791027194}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAngelScript"}
+		VarArray %Properties{}
+		s %TypeName{"ezAngelScriptParameter"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Editor/SpatialDataCategoryEnum.txt
+++ b/Data/Samples/Testing Chambers/Editor/SpatialDataCategoryEnum.txt
@@ -1,3 +1,5 @@
 GrabObjectMarker
+Hunter
 NPC
 Player
+Prey

--- a/Data/Samples/Testing Chambers/Prefabs/Asteroid.ezPrefab
+++ b/Data/Samples/Testing Chambers/Prefabs/Asteroid.ezPrefab
@@ -1,0 +1,419 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{6505302465728482316,3622048411735579724}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters{}
+	}
+}
+o
+{
+	Uuid %id{u4{14738257445283527324,4631693869777232906}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Prefab"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{14738257445283527324,4631693869777232906}}
+		u4 %Hash{3227130389593459153}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{6505302465728482316,3622048411735579724}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 14bf3313-89f3-4692-873c-d127980bf748 }"}
+			s{"{ 3bf60313-2bce-45cf-8836-68e3b9ef5323 }"}
+			s{"{ 526ebdd3-265d-4bbb-93a3-6389cec9d729 }"}
+		}
+		VarArray %References
+		{
+			s{"{ 3bf60313-2bce-45cf-8836-68e3b9ef5323 }"}
+		}
+		s %Tags{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{15370275058793026006,3691800422002923}}
+	s %t{"ezJoltStaticActorComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		u1 %CollisionLayer{0}
+		s %CollisionMesh{"{ 526ebdd3-265d-4bbb-93a3-6389cec9d729 }"}
+		b %PullSurfacesFromGraphicsMesh{0}
+		s %Surface{"{ 14bf3313-89f3-4692-873c-d127980bf748 }"}
+	}
+}
+o
+{
+	Uuid %id{u4{1709678010642266006,4950783661910263110}}
+	s %t{"ezPrefabDocumentSettings"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ExposedProperties{}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezSceneDocumentRoot"}
+	u3 %v{2}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{981123763977627461,12383812648246492793}}
+		}
+		Uuid %Settings{u4{1709678010642266006,4950783661910263110}}
+	}
+}
+o
+{
+	Uuid %id{u4{981123763977627461,12383812648246492793}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15094603539008133082,17793004499302627082}}
+			Uuid{u4{15370275058793026006,3691800422002923}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000A041}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Asteroid"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15094603539008133082,17793004499302627082}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		VarArray %Materials{}
+		s %Mesh{"{ 3bf60313-2bce-45cf-8836-68e3b9ef5323 }"}
+		f %SortingDepthOffset{0}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{6914292285925798136,1108246313736053318}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11638255232360359673,3108610646416571142}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezExposedSceneProperty"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14332645745114734426,3197497487504472660}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneDocumentSettingsBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezPrefabDocumentSettings"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14633628111157529947,3328384510238863063}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezMeshComponentBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{17523044089822028024,3521005166208929094}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCategoryAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7605758958972330253,6687734095884105025}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponentBase"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{13649880205026559927,7297274558339895637}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObject"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14538573732623829394,8132504581476750103}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezJoltActorComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltStaticActorComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3251891958765718680,9159887340540620231}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezDocumentRoot"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentRoot"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{14543630447052729839,9459039542380974471}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezObjectMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14700230518358869173,11472901527618371423}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettingsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16777871838542487558,12116962178824346014}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezRenderComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6839391121561780669,12349512622905798822}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltActorComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{9604010176759229512,12868035041842190965}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPropertyAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Prefabs/Weapons/Plasma/Plasma_ProjectileFast.ezPrefab
+++ b/Data/Samples/Testing Chambers/Prefabs/Weapons/Plasma/Plasma_ProjectileFast.ezPrefab
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{10968892147187856520,4680268186461628477}}
-		u4 %Hash{12975756229009329803}
+		u4 %Hash{18207020935216121409}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{14975086783168853274,7590948841737216774}}
@@ -20,7 +20,6 @@ o
 		VarArray %PackageDeps
 		{
 			s{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
-			s{"{ 8f19ce05-bf1e-4626-9659-e6acc058dee5 }"}
 			s{"{ d8a5e2ee-bb0e-4cc1-9e1f-72e77393f595 }"}
 			s{"{ e00262e8-58f5-42f5-880d-569257047201 }"}
 		}
@@ -64,7 +63,7 @@ o
 		b %Active{1}
 		f %AspectRatio{0x0000803F}
 		s %BlendMode{"ezSpriteBlendMode::Additive"}
-		Color %Color{f{0xDB085D41,0x89041244,0,0x0000803F}}
+		Color %Color{f{0x085F5841,0x89041244,0,0x0000803F}}
 		u1 %Columns{1}
 		f %Framerate{0x0000C041}
 		b %IsAnimated{0}
@@ -75,6 +74,31 @@ o
 		f %Size{0x0000803F}
 		s %Texture{"{ e00262e8-58f5-42f5-880d-569257047201 }"}
 		b %UseMaxScreenSize{1}
+	}
+}
+o
+{
+	Uuid %id{u4{658211392837241996,4874009165445133687}}
+	s %t{"ezPointLightComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		b %CastShadows{0}
+		f %ConstantBias{0xCDCCCC3D}
+		ColorGamma %EffectiveColor{u1{255,255,255,255}}
+		f %Intensity{0x0000C842}
+		f %Length{0}
+		ColorGamma %LightColor{u1{42,255,0,255}}
+		f %PenumbraSize{0xCDCC4C3D}
+		f %Radius{0}
+		f %Range{0}
+		f %ShadowFadeOutRange{0}
+		f %SlopeBias{0x0000803E}
+		f %SpecularMultiplier{0x0000803F}
+		u3 %Temperature{6550}
+		b %TransparentShadows{0}
+		b %UseColorTemperature{0}
 	}
 }
 o
@@ -150,7 +174,7 @@ o
 		f %InertiaRatio{0x0000A040}
 		s %Interaction{"Plasma_Impact"}
 		s %Reaction{"ezProjectileReaction::Absorb"}
-		s %Surface{"{ 8f19ce05-bf1e-4626-9659-e6acc058dee5 }"}
+		s %Surface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
 	}
 }
 o
@@ -167,6 +191,7 @@ o
 			Uuid{u4{7046036172170978504,17788223592979233661}}
 			Uuid{u4{16616760190989313676,4864854735156217753}}
 			Uuid{u4{7542386066989952675,5356859417278452236}}
+			Uuid{u4{658211392837241996,4874009165445133687}}
 		}
 		s %GlobalKey{""}
 		Vec3 %LocalPosition{f{0,0,0}}
@@ -1142,6 +1167,23 @@ o
 }
 o
 {
+	Uuid %id{u4{13157915159061735959,12012078319048480294}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezLightComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPointLightComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
 	Uuid %id{u4{8462158745466161957,12084886310631755596}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -1227,6 +1269,23 @@ o
 }
 o
 {
+	Uuid %id{u4{17338863546649435593,13192242791875444156}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPointLightVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{11078601447512948093,13307465990423964330}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
@@ -1277,6 +1336,23 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Surface"}
 		s %Type{"ezStringView"}
+	}
+}
+o
+{
+	Uuid %id{u4{12814930320360971966,14780945004767832345}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezLightComponent"}
+		u3 %TypeVersion{6}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Scenes/VoxelAi.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/VoxelAi.ezScene
@@ -1,0 +1,8728 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{984390114722623023,11038557269066726856}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Scene"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{984390114722623023,11038557269066726856}}
+		u4 %Hash{13209606914711645342}
+		VarArray %MetaInfo{}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 04e4bc2b-20b1-4909-a98a-b2de0d9a86d7 }"}
+			s{"{ e096ce19-543a-4c1a-ac0b-95315930d3bc }"}
+			s{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+			s{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		}
+		VarArray %References
+		{
+			s{"{ 04e4bc2b-20b1-4909-a98a-b2de0d9a86d7 }"}
+			s{"{ e096ce19-543a-4c1a-ac0b-95315930d3bc }"}
+			s{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+			s{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		}
+		s %Tags{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{11507096185750263752,68610870797123598}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4938572999662793597,156856820847542166}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9477364054441820055,17886499822752316359}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x90138AC2,0xCDCB7542,0xD3215442}}
+		Quat %LocalRotation{f{0x980634BF,0x979ECABE,0x0B90163F,0x86D55E3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x192CAE3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5938978941636480071,264425805122340581}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10998903903333299923,286566904722320323}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12442700171646279486,320414379957813100}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14781530522358675229,364745863485855749}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{873577503428150071,18094388865390629942}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xFA06E8C2,0x1AC38B42,0xADFE4642}}
+		Quat %LocalRotation{f{0xB51426BF,0x4A8AC2BD,0xD9471B3F,0x0A37E63E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2EC6F13F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5369965496057010981,394089542067491070}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15223135029766604578,402171543121952739}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16798959260581387814,414817906507748607}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2891006241650862656,18144460908412522800}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x915154C2,0xF0145942,0xE0191641}}
+		Quat %LocalRotation{f{0xC24643BF,0x2CC2CDBD,0x4EEA093F,0x18BDAF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{580353414401331732,433879085636424488}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5119144469180358190,18163522087541198681}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x37BCF2C2,0xBE719A42,0xE2521142}}
+		Quat %LocalRotation{f{0x07BC013F,0x907D3BBF,0x9DC1E83E,0xE4B6393C}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x599A953F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6752801426062021303,483655616391385632}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5804054899726677289,551030363491415257}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6671726364031285271,656039938422350568}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6968305130971237294,785711942601901021}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11507096185750263752,68610870797123598}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x09100DC2,0x6F98EF42,0xCB068542}}
+		Quat %LocalRotation{f{0x782330BF,0xD458CDBE,0x9EDD373D,0xB8641ABF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x4C8FCB3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18195116227179575363,854034321371546326}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11601435772183538876,897333045943248786}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1400187886857453613,981526876927118004}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5938978941636480071,264425805122340581}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x26B975C2,0xFF838A42,0x0C297641}}
+		Quat %LocalRotation{f{0xB127523E,0x6A92DBBD,0x589CD53E,0x50FA603F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xC7F5A93F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6460112848554273465,1003667976527097746}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10998903903333299923,286566904722320323}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD8CC01C2,0xE2D6DB42,0x74C29642}}
+		Quat %LocalRotation{f{0xF058BABE,0xBE1E03BF,0x568A45BF,0xD062CABD}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9D94823F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2336071731058436327,1026026986334629166}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7903909116867253028,1037515451762590523}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12442700171646279486,320414379957813100}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3AAD8AC2,0x4AE10C42,0x974358C2}}
+		Quat %LocalRotation{f{0x5C847EBD,0x09CC17BF,0x827E2B3F,0xEC8AE23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{831174441277984523,1111190613872268493}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5369965496057010981,394089542067491070}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x50D268C2,0xF82ED341,0x89687DC2}}
+		Quat %LocalRotation{f{0xC050A6BA,0x97E28A3E,0x1E6CEEBD,0xA797743F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10684343974987578120,1119272614926730162}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15223135029766604578,402171543121952739}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x77940042,0x1E2F2442,0x8A7118C1}}
+		Quat %LocalRotation{f{0xD693473E,0x323CA7BE,0x7F2334BF,0x69A3193F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x948F5F3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2214010371282994845,1200756688196163055}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6752801426062021303,483655616391385632}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE0151541,0x101F8EC0,0xB2EE8D41}}
+		Quat %LocalRotation{f{0xF5548D3E,0xD2663DBF,0x41CC1CBF,0x4E74123D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9BF8983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1265263844947650831,1268131435296192680}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5804054899726677289,551030363491415257}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x934C3B42,0xAC654D42,0x9D5B64C0}}
+		Quat %LocalRotation{f{0x5944753E,0x17C475BF,0xE4A2D33D,0xFCECCF3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x31436B3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2132935309252258813,1373141010227127991}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6671726364031285271,656039938422350568}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x922A9EC2,0x1BCEC642,0x2F7E7442}}
+		Quat %LocalRotation{f{0x6726C53E,0xFE1764BF,0xCC91C83D,0x93FC60BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3424943F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15596497859908400696,1385552829508671060}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8428097234103858262,2096931197610443185}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1C7DE242,0xB81B6EC2,0xA5F3AEB5}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14208078346043719634,1409852076226403565}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13656325172400548905,1571135393176323749}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18195116227179575363,854034321371546326}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xF48C92C2,0x1EB1A642,0x58059E42}}
+		Quat %LocalRotation{f{0x90FD14BF,0x02FA25BF,0x8F16B5BE,0xDA41AE3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x1C15AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7062644717404512418,1614434117748026209}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11601435772183538876,897333045943248786}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x5D5543C1,0xA9A68042,0x0B070442}}
+		Quat %LocalRotation{f{0xD6F875BE,0x39A83EBF,0x734A1EBF,0xA458953D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9BF8983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13138120847900283347,1638852265393907875}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16244024749988961485,1743128058139406589}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2336071731058436327,1026026986334629166}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x8990A4C1,0xA7835842,0xA34FC341}}
+		Quat %LocalRotation{f{0x46C559BD,0xB3642B3F,0x942533BF,0x063579BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11442127349311649784,1835616673826018267}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9143613580702434276,1858221171041821198}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8428097234103858262,2096931197610443185}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{1}
+		}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9669287291264693176,2126953148031180988}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14208078346043719634,1409852076226403565}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD4119342,0x1C854D42,0xD2A48B40}}
+		Quat %LocalRotation{f{0x763B4B3E,0x28EA54BF,0xD095EEBE,0x6AEF68BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8A58FF3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11392852654039986133,2176481253879392489}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11640213609892759610,2284108422392109859}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4471812984088217176,2995486790493881984}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x088E8B41,0x8A58CB42,0xA5F3AEB5}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3914610640244243051,2338147614608789346}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8599329793121256889,2355953337198685298}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13138120847900283347,1638852265393907875}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x8FA060C2,0x0C5CB641,0x00F64B42}}
+		Quat %LocalRotation{f{0xC8FFD9BE,0xDFC105BF,0xDE4D0C3F,0xCA9AFD3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB504743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2382469613587276081,2357475624257722894}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5398039151255442013,2489076974887317800}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8544034792041121136,2491587603654526121}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6903336294532623326,2552717745630795690}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11442127349311649784,1835616673826018267}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9C336CC2,0xD2371E43,0xC5889E42}}
+		Quat %LocalRotation{f{0x4F9D273F,0xC087BF3C,0x3D06B4BE,0xA92E2BBF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3906783F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12024076227645736246,2572813590114193297}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4604822525923407818,2575322242846598621}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9143613580702434276,1858221171041821198}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xB5AA78C2,0xDB890E42,0x001C7F42}}
+		Quat %LocalRotation{f{0x349588BE,0x01A524BF,0xF989443E,0x5D0F31BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9E339C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11274581187320769864,2587064747908704572}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6473993267728477782,2692802867963021966}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7231103959708793654,2771153053809586048}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6854061599260959675,2893582325684169912}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11392852654039986133,2176481253879392489}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x64BF41C2,0x41321E43,0xC00B9B42}}
+		Quat %LocalRotation{f{0x7E2E983E,0xE406C4BD,0x00169DBE,0xB82A663F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x14F4A23F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18150763296502613977,2923408971586870450}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6283571287634587221,2934213646788251010}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4471812984088217176,2995486790493881984}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3377678543933640020,3007361240393440012}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5440048566629645410,3032126798749835058}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11973647971865627478,3035318322588116354}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17822563659174768209,3055248686413566769}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3914610640244243051,2338147614608789346}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCE9D5241,0x9F9E6742,0x41113740}}
+		Quat %LocalRotation{f{0xD510FBBE,0x5B403BBF,0x80464F3B,0xCB99F2BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xE9208D3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{16290422632517801239,3074576696062500317}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2382469613587276081,2357475624257722894}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x833D3442,0x09B76340,0xFA35C241}}
+		Quat %LocalRotation{f{0xAD2C38BE,0x4EAA1A3F,0x662C17BF,0x410001BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2C55AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5916310643405726072,3179991407819645019}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{859248096476415555,3206178046692095223}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5398039151255442013,2489076974887317800}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1D7F86C2,0xBA88C241,0x28A26DBE}}
+		Quat %LocalRotation{f{0xC050A6BA,0x97E28A3E,0x1E6CEEBD,0xA797743F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x005C5B40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4005243737262094678,3208688675459303544}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8544034792041121136,2491587603654526121}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x937188C2,0x39819642,0x3DEB2B42}}
+		Quat %LocalRotation{f{0x4496DB3E,0xF0734DBC,0xA02F603D,0x34D066BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8AF76C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9074307766595988750,3254770165566459822}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7485285172866709788,3289914661918970720}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12024076227645736246,2572813590114193297}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC4FC0F42,0x94D86BC0,0xB75C8641}}
+		Quat %LocalRotation{f{0xBCF5CABD,0x022B46BF,0x6C5B18BF,0xE75444BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBEA0963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6735790132541743406,3304165819713481995}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11274581187320769864,2587064747908704572}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x21C6BDC1,0xDFEDF4BF,0xE7544BBE}}
+		Quat %LocalRotation{f{0xF915653F,0x1CA1FABD,0x083DCEBE,0xA3D217BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBEA0963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13259957372608365455,3331176008070339412}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1935202212949451324,3409903939767799389}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6473993267728477782,2692802867963021966}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xFAB56241,0x2786E542,0x8CE77342}}
+		Quat %LocalRotation{f{0xF68A8C3E,0xA09727BF,0x19BC203F,0x0C67A3BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x42227C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2692312904929767196,3488254125614363471}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7231103959708793654,2771153053809586048}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x34956941,0xCF9E3742,0x771B6F41}}
+		Quat %LocalRotation{f{0xBFE002BE,0xFDC6CB3E,0xC07691BE,0xE5E45CBF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2C55AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13611972241723587519,3640510043391647873}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18150763296502613977,2923408971586870450}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0ED9BD41,0x445D0B43,0xB5C0F242}}
+		Quat %LocalRotation{f{0x1C6F993E,0xF2871D3F,0x60C5E1BD,0x787E38BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x68823F40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1744780232855560763,3651314718593028433}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6283571287634587221,2934213646788251010}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7AA9A5C2,0x39EF8A42,0x2ED55842}}
+		Quat %LocalRotation{f{0x4021B13B,0x001D7BBF,0x2402473E,0x40807BBB}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9A228E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17538867694598505954,3667975995445742930}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17285631562864165178,3724462312198217435}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3377678543933640020,3007361240393440012}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x218294C2,0xB2148A42,0x04D64A42}}
+		Quat %LocalRotation{f{0xE636163F,0x7270D6BD,0x4EDDE8BE,0xA46629BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB339963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{901257511850618952,3749227870554612481}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5440048566629645410,3032126798749835058}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x12CD8342,0x3548E042,0x9B298642}}
+		Quat %LocalRotation{f{0xF877BEBE,0x5648323F,0x81DAE13E,0x6071DA3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xC2ED4F40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7434856917086601020,3752419394392893777}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11973647971865627478,3035318322588116354}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x6D0C64C2,0x3941E842,0xA6C98D42}}
+		Quat %LocalRotation{f{0x4125F5BE,0x72DE083E,0x94CE443F,0xE2FDCD3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x5EDD923F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14940799757441733597,3840368968727264202}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1377519588626699614,3897092479624422442}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5916310643405726072,3179991407819645019}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xAE8E79C2,0x4049D942,0x6C7F8A42}}
+		Quat %LocalRotation{f{0xACE6CA3E,0x5F9629BF,0xF5F6D83E,0x6A9DF23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2BE86D3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4535516711816962292,3971871237371237245}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9074307766595988750,3254770165566459822}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x62F78FC1,0xE3B2A842,0x2C7F5442}}
+		Quat %LocalRotation{f{0x629D3EBF,0x6859533E,0xE16394BE,0x369610BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB419883F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11920543939998954922,4013678223714920245}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8721166317829338997,4048277079875116835}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13259957372608365455,3331176008070339412}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC075AEC2,0xCA15EE42,0x3004A942}}
+		Quat %LocalRotation{f{0x3BB7123E,0xA85BBB3D,0x0B080CBF,0x64D7513F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x7C5DC73F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9017122922369157512,4101279331027334319}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16639041006663320568,4254919372435791249}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13000076639819479496,4385077067250520353}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17538867694598505954,3667975995445742930}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x97CA0D42,0x4C542943,0x08A60043}}
+		Quat %LocalRotation{f{0x168AE03E,0xE2A08B3E,0x48E8413C,0x05335BBF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x54229B3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{16821537319097659373,4411131274450892026}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14385892394722239737,4419902885008963064}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12512159904214010366,4437871269495203541}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14889556137497076169,4444598375377005372}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10402008702662707139,4557470040532041625}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14940799757441733597,3840368968727264202}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9159E442,0xCF4F1E42,0x87331DBF}}
+		Quat %LocalRotation{f{0x3C8448BF,0x042CB73E,0xDA07C33E,0xC16AAC3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8A58FF3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7381752885219928464,4730779295519697668}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11920543939998954922,4013678223714920245}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xA8EDB4C2,0xC5309E41,0x90336740}}
+		Quat %LocalRotation{f{0x70E047BF,0x06A856BE,0x1A84113F,0x7A7D1CBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x413C743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11241766294769102318,4780821127075773991}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4478331867590131054,4818380402832111742}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9017122922369157512,4101279331027334319}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7951AAC2,0x11FAD542,0x874CAD42}}
+		Quat %LocalRotation{f{0x70E047BF,0x06A856BE,0x1A84113F,0x7A7D1CBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x413C743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{542397246858413971,4849354489361412089}}
+	s %t{"ezAiVoxelGridComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		u3 %CollisionLayer{0}
+		Vec3 %Size{f{0x00008043,0x00008043,0x00000043}}
+		b %Visualize{1}
+		f %VoxelSize{0x00008040}
+	}
+}
+o
+{
+	Uuid %id{u4{17442247360119285412,4883262841459907987}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5081405673877899453,5070137657895881318}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9888513722044587412,4909962411414149088}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{12319032775465026229,5714878076686966702}}
+			Uuid{u4{10647766099921881482,5649818585139732532}}
+			Uuid{u4{14082698255028039983,10480513874443598079}}
+			Uuid{u4{8982853611849151659,5523308238274413657}}
+			Uuid{u4{7297780701027392675,5225725726502415237}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x42AE3F42,0xF03A3C42,0x000050C1}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6850174716345262263,4970996448202869821}}
+	s %t{"ezSpawnComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %AttachAsChild{0}
+		Time %DelayRange{d{0x0000000000002440}}
+		Angle %Deviation{f{0}}
+		Time %MinDelay{d{0x0000000000004E40}}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %SpawnAtStart{1}
+		b %SpawnContinuously{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12100249951884294110,4972020444240568672}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16639041006663320568,4254919372435791249}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x296FEDC0,0x728AD142,0x2ADAA842}}
+		Quat %LocalRotation{f{0x402C97BE,0x372AA9BE,0x8045CABE,0x88024E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x78F0A13F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5081405673877899453,5070137657895881318}}
+	s %t{"ezFogComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		f %Density{0xCDCCCC3E}
+		f %HeightFalloff{0}
+		b %ModulateWithSkyColor{1}
+		f %SkyDistance{0x00007A44}
+		f %StartDistance{0x0000C842}
+	}
+}
+o
+{
+	Uuid %id{u4{12282746264318632915,5128232346255669449}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16821537319097659373,4411131274450892026}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xEBFC9AC1,0x5583EC42,0x87189042}}
+		Quat %LocalRotation{f{0x2C3F8FBE,0x6FE15C3E,0x6C26CABE,0x7C1E593F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xE9E0A53F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9847101339943213279,5137003956813740487}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14385892394722239737,4419902885008963064}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x48A548C2,0x934B1542,0x73A34941}}
+		Quat %LocalRotation{f{0xA4D2C33D,0x9B66D0BE,0x94A85DBF,0x20AA8C3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xD72A743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7973368849434983908,5154972341299980964}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12512159904214010366,4437871269495203541}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x202C19C2,0x546D0B43,0xA150BF42}}
+		Quat %LocalRotation{f{0x34F42BBF,0x7CA9883E,0xFFE75B3E,0xD627283F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x808BAA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10350765082718049711,5161699447181782795}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14889556137497076169,4444598375377005372}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE976EBC2,0xEF381242,0xB1E929C0}}
+		Quat %LocalRotation{f{0xC24643BF,0x2CC2CDBD,0x4EEA093F,0x18BDAF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{204177940242801098,5218433723376666101}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7297780701027392675,5225725726502415237}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{18027532907789932320,6816720846850589583}}
+			Uuid{u4{13514500383938009253,11904417250852226006}}
+			Uuid{u4{2908772838352832694,11679880794473688392}}
+			Uuid{u4{15686904941227541054,17311104252286377052}}
+			Uuid{u4{13611972241723587519,3640510043391647873}}
+			Uuid{u4{4535516711816962292,3971871237371237245}}
+			Uuid{u4{15023611869411884690,8810456330477969763}}
+			Uuid{u4{9749473018812573976,14540461302783882908}}
+			Uuid{u4{16244024749988961485,1743128058139406589}}
+			Uuid{u4{2161335146408833891,6648784298409268810}}
+			Uuid{u4{12178452586447742807,6366249939303870046}}
+			Uuid{u4{17707576121804350477,11108902387832995656}}
+			Uuid{u4{5379141206337828754,16414281310650220170}}
+			Uuid{u4{17822563659174768209,3055248686413566769}}
+			Uuid{u4{1716525786625175799,8352842728506207792}}
+			Uuid{u4{17274814104615037160,8691157933462323689}}
+			Uuid{u4{3952092146355712389,14194158620332049379}}
+			Uuid{u4{10684343974987578120,1119272614926730162}}
+			Uuid{u4{9190514880104620183,6318450731627871537}}
+			Uuid{u4{15638264311495466021,12009498886691647428}}
+			Uuid{u4{3588085813258680510,16675255055590469180}}
+			Uuid{u4{859248096476415555,3206178046692095223}}
+			Uuid{u4{9484500967100749031,8290015576856986056}}
+			Uuid{u4{3518002742686046081,14037217798908125192}}
+			Uuid{u4{7903909116867253028,1037515451762590523}}
+			Uuid{u4{1820378673404280009,6256243965054391908}}
+			Uuid{u4{10282346228992868316,8455418118983052715}}
+			Uuid{u4{10926358058581292664,8939134894052778542}}
+			Uuid{u4{9655133432379298852,13711739127637757720}}
+			Uuid{u4{6460112848554273465,1003667976527097746}}
+			Uuid{u4{6203704414458585196,6051843602894251487}}
+			Uuid{u4{13179975976408069624,11373491531122034293}}
+			Uuid{u4{10121685218494662578,16678446579428750476}}
+			Uuid{u4{1377519588626699614,3897092479624422442}}
+			Uuid{u4{15395396991277245925,9405375676327650685}}
+			Uuid{u4{4819763610660320371,14299168195262984690}}
+			Uuid{u4{13656325172400548905,1571135393176323749}}
+			Uuid{u4{3962794701584910249,6461488139792304353}}
+			Uuid{u4{10767224527073860164,12065774525354507488}}
+			Uuid{u4{7165160168998192612,17744407587867968441}}
+			Uuid{u4{7381752885219928464,4730779295519697668}}
+			Uuid{u4{8721166317829338997,4048277079875116835}}
+			Uuid{u4{1525715790562675120,16650489497234074134}}
+			Uuid{u4{1744780232855560763,3651314718593028433}}
+			Uuid{u4{10973643498172318713,9097008287483547822}}
+			Uuid{u4{4953685185425355253,8319561027328439681}}
+			Uuid{u4{17468358823766736787,13290773048521712448}}
+			Uuid{u4{580353414401331732,433879085636424488}}
+			Uuid{u4{4005243737262094678,3208688675459303544}}
+			Uuid{u4{16298567522150672114,8742542142097212035}}
+			Uuid{u4{4087016188265515171,13907554061962974703}}
+			Uuid{u4{16798959260581387814,414817906507748607}}
+			Uuid{u4{6702975239990075860,5497922198880551414}}
+			Uuid{u4{1113654410653637739,10969895788426693332}}
+			Uuid{u4{10350765082718049711,5161699447181782795}}
+			Uuid{u4{9847101339943213279,5137003956813740487}}
+			Uuid{u4{4500083230295165834,10204829389998195617}}
+			Uuid{u4{11286158094529318447,15281980522234541997}}
+			Uuid{u4{4604822525923407818,2575322242846598621}}
+			Uuid{u4{5152679069328954458,7606213321127962323}}
+			Uuid{u4{7625401301070855155,13082884005883398865}}
+			Uuid{u4{1935202212949451324,3409903939767799389}}
+			Uuid{u4{12738794529679816414,8289849675997379012}}
+			Uuid{u4{71993573400601575,8022407815261655295}}
+			Uuid{u4{7307982337195414428,12779810049678527997}}
+			Uuid{u4{14787078253292355668,17898047629276425371}}
+			Uuid{u4{14969574565726694473,18054259531291526148}}
+			Uuid{u4{7973368849434983908,5154972341299980964}}
+			Uuid{u4{8257082901040502154,10442489796227198839}}
+			Uuid{u4{9540889900669021233,15819609510720026611}}
+			Uuid{u4{6903336294532623326,2552717745630795690}}
+			Uuid{u4{15587624211033868442,7546613447969942191}}
+			Uuid{u4{4047694932052106360,7652880805608050007}}
+			Uuid{u4{10402008702662707139,4557470040532041625}}
+			Uuid{u4{13856293011407351417,9624344981095934878}}
+			Uuid{u4{12356115592672754734,15052980333067037687}}
+			Uuid{u4{2214010371282994845,1200756688196163055}}
+			Uuid{u4{16290422632517801239,3074576696062500317}}
+			Uuid{u4{8708562102459382354,6850167517261238352}}
+			Uuid{u4{10172113474274771346,16215941846954827419}}
+			Uuid{u4{6735790132541743406,3304165819713481995}}
+			Uuid{u4{17224431103259518521,6735724734664369247}}
+			Uuid{u4{12854099290784773299,8609544742530706509}}
+			Uuid{u4{5272238760726354414,12385135563729444544}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x74F0A0C2,0x0A458EC1,0x1474A6C1}}
+		Quat %LocalRotation{f{0xD26B003F,0x3CCB473F,0x120B983E,0xE66A673E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xF253803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Asteroids"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2432316167772296632,5237494902505341982}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15772623383111786673,5249989277318373113}}
+	s %t{"ezJoltSettingsComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec3 %CharacterGravity{f{0,0,0}}
+		f %FixedFrameRate{0x00007042}
+		u3 %MaxBodies{10000}
+		u3 %MaxSubSteps{4}
+		Vec3 %ObjectGravity{f{0,0,0}}
+		f %SleepVelocityThreshold{0x8FC2F53C}
+		s %SteppingMode{"ezJoltSteppingMode::SemiFixed"}
+	}
+}
+o
+{
+	Uuid %id{u4{16903543888798250127,5297221651590193787}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14247506853400016772,5571631433192533126}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10742495469237611654,5334742531089474064}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5852261874392265109,5364565529029322380}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7680532900834896275,5725464895366085207}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x39FA3343,0x72EF6943,0x766113C2}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11284325974667413144,5409121994584301185}}
+	s %t{"ezShapeIconComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6410053889597701264,5414046417151847792}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11284325974667413144,5409121994584301185}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC0CAECC2,0x9AC6C2C3,0x00CA9DC0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Test Path End"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6702975239990075860,5497922198880551414}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11241766294769102318,4780821127075773991}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE8C8A0C2,0xCC8E0B42,0xA1CEBDC1}}
+		Quat %LocalRotation{f{0xC24643BF,0x2CC2CDBD,0x4EEA093F,0x18BDAF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8982853611849151659,5523308238274413657}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{16903543888798250127,5297221651590193787}}
+			Uuid{u4{16323252506754980125,9852852034805909632}}
+			Uuid{u4{14327041911300821168,15210135607427966558}}
+			Uuid{u4{15596497859908400696,1385552829508671060}}
+			Uuid{u4{973968950191104544,10291903722067027738}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x42AE3FC2,0xF03A3CC2,0x00005041}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Ships"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6359169728183306467,5539142893249614485}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14247506853400016772,5571631433192533126}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{1}
+		}
+		s %Prefab{"{ e096ce19-543a-4c1a-ac0b-95315930d3bc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13729305934883646641,5601349659823094114}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16717243641226769265,5649148867499092623}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10647766099921881482,5649818585139732532}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6850174716345262263,4970996448202869821}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x21D789C2,0xAC50A7C2,0x9A997142}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9201663382265441438,5687129801240776570}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15772623383111786673,5249989277318373113}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12319032775465026229,5714878076686966702}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{542397246858413971,4849354489361412089}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7680532900834896275,5725464895366085207}}
+	s %t{"ezAiVoxelPathTestComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		u3 %MaxHops{16}
+		u3 %MaxIterationsPerHop{10000}
+		s %PathEnd{"{ 13cfed70-8e88-4b22-90fc-94f80c16f558 }"}
+		f %SearchMargin{0x0000A040}
+		b %VisualizePathState{1}
+		b %VisualizeSmoothedPath{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8501585756363936707,5744387067987526930}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8312075601925238365,5807283793396015240}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9755871870238217928,5841131268631508017}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12536306728358543020,5922888431795647656}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6700126201187860349,5931683226604491387}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14112130959173326256,5935534795181443524}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{204177940242801098,5218433723376666101}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x915154C2,0xF0145942,0xE0191641}}
+		Quat %LocalRotation{f{0xC24643BF,0x2CC2CDBD,0x4EEA093F,0x18BDAF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{16340269186702821790,5954595974310119405}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2432316167772296632,5237494902505341982}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x37BCF2C2,0xBE719A42,0xE2521142}}
+		Quat %LocalRotation{f{0x07BC013F,0x907D3BBF,0x9DC1E83E,0xE4B6393C}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x599A953F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4065973124653959745,6004372505065080549}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3316478084328993363,6018623662859591824}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6203704414458585196,6051843602894251487}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10742495469237611654,5334742531089474064}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7C23F8C1,0x4DDEAF42,0x6EF75A42}}
+		Quat %LocalRotation{f{0x02A6D03E,0x192D4CBF,0x807E343D,0x889AE23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBB9D853F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4119579888859407162,6099619775045812160}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13247353157238408812,6133066445456460929}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1820378673404280009,6256243965054391908}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6359169728183306467,5539142893249614485}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x782597C2,0xD7174642,0x4DD630C2}}
+		Quat %LocalRotation{f{0x5C847EBD,0x09CC17BF,0x827E2B3F,0xEC8AE23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9190514880104620183,6318450731627871537}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13729305934883646641,5601349659823094114}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x5E703342,0x7C241142,0xC30946C0}}
+		Quat %LocalRotation{f{0xE2DFF2BE,0x31D850BF,0x3C08233E,0x7E7B94BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x67CE2640}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12178452586447742807,6366249939303870046}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16717243641226769265,5649148867499092623}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x4D1B2EC1,0x8A654B42,0xD2BCB441}}
+		Quat %LocalRotation{f{0xD7828D3E,0xAEB143BF,0x10617F3D,0x9840143F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9C5A523F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15508287925771513805,6374751210045241243}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezSceneDocumentRoot"}
+	u3 %v{2}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{1770930792210326821,10385234089704887553}}
+			Uuid{u4{9888513722044587412,4909962411414149088}}
+			Uuid{u4{7201685420636525854,10430679300087844005}}
+			Uuid{u4{5852261874392265109,5364565529029322380}}
+			Uuid{u4{6410053889597701264,5414046417151847792}}
+		}
+		Uuid %Settings{u4{15341415101869333829,10567418871792982965}}
+	}
+}
+o
+{
+	Uuid %id{u4{3962794701584910249,6461488139792304353}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8501585756363936707,5744387067987526930}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3E5B80C2,0x6FEEA942,0xDA15A642}}
+		Quat %LocalRotation{f{0xEC19983E,0xAE4947BF,0x8378CDBE,0x9CC0C2BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xCE7B903F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3773284547146211907,6524384865200792663}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8312075601925238365,5807283793396015240}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD8CC01C2,0xE2D6DB42,0x74C29642}}
+		Quat %LocalRotation{f{0xF058BABE,0xBE1E03BF,0x568A45BF,0xD062CABD}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9D94823F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18095987503359926385,6546743875008324083}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5217080815459191470,6558232340436285440}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9755871870238217928,5841131268631508017}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3AAD8AC2,0x4AE10C42,0x974358C2}}
+		Quat %LocalRotation{f{0x5C847EBD,0x09CC17BF,0x827E2B3F,0xEC8AE23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7997515673579516562,6639989503600425079}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12536306728358543020,5922888431795647656}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x77940042,0x1E2F2442,0x8A7118C1}}
+		Quat %LocalRotation{f{0xD693473E,0x323CA7BE,0x7F2334BF,0x69A3193F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x948F5F3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2161335146408833891,6648784298409268810}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6700126201187860349,5931683226604491387}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xAAF5E6C1,0x482A6942,0x4337E841}}
+		Quat %LocalRotation{f{0x46C559BD,0xB3642B3F,0x942533BF,0x063579BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17973926143584484903,6721473576869857972}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4065973124653959745,6004372505065080549}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE0151541,0x101F8EC0,0xB2EE8D41}}
+		Quat %LocalRotation{f{0xF5548D3E,0xD2663DBF,0x41CC1CBF,0x4E74123D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9BF8983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17224431103259518521,6735724734664369247}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3316478084328993363,6018623662859591824}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE29A91BF,0x07EF31C1,0x6F4931C1}}
+		Quat %LocalRotation{f{0xCF5A7F3F,0x002D37BB,0x40668F3A,0x683191BD}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9BF8983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18027532907789932320,6816720846850589583}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4119579888859407162,6099619775045812160}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1F0385C2,0x51DBBFC1,0xE1803FC2}}
+		Quat %LocalRotation{f{0x85367CBF,0x70DBD2BC,0x79D9153E,0x7BDEAE3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xA96CA33F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1679671192103343284,6829512376165164768}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8708562102459382354,6850167517261238352}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13247353157238408812,6133066445456460929}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC23D8541,0x16CF67C1,0x63970141}}
+		Quat %LocalRotation{f{0x56EA57BD,0xE4EE293F,0xDC9E31BF,0xB8648C3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9691470124107980916,6889112249323184900}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12909669558500339138,6906269718182365977}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5741268932695796704,7617648086284138102}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1C7DE242,0xB81B6EC2,0xA5F3AEB5}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8586485986831132818,6935779733803272584}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10969496870992487347,7091852281850018666}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15508287925771513805,6374751210045241243}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xF48C92C2,0x1EB1A642,0x58059E42}}
+		Quat %LocalRotation{f{0x90FD14BF,0x02FA25BF,0x8F16B5BE,0xDA41AE3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x1C15AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13557196448580899927,7263844946813101506}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18095987503359926385,6546743875008324083}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x8990A4C1,0xA7835842,0xA34FC341}}
+		Quat %LocalRotation{f{0x46C559BD,0xB3642B3F,0x942533BF,0x063579BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4610784628179628033,7305306743456877872}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8755299047903588226,7356333562499713184}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6456785279294372718,7378938059715516115}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15587624211033868442,7546613447969942191}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1679671192103343284,6829512376165164768}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x78978CC2,0x5AFA1A43,0x110B9A42}}
+		Quat %LocalRotation{f{0x90D2FEBC,0xB0E26BBF,0x90D55BBD,0xCC62C4BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3906783F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17277585584458842872,7572748604192601589}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14023292021879775489,7572914505052208633}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9492476240204381711,7602459955523662258}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5152679069328954458,7606213321127962323}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9691470124107980916,6889112249323184900}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0EA288C2,0x8F715142,0x10217A42}}
+		Quat %LocalRotation{f{0x980634BF,0x979ECABE,0x0B90163F,0x86D55E3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x192CAE3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5741268932695796704,7617648086284138102}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6255316841404202257,7635741656701430369}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4047694932052106360,7652880805608050007}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8586485986831132818,6935779733803272584}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3FAFC9C1,0xF888C642,0x42A18E41}}
+		Quat %LocalRotation{f{0xC9D002BF,0xFA02E2BD,0x44248D3E,0xA8814E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x7CA4863F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14821137283771894774,7738317047178275292}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1227782338836181493,7858864503282484263}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{18142385385888766139,7878192512931417811}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17392890345563799757,7892443670725929086}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3366861085684512002,7974056861657546266}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2711210849847380455,8009793863561012717}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5857206490633059578,8012304492328221038}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{71993573400601575,8022407815261655295}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4610784628179628033,7305306743456877872}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE0EC2D41,0x8C69D942,0x3DE66742}}
+		Quat %LocalRotation{f{0x3A7AC7BE,0x3778ADBE,0x7F96023F,0x3C1A303F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9DE7943F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2390614503220146956,8025441070292434612}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4216507993124561768,8073434634304490607}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8755299047903588226,7356333562499713184}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9C336CC2,0xD2371E43,0xC5889E42}}
+		Quat %LocalRotation{f{0x4F9D273F,0xC087BF3C,0x3D06B4BE,0xA92E2BBF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3906783F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1115658850481359532,8093355258673192340}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1917994224515346260,8096039131520293538}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6456785279294372718,7378938059715516115}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xB5AA78C2,0xDB890E42,0x001C7F42}}
+		Quat %LocalRotation{f{0x349588BE,0x01A524BF,0xF989443E,0x5D0F31BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9E339C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8587752885912708306,8107781636582399489}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3787164966320416224,8213519756636716883}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15465149113360319122,8222033822248001119}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12738794529679816414,8289849675997379012}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17277585584458842872,7572748604192601589}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1B6BE33F,0x0FE0C842,0xCF456042}}
+		Quat %LocalRotation{f{0xF68A8C3E,0xA09727BF,0x19BC203F,0x0C67A3BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x42227C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9484500967100749031,8290015576856986056}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14023292021879775489,7572914505052208633}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xAD3B41C2,0x8089A841,0x80688AC2}}
+		Quat %LocalRotation{f{0xC050A6BA,0x97E28A3E,0x1E6CEEBD,0xA797743F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4953685185425355253,8319561027328439681}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9492476240204381711,7602459955523662258}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x6093CEC2,0x73DF8542,0x072F5A42}}
+		Quat %LocalRotation{f{0xF88C0D3D,0xD6A44F3E,0xB7B153BF,0xE4F805BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xCBF28E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1716525786625175799,8352842728506207792}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6255316841404202257,7635741656701430369}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCCF74B41,0xC48C7C42,0x60F726C0}}
+		Quat %LocalRotation{f{0xD510FBBE,0x5B403BBF,0x80464F3B,0xCB99F2BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xE9208D3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15512434552951345171,8379907215678770399}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15463934995094552419,8444125860260565367}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3596742986226525663,8454930535461945927}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10282346228992868316,8455418118983052715}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14821137283771894774,7738317047178275292}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x2F39B83F,0x2BF07542,0xD78BAE42}}
+		Quat %LocalRotation{f{0x04C656BF,0xEED811BE,0x92FCF63E,0x1ABA543E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3A4FAA40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15135735357766706651,8575965575087261686}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1227782338836181493,7858864503282484263}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCE9D5241,0x9F9E6742,0x41113740}}
+		Quat %LocalRotation{f{0xD510FBBE,0x5B403BBF,0x80464F3B,0xCB99F2BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xE9208D3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13603594331109739681,8595293584736195234}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18142385385888766139,7878192512931417811}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x833D3442,0x09B76340,0xFA35C241}}
+		Quat %LocalRotation{f{0xAD2C38BE,0x4EAA1A3F,0x662C17BF,0x410001BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2C55AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12854099290784773299,8609544742530706509}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17392890345563799757,7892443670725929086}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x413E13C2,0x3346BFC0,0x0010EDBF}}
+		Quat %LocalRotation{f{0x4E1AD3BD,0x8E20D03E,0x455E19BF,0x289C2E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2C55AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1487443972346720767,8688274604522873262}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17274814104615037160,8691157933462323689}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3366861085684512002,7974056861657546266}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x06B2E141,0x4A3C5742,0x89524F3F}}
+		Quat %LocalRotation{f{0xACE3DDBE,0xF974B1BE,0xFB4D913E,0xBF3048BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2E03843F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3229482341997664514,8700708296493339936}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16619163868777905613,8726894935365790140}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2711210849847380455,8009793863561012717}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1D7F86C2,0xBA88C241,0x28A26DBE}}
+		Quat %LocalRotation{f{0xC050A6BA,0x97E28A3E,0x1E6CEEBD,0xA797743F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x005C5B40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1318415435854033120,8729405564132998461}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5857206490633059578,8012304492328221038}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x937188C2,0x39819642,0x3DEB2B42}}
+		Quat %LocalRotation{f{0x4496DB3E,0xF0734DBC,0xA02F603D,0x34D066BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8AF76C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{16298567522150672114,8742542142097212035}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2390614503220146956,8025441070292434612}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE27483C2,0xB6409542,0x81C6D341}}
+		Quat %LocalRotation{f{0x3C7B17BD,0xFFBB0E3F,0xF1C13ABF,0x82F0C9BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xDDF0983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6387479465187927192,8775487054240154739}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15023611869411884690,8810456330477969763}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1115658850481359532,8093355258673192340}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x87A222C1,0xDD019342,0x99D52242}}
+		Quat %LocalRotation{f{0x039F11BF,0xDB400ABF,0xCDB717BE,0x64331A3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x7334833F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4048961831133681848,8824882708387176912}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8587752885912708306,8107781636582399489}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x21C6BDC1,0xDFEDF4BF,0xE7544BBE}}
+		Quat %LocalRotation{f{0xF915653F,0x1CA1FABD,0x083DCEBE,0xA3D217BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBEA0963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10573129071200303897,8851892896744034329}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{18395084066186377875,8907243909291157455}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17695117985250941382,8930620828441494306}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3787164966320416224,8213519756636716883}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xFAB56241,0x2786E542,0x8CE77342}}
+		Quat %LocalRotation{f{0xF68A8C3E,0xA09727BF,0x19BC203F,0x0C67A3BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x42227C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10926358058581292664,8939134894052778542}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15465149113360319122,8222033822248001119}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD74A0EC2,0xD223AE42,0x15690F42}}
+		Quat %LocalRotation{f{0x7240D73E,0xCE8641BF,0x6D90F33E,0x706D233E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xA585A63F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10973643498172318713,9097008287483547822}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15512434552951345171,8379907215678770399}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9F8CBBC2,0x04238542,0x98285D42}}
+		Quat %LocalRotation{f{0x4021B13B,0x001D7BBF,0x2402473E,0x40807BBB}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9A228E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10925143940315525961,9161226932065342790}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15463934995094552419,8444125860260565367}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0ED9BD41,0x445D0B43,0xB5C0F242}}
+		Quat %LocalRotation{f{0x1C6F993E,0xF2871D3F,0x60C5E1BD,0x787E38BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x68823F40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17504696005157050821,9172031607266723350}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3596742986226525663,8454930535461945927}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7AA9A5C2,0x39EF8A42,0x2ED55842}}
+		Quat %LocalRotation{f{0x4021B13B,0x001D7BBF,0x2402473E,0x40807BBB}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9A228E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12253971456033672039,9361085857400959119}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15395396991277245925,9405375676327650685}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1487443972346720767,8688274604522873262}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x85C68DC2,0xFE90D642,0x44CD8242}}
+		Quat %LocalRotation{f{0x701702BD,0x29A776BF,0x8BA45EBE,0xBBAB1CBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xABA48E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17137435360928189672,9417809368298117359}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3229482341997664514,8700708296493339936}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xAE8E79C2,0x4049D942,0x6C7F8A42}}
+		Quat %LocalRotation{f{0xACE6CA3E,0x5F9629BF,0xF5F6D83E,0x6A9DF23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2BE86D3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9038874285074192292,9487728318193418194}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1848688410408900734,9492588126044932162}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6387479465187927192,8775487054240154739}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x62F78FC1,0xE3B2A842,0x2C7F5442}}
+		Quat %LocalRotation{f{0x629D3EBF,0x6859533E,0xE16394BE,0x369610BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB419883F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9233715638590893364,9534395112388615162}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6034338016421277439,9568993968548811752}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10573129071200303897,8851892896744034329}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC075AEC2,0xCA15EE42,0x3004A942}}
+		Quat %LocalRotation{f{0x3BB7123E,0xA85BBB3D,0x0B080CBF,0x64D7513F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x7C5DC73F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13856293011407351417,9624344981095934878}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18395084066186377875,8907243909291157455}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x30D09342,0xFBCA3A42,0x6D1E1441}}
+		Quat %LocalRotation{f{0x3C8448BF,0x042CB73E,0xDA07C33E,0xC16AAC3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8A58FF3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12795873955819528612,9725388724422421416}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10285106871451420764,9801691737506735368}}
+	s %t{"ezSpawnComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %AttachAsChild{0}
+		Time %DelayRange{d{0x0000000000003E40}}
+		Angle %Deviation{f{0}}
+		Time %MinDelay{d{0x0000000000804640}}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %SpawnAtStart{1}
+		b %SpawnContinuously{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16323252506754980125,9852852034805909632}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9154851880950437691,10564230402907681757}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC1710A43,0xE17D3F42,0xA5F3AEB5}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11699064093314178179,9940619773682657981}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9825331602805948808,9958588158168898458}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12202727836089014611,9965315264050700289}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7715180401254645581,10078186929205736542}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12253971456033672039,9361085857400959119}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9159E442,0xCF4F1E42,0x87331DBF}}
+		Quat %LocalRotation{f{0x3C8448BF,0x042CB73E,0xDA07C33E,0xC16AAC3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8A58FF3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4500083230295165834,10204829389998195617}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9038874285074192292,9487728318193418194}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x17AA49C2,0xB4DBA641,0x3ABBDE41}}
+		Quat %LocalRotation{f{0x5FBE12BF,0x691B2ABF,0xDBAFF2BE,0xD8DF933D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x1739923F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4694924583811866906,10251496184193392585}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9233715638590893364,9534395112388615162}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xA8EDB4C2,0xC5309E41,0x90336740}}
+		Quat %LocalRotation{f{0x70E047BF,0x06A856BE,0x1A84113F,0x7A7D1CBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x413C743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5652445465432664197,10252794716621915909}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15388240088346746455,10277778492191783239}}
+	s %t{"ezSceneLayer"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Layer{u4{984390114722623023,11038557269066726856}}
+	}
+}
+o
+{
+	Uuid %id{u4{973968950191104544,10291903722067027738}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16764675988502422805,10566313503669367077}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x67669E42,0xCDCCD042,0x6666D641}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8554937993361040760,10301538015749468908}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16302313019159904029,10370071378035107006}}
+	s %t{"ezAiVoxelGridComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		u3 %CollisionLayer{0}
+		Vec3 %Size{f{0x00008043,0x00008043,0x00000043}}
+		b %Visualize{0}
+		f %VoxelSize{0x00008040}
+	}
+}
+o
+{
+	Uuid %id{u4{1770930792210326821,10385234089704887553}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{5875481322883679038,10489266536684266647}}
+			Uuid{u4{7911033197684363563,10761077794199361872}}
+			Uuid{u4{15721977816704437293,10460849402794787825}}
+			Uuid{u4{9201663382265441438,5687129801240776570}}
+			Uuid{u4{17442247360119285412,4883262841459907987}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Environment"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3799623102873825319,10391801316028218233}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7589529848582374751,10405709425899431641}}
+	s %t{"ezSkyBoxComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		s %CubeMap{"{ 04e4bc2b-20b1-4909-a98a-b2de0d9a86d7 }"}
+		f %ExposureBias{0xCDCCCC3F}
+		b %InverseTonemap{0}
+		b %UseFog{0}
+		f %VirtualDistance{0x00007A44}
+	}
+}
+o
+{
+	Uuid %id{u4{7201685420636525854,10430679300087844005}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{9632204474056964671,11235594965360661619}}
+			Uuid{u4{7960937798513819924,11170535473813427449}}
+			Uuid{u4{11395869953619978425,16001230763117292996}}
+			Uuid{u4{6296025310441090101,11044025126948108574}}
+			Uuid{u4{4610952399619331117,10746442615176110154}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x42AE3F42,0xAA5752C3,0x000050C1}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8257082901040502154,10442489796227198839}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12795873955819528612,9725388724422421416}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x064116C2,0xC7E62143,0x29A89B42}}
+		Quat %LocalRotation{f{0x3DAB533F,0x4026BB3C,0xEF74DF3E,0x8A45B53E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0DC0473F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15721977816704437293,10460849402794787825}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17478741356590978106,10752479394959776017}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x4B5A3042,0x145AAE42,0x3019B742}}
+		Quat %LocalRotation{f{0x8BD2A6BE,0xE3C255BE,0x1CC3463F,0xC6AFFEBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Scene Thumbnail Camera"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14082698255028039983,10480513874443598079}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10285106871451420764,9801691737506735368}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xF0687442,0x0CE11B41,0x06754842}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5875481322883679038,10489266536684266647}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7792690679915796521,10896448552348697957}}
+			Uuid{u4{5885786054452644685,11340198510385167590}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x00004037,0xB8C9CEC2,0x88B84E42}}
+		Quat %LocalRotation{f{0xBE2BA7BE,0xBD2BA73E,0xED90203F,0xEC90203F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4163346414937200705,10491713336876564738}}
+	s %t{"ezSpawnComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %AttachAsChild{0}
+		Time %DelayRange{d{0x0000000000002440}}
+		Angle %Deviation{f{0}}
+		Time %MinDelay{d{0x0000000000004E40}}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %SpawnAtStart{1}
+		b %SpawnContinuously{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9154851880950437691,10564230402907681757}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{1}
+		}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16764675988502422805,10566313503669367077}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{1}
+		}
+		s %Prefab{"{ e096ce19-543a-4c1a-ac0b-95315930d3bc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15341415101869333829,10567418871792982965}}
+	s %t{"ezSceneDocumentSettings"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Layers
+		{
+			Uuid{u4{15388240088346746455,10277778492191783239}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17718767031187096082,10656390459317256870}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7160273038535151721,10657720845487435404}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11699064093314178179,9940619773682657981}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x48A548C2,0x934B1542,0x73A34941}}
+		Quat %LocalRotation{f{0xA4D2C33D,0x9B66D0BE,0x94A85DBF,0x20AA8C3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xD72A743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5286540548026922350,10675689229973675881}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9825331602805948808,9958588158168898458}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x202C19C2,0x546D0B43,0xA150BF42}}
+		Quat %LocalRotation{f{0x34F42BBF,0x7CA9883E,0xFFE75B3E,0xD627283F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x808BAA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7663936781309988153,10682416335855477712}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12202727836089014611,9965315264050700289}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE976EBC2,0xEF381242,0xB1E929C0}}
+		Quat %LocalRotation{f{0xC24643BF,0x2CC2CDBD,0x4EEA093F,0x18BDAF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4610952399619331117,10746442615176110154}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{15340704606381870762,12337437735524284500}}
+			Uuid{u4{10827672082529947695,17425134139525920923}}
+			Uuid{u4{221944536944771136,17200597683147383309}}
+			Uuid{u4{13000076639819479496,4385077067250520353}}
+			Uuid{u4{10925143940315525961,9161226932065342790}}
+			Uuid{u4{1848688410408900734,9492588126044932162}}
+			Uuid{u4{12336783568003823132,14331173219151664680}}
+			Uuid{u4{7062644717404512418,1614434117748026209}}
+			Uuid{u4{13557196448580899927,7263844946813101506}}
+			Uuid{u4{17921250918710323949,12169501187082963727}}
+			Uuid{u4{9491624285039681249,11886966827977564963}}
+			Uuid{u4{15020747820396288919,16629619276506690573}}
+			Uuid{u4{2692312904929767196,3488254125614363471}}
+			Uuid{u4{15135735357766706651,8575965575087261686}}
+			Uuid{u4{17476441558926665857,13873559617179902709}}
+			Uuid{u4{14587985803206975602,14211874822136018606}}
+			Uuid{u4{1265263844947650831,1268131435296192680}}
+			Uuid{u4{7997515673579516562,6639989503600425079}}
+			Uuid{u4{6503686578696558625,11839167620301566454}}
+			Uuid{u4{12951436010087404463,17530215775365342345}}
+			Uuid{u4{901257511850618952,3749227870554612481}}
+			Uuid{u4{16619163868777905613,8726894935365790140}}
+			Uuid{u4{6797672665692687473,13810732465530680973}}
+			Uuid{u4{831174441277984523,1111190613872268493}}
+			Uuid{u4{5217080815459191470,6558232340436285440}}
+			Uuid{u4{17580294445705770067,11776960853728086825}}
+			Uuid{u4{7595517927584806758,13976135007656747632}}
+			Uuid{u4{8239529757173231106,14459851782726473459}}
+			Uuid{u4{6968305130971237294,785711942601901021}}
+			Uuid{u4{3773284547146211907,6524384865200792663}}
+			Uuid{u4{3516876113050523638,11572560491567946404}}
+			Uuid{u4{10493147675000008066,16894208419795729210}}
+			Uuid{u4{7434856917086601020,3752419394392893777}}
+			Uuid{u4{17137435360928189672,9417809368298117359}}
+			Uuid{u4{12708568689869184367,14926092565001345602}}
+			Uuid{u4{2132935309252258813,1373141010227127991}}
+			Uuid{u4{10969496870992487347,7091852281850018666}}
+			Uuid{u4{1275966400176848691,11982205028465999270}}
+			Uuid{u4{8080396225665798606,17586491414028202405}}
+			Uuid{u4{4478331867590131054,4818380402832111742}}
+			Uuid{u4{4694924583811866906,10251496184193392585}}
+			Uuid{u4{6034338016421277439,9568993968548811752}}
+			Uuid{u4{17285631562864165178,3724462312198217435}}
+			Uuid{u4{17504696005157050821,9172031607266723350}}
+			Uuid{u4{8286815196764257155,14617725176157242739}}
+			Uuid{u4{2266856884017293695,13840277916002134598}}
+			Uuid{u4{14781530522358675229,364745863485855749}}
+			Uuid{u4{16340269186702821790,5954595974310119405}}
+			Uuid{u4{1318415435854033120,8729405564132998461}}
+			Uuid{u4{13611739220742610556,14263259030770906952}}
+			Uuid{u4{1400187886857453613,981526876927118004}}
+			Uuid{u4{14112130959173326256,5935534795181443524}}
+			Uuid{u4{4016146938582014302,11018639087554246331}}
+			Uuid{u4{16873570182955127797,16490612677100388249}}
+			Uuid{u4{7663936781309988153,10682416335855477712}}
+			Uuid{u4{7160273038535151721,10657720845487435404}}
+			Uuid{u4{1813254928887104276,15725546278671890534}}
+			Uuid{u4{8599329793121256889,2355953337198685298}}
+			Uuid{u4{1917994224515346260,8096039131520293538}}
+			Uuid{u4{2465850767920892900,13126930209801657240}}
+			Uuid{u4{4938572999662793597,156856820847542166}}
+			Uuid{u4{17695117985250941382,8930620828441494306}}
+			Uuid{u4{10051966228271754856,13810566564671073929}}
+			Uuid{u4{15831909345702091633,13543124703935350212}}
+			Uuid{u4{4621154035787352870,18300526938352222914}}
+			Uuid{u4{12100249951884294110,4972020444240568672}}
+			Uuid{u4{12282746264318632915,5128232346255669449}}
+			Uuid{u4{5286540548026922350,10675689229973675881}}
+			Uuid{u4{5570254599632440596,15963206684900893756}}
+			Uuid{u4{6854061599260959675,2893582325684169912}}
+			Uuid{u4{4216507993124561768,8073434634304490607}}
+			Uuid{u4{12900795909625806884,13067330336643637108}}
+			Uuid{u4{1360866630644044802,13173597694281744924}}
+			Uuid{u4{7715180401254645581,10078186929205736542}}
+			Uuid{u4{11169464709999289859,15145061869769629795}}
+			Uuid{u4{9669287291264693176,2126953148031180988}}
+			Uuid{u4{17973926143584484903,6721473576869857972}}
+			Uuid{u4{13603594331109739681,8595293584736195234}}
+			Uuid{u4{6021733801051320796,12370884405934933269}}
+			Uuid{u4{7485285172866709788,3289914661918970720}}
+			Uuid{u4{4048961831133681848,8824882708387176912}}
+			Uuid{u4{14537602801851456963,12256441623338064164}}
+			Uuid{u4{10167270989376711741,14130261631204401426}}
+			Uuid{u4{2585410459318292856,17905852452403139461}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x74F0A0C2,0x0A458EC1,0x1474A6C1}}
+		Quat %LocalRotation{f{0xD26B003F,0x3CCB473F,0x120B983E,0xE66A673E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xF253803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Asteroids"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17478741356590978106,10752479394959776017}}
+	s %t{"ezCameraComponent"}
+	u3 %v{11}
+	p
+	{
+		b %Active{1}
+		f %Aperture{0x0000803F}
+		s %BlackboardName{""}
+		s %CameraRenderPipeline{""}
+		f %Dimensions{0x00002041}
+		i1 %EditorShortcut{1}
+		VarArray %ExcludeTags{}
+		f %ExposureCompensation{0}
+		f %FOV{0x00007042}
+		f %FarPlane{0x00007A44}
+		f %ISO{0x0000C842}
+		VarArray %IncludeTags{}
+		s %Mode{"ezCameraMode::PerspectiveFixedFovY"}
+		f %NearPlane{0x0000803E}
+		s %RenderTarget{""}
+		Vec2 %RenderTargetOffset{f{0,0}}
+		Vec2 %RenderTargetSize{f{0x0000803F,0x0000803F}}
+		b %ShowStats{0}
+		Time %ShutterTime{d{0x000000000000F03F}}
+		s %UsageHint{"ezCameraUsageHint::Thumbnail"}
+	}
+}
+o
+{
+	Uuid %id{u4{7911033197684363563,10761077794199361872}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7589529848582374751,10405709425899431641}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0x0000803F}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"SkyLight"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14216715587390188569,10817938540263888704}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11560678551991955214,11092348321866228043}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8055667167829550096,10855459419763168981}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7792690679915796521,10896448552348697957}}
+	s %t{"ezSkyLightComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		s %CubeMap{"{ 04e4bc2b-20b1-4909-a98a-b2de0d9a86d7 }"}
+		f %DiffuseIntensity{0x00000041}
+		f %DiffuseSaturation{0x9A99993E}
+		VarArray %ExcludeTags{}
+		f %FarPlane{0x0000C842}
+		VarArray %IncludeTags
+		{
+			s{"SkyLight"}
+		}
+		f %NearPlane{0}
+		s %ReflectionProbeMode{"ezReflectionProbeMode::Static"}
+		b %ShowDebugInfo{0}
+		b %ShowMipMaps{0}
+		f %SpecularIntensity{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{7447563893131859152,10962779722668910969}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1113654410653637739,10969895788426693332}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5652445465432664197,10252794716621915909}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x44BCA2C2,0x55B01842,0x731CC3C1}}
+		Quat %LocalRotation{f{0xACF230BF,0xF801053F,0xC84BB0BD,0x0F5EFDBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4016146938582014302,11018639087554246331}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8554937993361040760,10301538015749468908}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE8C8A0C2,0xCC8E0B42,0xA1CEBDC1}}
+		Quat %LocalRotation{f{0xC24643BF,0x2CC2CDBD,0x4EEA093F,0x18BDAF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6296025310441090101,11044025126948108574}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{14216715587390188569,10817938540263888704}}
+			Uuid{u4{13636424205346918567,15373568923479604549}}
+			Uuid{u4{11640213609892759610,2284108422392109859}}
+			Uuid{u4{12909669558500339138,6906269718182365977}}
+			Uuid{u4{16733884722492594602,15812620610740722655}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x42AE3FC2,0xF03A3CC2,0x00005041}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Ships"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3672341426775244909,11059859781923309402}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11560678551991955214,11092348321866228043}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e096ce19-543a-4c1a-ac0b-95315930d3bc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17707576121804350477,11108902387832995656}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3799623102873825319,10391801316028218233}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x06C4853F,0xAD993F42,0x07248541}}
+		Quat %LocalRotation{f{0x3BB210BF,0x099537BF,0x781AC8BE,0xD229EEBD}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBEA0963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11042477633475585083,11122066548496789031}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14030415339818707707,11169865756172787540}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7960937798513819924,11170535473813427449}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4163346414937200705,10491713336876564738}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x21D789C2,0xAC50A7C2,0x9A997142}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18053291438717035711,11187316179047448583}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9632204474056964671,11235594965360661619}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16302313019159904029,10370071378035107006}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5814757454955875149,11265103956661221847}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1730311292564940863,11292397814886870005}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5885786054452644685,11340198510385167590}}
+	s %t{"ezDirectionalLightComponent"}
+	u3 %v{5}
+	p
+	{
+		b %Active{1}
+		b %CastShadows{1}
+		f %ConstantBias{0xCDCCCC3D}
+		ColorGamma %EffectiveColor{u1{255,255,255,255}}
+		f %FadeOutStart{0xCDCC4C3F}
+		f %Intensity{0x00002041}
+		ColorGamma %LightColor{u1{255,245,228,255}}
+		f %MinShadowRange{0x00001643}
+		f %NearPlaneOffset{0x0000C842}
+		u3 %NumCascades{3}
+		f %PenumbraSize{0xCDCC4C3D}
+		b %ScreenSpaceShadows{1}
+		f %SlopeBias{0x0000803E}
+		Angle %SourceAngle{f{0}}
+		f %SpecularMultiplier{0x0000803F}
+		f %SplitModeWeight{0x3333333F}
+		u3 %Temperature{5158}
+		b %TransparentShadows{0}
+		b %UseColorTemperature{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15306015581852886622,11348673453549730065}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13179975976408069624,11373491531122034293}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17718767031187096082,10656390459317256870}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1A3044C2,0xA684DA42,0x8793AD42}}
+		Quat %LocalRotation{f{0x64AE79BF,0x94D1EFBD,0x50B3E33D,0x23391A3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3B579E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4013297899779798791,11452400115278186304}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{629649782920931805,11539340551533286741}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3516876113050523638,11572560491567946404}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8055667167829550096,10855459419763168981}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7C23F8C1,0x4DDEAF42,0x6EF75A42}}
+		Quat %LocalRotation{f{0x02A6D03E,0x192D4CBF,0x807E343D,0x889AE23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBB9D853F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1432751587451345604,11620336663719507077}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10560524855830347254,11653783334130155846}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9811029815505380872,11668034491924667121}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2908772838352832694,11679880794473688392}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7447563893131859152,10962779722668910969}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xA1AE11C3,0x478CD042,0xC75AAA42}}
+		Quat %LocalRotation{f{0x6E207ABE,0x843F78BD,0x8193DE3D,0x6B3176BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3AA1853F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17580294445705770067,11776960853728086825}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3672341426775244909,11059859781923309402}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x782597C2,0xD7174642,0x4DD630C2}}
+		Quat %LocalRotation{f{0x5C847EBD,0x09CC17BF,0x827E2B3F,0xEC8AE23E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6503686578696558625,11839167620301566454}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11042477633475585083,11122066548496789031}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x5E703342,0x7C241142,0xC30946C0}}
+		Quat %LocalRotation{f{0xE2DFF2BE,0x31D850BF,0x3C08233E,0x7E7B94BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x67CE2640}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9491624285039681249,11886966827977564963}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14030415339818707707,11169865756172787540}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x4D1B2EC1,0x8A654B42,0xD2BCB441}}
+		Quat %LocalRotation{f{0xD7828D3E,0xAEB143BF,0x10617F3D,0x9840143F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9C5A523F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13514500383938009253,11904417250852226006}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18053291438717035711,11187316179047448583}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x29ACEEC1,0x896BD6C0,0x908308C2}}
+		Quat %LocalRotation{f{0xAF6A7CBF,0xF65A0EBE,0x3C4A5E3D,0xC842983D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x68823F40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1275966400176848691,11982205028465999270}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5814757454955875149,11265103956661221847}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3E5B80C2,0x6FEEA942,0xDA15A642}}
+		Quat %LocalRotation{f{0xEC19983E,0xAE4947BF,0x8378CDBE,0x9CC0C2BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xCE7B903F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15638264311495466021,12009498886691647428}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1730311292564940863,11292397814886870005}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x80D00642,0xBE81E542,0x8D778842}}
+		Quat %LocalRotation{f{0xF5B8233F,0x924AA4BE,0x76CDB9BE,0xA0D018BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xC2AB8940}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11846773391974440886,12062708977873750574}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10767224527073860164,12065774525354507488}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15306015581852886622,11348673453549730065}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC8109EC2,0x9E39B642,0xD4BBAF42}}
+		Quat %LocalRotation{f{0x84C9E6BD,0x15A8DBBD,0x105268BF,0x40C5C73E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0DA7913F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17921250918710323949,12169501187082963727}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4013297899779798791,11452400115278186304}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xAAF5E6C1,0x482A6942,0x4337E841}}
+		Quat %LocalRotation{f{0x46C559BD,0xB3642B3F,0x942533BF,0x063579BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14537602801851456963,12256441623338064164}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{629649782920931805,11539340551533286741}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE29A91BF,0x07EF31C1,0x6F4931C1}}
+		Quat %LocalRotation{f{0xCF5A7F3F,0x002D37BB,0x40668F3A,0x683191BD}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9BF8983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15340704606381870762,12337437735524284500}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1432751587451345604,11620336663719507077}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1F0385C2,0x51DBBFC1,0xE1803FC2}}
+		Quat %LocalRotation{f{0x85367CBF,0x70DBD2BC,0x79D9153E,0x7BDEAE3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xA96CA33F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17439586964404833342,12350229264838859685}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12164192355849881613,12365782934078621442}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6021733801051320796,12370884405934933269}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10560524855830347254,11653783334130155846}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC23D8541,0x16CF67C1,0x63970141}}
+		Quat %LocalRotation{f{0x56EA57BD,0xE4EE293F,0xDC9E31BF,0xB8648C3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5272238760726354414,12385135563729444544}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9811029815505380872,11668034491924667121}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0200803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7004641822699919358,12409829137996879817}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5899657685423071260,12456496622476967501}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3560405804836211629,12573671976716935025}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7307982337195414428,12779810049678527997}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11846773391974440886,12062708977873750574}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE7CC40C1,0x2212D742,0x64F29642}}
+		Quat %LocalRotation{f{0x402C97BE,0x372AA9BE,0x8045CABE,0x88024E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x78F0A13F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1923956326771566475,12826023632130572789}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14193924487158325310,12994638055832980297}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12900795909625806884,13067330336643637108}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17439586964404833342,12350229264838859685}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x78978CC2,0x5AFA1A43,0x110B9A42}}
+		Quat %LocalRotation{f{0x90D2FEBC,0xB0E26BBF,0x90D55BBD,0xCC62C4BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3906783F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7625401301070855155,13082884005883398865}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12164192355849881613,12365782934078621442}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x90138AC2,0xCDCB7542,0xD3215442}}
+		Quat %LocalRotation{f{0x980634BF,0x979ECABE,0x0B90163F,0x86D55E3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x192CAE3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14590757283050781314,13093465492866296506}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11336463720471713931,13093631393725903550}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6805647938796320153,13123176844197357175}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2465850767920892900,13126930209801657240}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7004641822699919358,12409829137996879817}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0EA288C2,0x8F715142,0x10217A42}}
+		Quat %LocalRotation{f{0x980634BF,0x979ECABE,0x0B90163F,0x86D55E3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x192CAE3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3568488539996140699,13156458545375125286}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1360866630644044802,13173597694281744924}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5899657685423071260,12456496622476967501}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3FAFC9C1,0xF888C642,0x42A18E41}}
+		Quat %LocalRotation{f{0xC9D002BF,0xFA02E2BD,0x44248D3E,0xA8814E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x7CA4863F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8625807243044541629,13190452990158197280}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12134308982363833216,13259033935851970209}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17468358823766736787,13290773048521712448}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3560405804836211629,12573671976716935025}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xFA06E8C2,0x1AC38B42,0xADFE4642}}
+		Quat %LocalRotation{f{0xB51426BF,0x4A8AC2BD,0xD9471B3F,0x0A37E63E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2EC6F13F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{8056793797465072539,13320116727103347769}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14706062044155738199,13413160559399624003}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8490883201134738847,13477057548527271956}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{680032784276450444,13494773750331241183}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15831909345702091633,13543124703935350212}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1923956326771566475,12826023632130572789}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE0EC2D41,0x8C69D942,0x3DE66742}}
+		Quat %LocalRotation{f{0x3A7AC7BE,0x3778ADBE,0x7F96023F,0x3C1A303F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9DE7943F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18150530275521637014,13546157958966129529}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9358554665439346829,13582067123458207267}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16875574622782849590,13614072147346887257}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9655133432379298852,13711739127637757720}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14193924487158325310,12994638055832980297}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x09100DC2,0x6F98EF42,0xCB068542}}
+		Quat %LocalRotation{f{0x782330BF,0xD458CDBE,0x9EDD373D,0xB8641ABF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x4C8FCB3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12778320811952257564,13742750710921696036}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10051966228271754856,13810566564671073929}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14590757283050781314,13093465492866296506}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1B6BE33F,0x0FE0C842,0xCF456042}}
+		Quat %LocalRotation{f{0xF68A8C3E,0xA09727BF,0x19BC203F,0x0C67A3BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x42227C3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6797672665692687473,13810732465530680973}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11336463720471713931,13093631393725903550}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xAD3B41C2,0x8089A841,0x80688AC2}}
+		Quat %LocalRotation{f{0xC050A6BA,0x97E28A3E,0x1E6CEEBD,0xA797743F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14288264073591600434,13823360230979105485}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2266856884017293695,13840277916002134598}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6805647938796320153,13123176844197357175}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x6093CEC2,0x73DF8542,0x072F5A42}}
+		Quat %LocalRotation{f{0xF88C0D3D,0xD6A44F3E,0xB7B153BF,0xE4F805BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xCBF28E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17476441558926665857,13873559617179902709}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3568488539996140699,13156458545375125286}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCCF74B41,0xC48C7C42,0x60F726C0}}
+		Quat %LocalRotation{f{0xD510FBBE,0x5B403BBF,0x80464F3B,0xCB99F2BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xE9208D3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12825606251543283613,13900624104352465316}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4087016188265515171,13907554061962974703}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8625807243044541629,13190452990158197280}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x26B975C2,0xFF838A42,0x0C297641}}
+		Quat %LocalRotation{f{0xB127523E,0x6A92DBBD,0x589CD53E,0x50FA603F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xC7F5A93F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7595517927584806758,13976135007656747632}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12134308982363833216,13259033935851970209}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x2F39B83F,0x2BF07542,0xD78BAE42}}
+		Quat %LocalRotation{f{0x04C656BF,0xEED811BE,0x92FCF63E,0x1ABA543E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3A4FAA40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3518002742686046081,14037217798908125192}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8056793797465072539,13320116727103347769}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x50D268C2,0xF82ED341,0x89687DC2}}
+		Quat %LocalRotation{f{0xC050A6BA,0x97E28A3E,0x1E6CEEBD,0xA797743F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB5AB1040}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10167270989376711741,14130261631204401426}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14706062044155738199,13413160559399624003}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x413E13C2,0x3346BFC0,0x0010EDBF}}
+		Quat %LocalRotation{f{0x4E1AD3BD,0x8E20D03E,0x455E19BF,0x289C2E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2C55AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3952092146355712389,14194158620332049379}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8490883201134738847,13477057548527271956}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x934C3B42,0xAC654D42,0x9D5B64C0}}
+		Quat %LocalRotation{f{0x5944753E,0x17C475BF,0xE4A2D33D,0xFCECCF3D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x31436B3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17247359744648210825,14208991493196568179}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14587985803206975602,14211874822136018606}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{680032784276450444,13494773750331241183}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x06B2E141,0x4A3C5742,0x89524F3F}}
+		Quat %LocalRotation{f{0xACE3DDBE,0xF974B1BE,0xFB4D913E,0xBF3048BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2E03843F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13611739220742610556,14263259030770906952}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18150530275521637014,13546157958966129529}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE27483C2,0xB6409542,0x81C6D341}}
+		Quat %LocalRotation{f{0x3C7B17BD,0xFFBB0E3F,0xF1C13ABF,0x82F0C9BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xDDF0983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4819763610660320371,14299168195262984690}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9358554665439346829,13582067123458207267}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x922A9EC2,0x1BCEC642,0x2F7E7442}}
+		Quat %LocalRotation{f{0x6726C53E,0xFE1764BF,0xCC91C83D,0x93FC60BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3424943F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12336783568003823132,14331173219151664680}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16875574622782849590,13614072147346887257}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x87A222C1,0xDD019342,0x99D52242}}
+		Quat %LocalRotation{f{0x039F11BF,0xDB400ABF,0xCDB717BE,0x64331A3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x7334833F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{16894906647451781192,14335879261262260264}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15708255764778316317,14427960797964852372}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8239529757173231106,14459851782726473459}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12778320811952257564,13742750710921696036}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD74A0EC2,0xD223AE42,0x15690F42}}
+		Quat %LocalRotation{f{0x7240D73E,0xCE8641BF,0x6D90F33E,0x706D233E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xA585A63F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9749473018812573976,14540461302783882908}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14288264073591600434,13823360230979105485}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x5D5543C1,0xA9A68042,0x0B070442}}
+		Quat %LocalRotation{f{0xD6F875BE,0x39A83EBF,0x734A1EBF,0xA458953D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9BF8983F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15824949149308344905,14564879450429764574}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8286815196764257155,14617725176157242739}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12825606251543283613,13900624104352465316}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9F8CBBC2,0x04238542,0x98285D42}}
+		Quat %LocalRotation{f{0x4021B13B,0x001D7BBF,0x2402473E,0x40807BBB}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x9A228E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12708568689869184367,14926092565001345602}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17247359744648210825,14208991493196568179}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x85C68DC2,0xFE90D642,0x44CD8242}}
+		Quat %LocalRotation{f{0x701702BD,0x29A776BF,0x8BA45EBE,0xBBAB1CBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xABA48E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6352045983666130734,15008445206867113111}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12356115592672754734,15052980333067037687}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16894906647451781192,14335879261262260264}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD4119342,0x1C854D42,0xD2A48B40}}
+		Quat %LocalRotation{f{0x763B4B3E,0x28EA54BF,0xD095EEBE,0x6AEF68BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8A58FF3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14079680955448047691,15102508438915249188}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11169464709999289859,15145061869769629795}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15708255764778316317,14427960797964852372}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x30D09342,0xFBCA3A42,0x6D1E1441}}
+		Quat %LocalRotation{f{0x3C8448BF,0x042CB73E,0xDA07C33E,0xC16AAC3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8A58FF3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14327041911300821168,15210135607427966558}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7158641285496278734,15921513975529738683}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x088E8B41,0x8A58CB42,0xA5F3AEB5}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10109045654411467054,15246105613096116333}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11286158094529318447,15281980522234541997}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15824949149308344905,14564879450429764574}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x8FA060C2,0x0C5CB641,0x00F64B42}}
+		Quat %LocalRotation{f{0xC8FFD9BE,0xDFC105BF,0xDE4D0C3F,0xCA9AFD3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB504743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7598278570043359206,15322408626180430285}}
+	s %t{"ezSpawnComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %AttachAsChild{0}
+		Time %DelayRange{d{0x0000000000003E40}}
+		Angle %Deviation{f{0}}
+		Time %MinDelay{d{0x0000000000804640}}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %SpawnAtStart{1}
+		b %SpawnContinuously{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13636424205346918567,15373568923479604549}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6468023579542376133,16084947291581376674}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC1710A43,0xE17D3F42,0xA5F3AEB5}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14710904529053797804,15498840775150049996}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9917932261116855212,15697180238845442747}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1813254928887104276,15725546278671890534}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6352045983666130734,15008445206867113111}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x17AA49C2,0xB4DBA641,0x3ABBDE41}}
+		Quat %LocalRotation{f{0x5FBE12BF,0x691B2ABF,0xDBAFF2BE,0xD8DF933D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x1739923F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2965617164024602639,15773511605295610826}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16733884722492594602,15812620610740722655}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14077847687094361247,16087030392343061994}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x67669E42,0xCDCCD042,0x6666D641}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9540889900669021233,15819609510720026611}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14079680955448047691,15102508438915249188}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x64BF41C2,0x41321E43,0xC00B9B42}}
+		Quat %LocalRotation{f{0x7E2E983E,0xE406C4BD,0x00169DBE,0xB82A663F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x14F4A23F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1112794801465763761,15912518204701913150}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7158641285496278734,15921513975529738683}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{1}
+		}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6064506845341701578,15933388425429296711}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8126876868037706968,15958153983785691757}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14660476273273689036,15961345507623973053}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5570254599632440596,15963206684900893756}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10109045654411467054,15246105613096116333}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x064116C2,0xC7E62143,0x29A89B42}}
+		Quat %LocalRotation{f{0x3DAB533F,0x4026BB3C,0xEF74DF3E,0x8A45B53E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0DC0473F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11395869953619978425,16001230763117292996}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7598278570043359206,15322408626180430285}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xF0687442,0x0CE11B41,0x06754842}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6468023579542376133,16084947291581376674}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ fc49c784-5551-43b2-81b8-8f9a60be8f8b }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14077847687094361247,16087030392343061994}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e096ce19-543a-4c1a-ac0b-95315930d3bc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15031938729779034524,16177107347990951787}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10172113474274771346,16215941846954827419}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14710904529053797804,15498840775150049996}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC4FC0F42,0x94D86BC0,0xB75C8641}}
+		Quat %LocalRotation{f{0xBCF5CABD,0x022B46BF,0x6C5B18BF,0xE75444BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBEA0963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5379141206337828754,16414281310650220170}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9917932261116855212,15697180238845442747}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x34956941,0xCF9E3742,0x771B6F41}}
+		Quat %LocalRotation{f{0xBFE002BE,0xFDC6CB3E,0xC07691BE,0xE5E45CBF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2C55AA3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4760735591723797594,16483496611342605886}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16873570182955127797,16490612677100388249}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2965617164024602639,15773511605295610826}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x44BCA2C2,0x55B01842,0x731CC3C1}}
+		Quat %LocalRotation{f{0xACF230BF,0xF801053F,0xC84BB0BD,0x0F5EFDBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x2422743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1778951922297015896,16594003180481599629}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15020747820396288919,16629619276506690573}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1112794801465763761,15912518204701913150}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x06C4853F,0xAD993F42,0x07248541}}
+		Quat %LocalRotation{f{0x3BB210BF,0x099537BF,0x781AC8BE,0xD229EEBD}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xBEA0963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1525715790562675120,16650489497234074134}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6064506845341701578,15933388425429296711}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x218294C2,0xB2148A42,0x04D64A42}}
+		Quat %LocalRotation{f{0xE636163F,0x7270D6BD,0x4EDDE8BE,0xA46629BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xB339963F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3588085813258680510,16675255055590469180}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8126876868037706968,15958153983785691757}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x12CD8342,0x3548E042,0x9B298642}}
+		Quat %LocalRotation{f{0xF877BEBE,0x5648323F,0x81DAE13E,0x6071DA3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xC2ED4F40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10121685218494662578,16678446579428750476}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14660476273273689036,15961345507623973053}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x6D0C64C2,0x3941E842,0xA6C98D42}}
+		Quat %LocalRotation{f{0x4125F5BE,0x72DE083E,0x94CE443F,0xE2FDCD3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x5EDD923F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15366463137308974153,16708033067721143500}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17490227064866430921,16813114703560564922}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12619187280444825064,16869390342223424982}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10493147675000008066,16894208419795729210}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15031938729779034524,16177107347990951787}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x1A3044C2,0xA684DA42,0x8793AD42}}
+		Quat %LocalRotation{f{0x64AE79BF,0x94D1EFBD,0x50B3E33D,0x23391A3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3B579E3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11703951223777219070,17027306516063191018}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{879125234361830510,17180946557471647948}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7124201514097319314,17188751380598362038}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{221944536944771136,17200597683147383309}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4760735591723797594,16483496611342605886}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xA1AE11C3,0x478CD042,0xC75AAA42}}
+		Quat %LocalRotation{f{0x6E207ABE,0x843F78BD,0x8193DE3D,0x6B3176BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x3AA1853F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15686904941227541054,17311104252286377052}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1778951922297015896,16594003180481599629}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x97CA0D42,0x4C542943,0x08A60043}}
+		Quat %LocalRotation{f{0x168AE03E,0xE2A08B3E,0x48E8413C,0x05335BBF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x54229B3F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{1061621546796169315,17337158459486748725}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10827672082529947695,17425134139525920923}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15366463137308974153,16708033067721143500}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x29ACEEC1,0x896BD6C0,0x908308C2}}
+		Quat %LocalRotation{f{0xAF6A7CBF,0xF65A0EBE,0x3C4A5E3D,0xC842983D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x68823F40}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12951436010087404463,17530215775365342345}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17490227064866430921,16813114703560564922}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x80D00642,0xBE81E542,0x8D778842}}
+		Quat %LocalRotation{f{0xF5B8233F,0x924AA4BE,0x76CDB9BE,0xA0D018BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xC2AB8940}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9159945090566379328,17583425866547445491}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8080396225665798606,17586491414028202405}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12619187280444825064,16869390342223424982}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC8109EC2,0x9E39B642,0xD4BBAF42}}
+		Quat %LocalRotation{f{0x84C9E6BD,0x15A8DBBD,0x105268BF,0x40C5C73E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0DA7913F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{7165160168998192612,17744407587867968441}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11703951223777219070,17027306516063191018}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7951AAC2,0x11FAD542,0x874CAD42}}
+		Quat %LocalRotation{f{0x70E047BF,0x06A856BE,0x1A84113F,0x7A7D1CBE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x413C743F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{9477364054441820055,17886499822752316359}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14787078253292355668,17898047629276425371}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{879125234361830510,17180946557471647948}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x296FEDC0,0x728AD142,0x2ADAA842}}
+		Quat %LocalRotation{f{0x402C97BE,0x372AA9BE,0x8045CABE,0x88024E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x78F0A13F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{2585410459318292856,17905852452403139461}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7124201514097319314,17188751380598362038}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0200803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14969574565726694473,18054259531291526148}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{1061621546796169315,17337158459486748725}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xEBFC9AC1,0x5583EC42,0x87189042}}
+		Quat %LocalRotation{f{0x2C3F8FBE,0x6FE15C3E,0x6C26CABE,0x7C1E593F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xE9E0A53F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{873577503428150071,18094388865390629942}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2891006241650862656,18144460908412522800}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5119144469180358190,18163522087541198681}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e86d240a-1508-4047-9c7a-61520fcf88cc }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4621154035787352870,18300526938352222914}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9159945090566379328,17583425866547445491}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE7CC40C1,0x2212D742,0x64F29642}}
+		Quat %LocalRotation{f{0x402C97BE,0x372AA9BE,0x8045CABE,0x88024E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x78F0A13F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{18145823255500990886,658922949661762930}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5071404559084149669,954820518351224209}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezFogComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{6914292285925798136,1108246313736053318}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12741513019009579696,2118083688060841630}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectionProbeMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5827458717401089751,2275458197221607663}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDirectionVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16469864444959171961,3022549874696704488}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltSteppingMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15272284220582915620,3290797833852729302}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCameraMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7820485296958179223,3350581541134417921}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginAi"}
+		VarArray %Properties{}
+		s %TypeName{"ezAiVoxelGridComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1168477127324465164,3417260966341483024}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPrefabReferenceComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{17523044089822028024,3521005166208929094}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCategoryAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9274987833270370026,4800691691683468795}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSpawnComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{11135730192525964575,4819325472927372842}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Editing"}
+	}
+}
+o
+{
+	Uuid %id{u4{5195345338716098525,5056385137718360950}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneLayerBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5837165590562654431,6019321076980052009}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneLayerBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneLayer"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18327411855245510474,6668321287849544166}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAnchor"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14561188410025902030,6776644216668443091}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDirectionalLightVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13649880205026559927,7297274558339895637}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObject"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{450943844669591006,7318511461061204347}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneDocumentSettingsBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettings"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{13162694393189465755,7325693197096097703}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginAi"}
+		VarArray %Properties{}
+		s %TypeName{"ezAiVoxelPathTestComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{11005437603101136476,7368533338987833088}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBitflagsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12167789330672921810,7954763302097546239}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSettingsComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltSettingsComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{8781371220448777178,8391987746845008996}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSkyBoxComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8760458049236453716,8881392678316352754}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezConeVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3251891958765718680,9159887340540620231}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezDocumentRoot"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentRoot"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{14543630447052729839,9459039542380974471}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezObjectMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16508388108942581257,9601460247128054931}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCameraComponent"}
+		u3 %TypeVersion{11}
+	}
+}
+o
+{
+	Uuid %id{u4{8228401658076077542,9903301473102603301}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCameraVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14619222012368174598,9914418461412086272}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezLightComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDirectionalLightComponent"}
+		u3 %TypeVersion{5}
+	}
+}
+o
+{
+	Uuid %id{u4{5175953824557395014,10566581888453829842}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezConeAngleManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17733595291106647553,10998690428477627554}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBoxVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14700230518358869173,11472901527618371423}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettingsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14929650074649117491,12034915874076129355}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSettingsComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16777871838542487558,12116962178824346014}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezRenderComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12548802506357991701,12127202460150289855}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11135730192525964575,4819325472927372842}}
+		}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEnginePluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezShapeIconComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9604010176759229512,12868035041842190965}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPropertyAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12814930320360971966,14780945004767832345}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezLightComponent"}
+		u3 %TypeVersion{6}
+	}
+}
+o
+{
+	Uuid %id{u4{9327907810903036587,14925289355879257238}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSettingsComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSkyLightComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18075037991921780250,16373560435556338007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14469700887475489738,16951777026318265606}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBasisAxis"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17965579125706971693,17079293274319994058}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCameraUsageHint"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Scenes/VoxelAi_data/Hunter.ezPrefab
+++ b/Data/Samples/Testing Chambers/Scenes/VoxelAi_data/Hunter.ezPrefab
@@ -1,0 +1,1086 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{13606272058858474412,5483788108129816089}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Prefab"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{13606272058858474412,5483788108129816089}}
+		u4 %Hash{13699317154053598318}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{8150991766768770418,17025925912514406868}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 539b683d-a71e-40f3-8834-b4cc4a553998 }"}
+			s{"{ 5451b35f-d73c-402e-a540-c542d3e52be0 }"}
+			s{"{ 66eac2eb-5265-4ffe-88f6-1bf98fd85300 }"}
+			s{"{ ad417552-5eb2-4bec-81d8-3960872cd7db }"}
+			s{"{ df645de1-e23c-42d7-a6ae-03874af6223e }"}
+		}
+		VarArray %References
+		{
+			s{"{ 66eac2eb-5265-4ffe-88f6-1bf98fd85300 }"}
+			s{"{ ad417552-5eb2-4bec-81d8-3960872cd7db }"}
+		}
+		s %Tags{""}
+	}
+}
+o
+{
+	Uuid %id{u4{8150991766768770418,17025925912514406868}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters
+		{
+			Uuid{u4{5135294975067951162,17700310035375520073}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5135294975067951162,17700310035375520073}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		b %DefaultValue{0}
+		s %Name{"ShowDebugInfo"}
+		s %Type{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{4125980421196431378,559235602475292111}}
+	s %t{"ezScriptComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		b %HandleGlobalEvents{0}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{0}
+		}
+		b %PassThroughUnhandledEvents{0}
+		s %ScriptClass{"{ df645de1-e23c-42d7-a6ae-03874af6223e }"}
+		Time %UpdateInterval{d{0}}
+		b %UpdateOnlyWhenSimulating{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14969317091821892762,4658641618720113977}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0xDF98073D,0x0000803F,0,0x0000803F}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		VarArray %Materials{}
+		s %Mesh{"{ ad417552-5eb2-4bec-81d8-3960872cd7db }"}
+		f %SortingDepthOffset{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14367182642350034561,4910213258770901023}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{16826106371207424600,10078871490340165754}}
+			Uuid{u4{10004883711012009371,5172803924766645168}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Gun"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13352597756551650223,4919720521958607856}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{12257454435253056682,5440448564465434522}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCDCC4CBE,0,0xCDCC4C3E}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10004883711012009371,5172803924766645168}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3860702493726004107,5716660241226282861}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCDCCCC3F,0x9A9959C0,0xCDCC4CBF}}
+		Quat %LocalRotation{f{0,0,0x3EAA323D,0xA0C17F3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{16330649098076699294,5195851883782787515}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14969317091821892762,4658641618720113977}}
+			Uuid{u4{12425257264781878969,5612427354627819916}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xCDCCCC3D}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14779844208755174031,5336328300547643008}}
+	s %t{"ezFmodEventComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		b %NoGlobalPitch{0}
+		u1 %OcclusionCollisionLayer{0}
+		f %OcclusionThreshold{0x0000003F}
+		s %OnFinishedAction{"ezOnComponentFinishedAction::None"}
+		b %Paused{0}
+		f %Pitch{0x9A99193F}
+		b %ShowDebugInfo{0}
+		s %SoundEvent{"{ 5451b35f-d73c-402e-a540-c542d3e52be0 }"}
+		b %UseOcclusion{0}
+		f %Volume{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{3239618440592907436,5432095516361583472}}
+	s %t{"ezExposedSceneProperty"}
+	u3 %v{1}
+	p
+	{
+		s %Name{"ShowDebugInfo"}
+		Uuid %Object{u4{4125980421196431378,559235602475292111}}
+		s %PropertyPath{"Parameters[ShowDebugInfo]"}
+	}
+}
+o
+{
+	Uuid %id{u4{12257454435253056682,5440448564465434522}}
+	s %t{"ezPointLightComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		b %CastShadows{0}
+		f %ConstantBias{0xCDCCCC3D}
+		ColorGamma %EffectiveColor{u1{255,255,255,255}}
+		f %Intensity{0x00004842}
+		f %Length{0}
+		ColorGamma %LightColor{u1{66,255,59,255}}
+		f %PenumbraSize{0xCDCC4C3D}
+		f %Radius{0}
+		f %Range{0}
+		f %ShadowFadeOutRange{0}
+		f %SlopeBias{0x0000803E}
+		f %SpecularMultiplier{0x0000803F}
+		u3 %Temperature{6550}
+		b %TransparentShadows{0}
+		b %UseColorTemperature{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12425257264781878969,5612427354627819916}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		VarArray %Materials{}
+		s %Mesh{"{ 66eac2eb-5265-4ffe-88f6-1bf98fd85300 }"}
+		f %SortingDepthOffset{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3860702493726004107,5716660241226282861}}
+	s %t{"ezSpawnComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %AttachAsChild{0}
+		Time %DelayRange{d{0}}
+		Angle %Deviation{f{0x5077563D}}
+		Time %MinDelay{d{0x000000000000E03F}}
+		VarDict %Parameters{}
+		s %Prefab{"{ 539b683d-a71e-40f3-8834-b4cc4a553998 }"}
+		b %SpawnAtStart{1}
+		b %SpawnContinuously{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14128755067403301539,5717501501561570591}}
+	s %t{"ezPrefabDocumentSettings"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ExposedProperties
+		{
+			Uuid{u4{3239618440592907436,5432095516361583472}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezSceneDocumentRoot"}
+	u3 %v{2}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{13832384316238430026,12801859964305302754}}
+		}
+		Uuid %Settings{u4{14128755067403301539,5717501501561570591}}
+	}
+}
+o
+{
+	Uuid %id{u4{16826106371207424600,10078871490340165754}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10681925153921419336,10622727806799803447}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCACCCC3F,0x98995940,0xCBCC4CBF}}
+		Quat %LocalRotation{f{0,0,0x3EAA32BD,0xA0C17F3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10681925153921419336,10622727806799803447}}
+	s %t{"ezSpawnComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %AttachAsChild{0}
+		Time %DelayRange{d{0}}
+		Angle %Deviation{f{0x5077563D}}
+		Time %MinDelay{d{0x000000000000E03F}}
+		VarDict %Parameters{}
+		s %Prefab{"{ 539b683d-a71e-40f3-8834-b4cc4a553998 }"}
+		b %SpawnAtStart{1}
+		b %SpawnContinuously{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13832384316238430026,12801859964305302754}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{16330649098076699294,5195851883782787515}}
+			Uuid{u4{13352597756551650223,4919720521958607856}}
+			Uuid{u4{14367182642350034561,4910213258770901023}}
+		}
+		VarArray %Components
+		{
+			Uuid{u4{10165059359542952217,18296316791441185422}}
+			Uuid{u4{15917429796719960803,18401799724584839126}}
+			Uuid{u4{4125980421196431378,559235602475292111}}
+			Uuid{u4{14779844208755174031,5336328300547643008}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"<Prefab-Root>"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{10165059359542952217,18296316791441185422}}
+	s %t{"ezAiVoxelNavigationComponent"}
+	u3 %v{5}
+	p
+	{
+		f %Acceleration{0x0000C841}
+		b %Active{1}
+		b %ApplySteering{1}
+		f %BankAmount{0x000040C0}
+		f %CorridorCorrectionRate{0x00000040}
+		s %DebugFlags{"ezAiVoxelNavigationDebugFlags::PrintState|ezAiVoxelNavigationDebugFlags::VisPath"}
+		f %Deceleration{0x0000F041}
+		f %LookAheadDistance{0x00007041}
+		Angle %MaxAngularSpeed{f{0x920A0640}}
+		Angle %MaxBankAngle{f{0xDB0F493F}}
+		f %MaxPathOffset{0x00002041}
+		s %NavigationTarget{""}
+		f %ReachedDistance{0x00002041}
+		f %Speed{0x0000B041}
+	}
+}
+o
+{
+	Uuid %id{u4{15917429796719960803,18401799724584839126}}
+	s %t{"ezMarkerComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		s %Marker{"Hunter"}
+		f %Radius{0x0000A040}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{18145823255500990886,658922949661762930}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6914292285925798136,1108246313736053318}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8577194213068516669,1439152778878942207}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMarkerComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7306866003362116324,1480773640113041639}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezFmodComponent"}
+		s %PluginName{"ezEditorPluginFmod"}
+		VarArray %Properties{}
+		s %TypeName{"ezFmodEventComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{5827458717401089751,2275458197221607663}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDirectionVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11638255232360359673,3108610646416571142}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezExposedSceneProperty"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14332645745114734426,3197497487504472660}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneDocumentSettingsBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezPrefabDocumentSettings"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14633628111157529947,3328384510238863063}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezMeshComponentBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{13180226495177211365,3486873224131216715}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEventMessageHandlerComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezScriptComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{17523044089822028024,3521005166208929094}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCategoryAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9274987833270370026,4800691691683468795}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSpawnComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{5109955776826617296,6026817826851389185}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEventMessageHandlerComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{18327411855245510474,6668321287849544166}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAnchor"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7605758958972330253,6687734095884105025}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponentBase"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{13649880205026559927,7297274558339895637}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObject"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11005437603101136476,7368533338987833088}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBitflagsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8760458049236453716,8881392678316352754}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezConeVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3251891958765718680,9159887340540620231}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezDocumentRoot"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentRoot"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{1975187931105783413,9436176493045113306}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObjectHandle"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14543630447052729839,9459039542380974471}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezObjectMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1059777785414581172,10096107093115669027}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginFmod"}
+		VarArray %Properties{}
+		s %TypeName{"ezFmodComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5175953824557395014,10566581888453829842}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezConeAngleManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14700230518358869173,11472901527618371423}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettingsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2869469983493172804,11764438314605031013}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezOnComponentFinishedAction"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13157915159061735959,12012078319048480294}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezLightComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPointLightComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{16777871838542487558,12116962178824346014}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezRenderComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9604010176759229512,12868035041842190965}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPropertyAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17338863546649435593,13192242791875444156}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPointLightVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12814930320360971966,14780945004767832345}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezLightComponent"}
+		u3 %TypeVersion{6}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18075037991921780250,16373560435556338007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15796815132701145913,16426079668733115146}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15209786411787426442,16782334254511558095}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginAi"}
+		VarArray %Properties{}
+		s %TypeName{"ezAiVoxelNavigationComponent"}
+		u3 %TypeVersion{5}
+	}
+}
+o
+{
+	Uuid %id{u4{14469700887475489738,16951777026318265606}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBasisAxis"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14207082430471941233,17000358661146427261}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6074073907547097165,17887383365336627774}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"ezEditorPluginAi"}
+		VarArray %Properties{}
+		s %TypeName{"ezAiVoxelNavigationDebugFlags"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Scenes/VoxelAi_data/Prey.ezPrefab
+++ b/Data/Samples/Testing Chambers/Scenes/VoxelAi_data/Prey.ezPrefab
@@ -1,0 +1,1122 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{10056465815060854913,4878055157009074052}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Prefab"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{10056465815060854913,4878055157009074052}}
+		u4 %Hash{10008101256517026674}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{10134795862493884603,10855970841238033761}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 5451b35f-d73c-402e-a540-c542d3e52be0 }"}
+			s{"{ 72115f7a-5947-4a21-899f-868368bd41d7 }"}
+			s{"{ bd206a4c-51b4-4b73-93ce-7d6316cd14c4 }"}
+			s{"{ c75fd9fb-43d7-4023-a5c0-ccb045a9fd76 }"}
+		}
+		VarArray %References
+		{
+			s{"{ c75fd9fb-43d7-4023-a5c0-ccb045a9fd76 }"}
+		}
+		s %Tags{""}
+	}
+}
+o
+{
+	Uuid %id{u4{10134795862493884603,10855970841238033761}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters
+		{
+			Uuid{u4{6672720812875048425,17630670100342587929}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{6672720812875048425,17630670100342587929}}
+	s %t{"ezExposedParameter"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		b %DefaultValue{0}
+		s %Name{"ShowDebugInfo"}
+		s %Type{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{16466001873843383542,155403907647483730}}
+	s %t{"ezScriptComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		b %HandleGlobalEvents{0}
+		VarDict %Parameters
+		{
+			b %ShowDebugInfo{0}
+		}
+		b %PassThroughUnhandledEvents{0}
+		s %ScriptClass{"{ bd206a4c-51b4-4b73-93ce-7d6316cd14c4 }"}
+		Time %UpdateInterval{d{0}}
+		b %UpdateOnlyWhenSimulating{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15482374815228112554,4947689173245498325}}
+	s %t{"ezFmodEventComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		b %NoGlobalPitch{0}
+		u1 %OcclusionCollisionLayer{0}
+		f %OcclusionThreshold{0x0000003F}
+		s %OnFinishedAction{"ezOnComponentFinishedAction::None"}
+		b %Paused{0}
+		f %Pitch{0x6666A63F}
+		b %ShowDebugInfo{0}
+		s %SoundEvent{"{ 5451b35f-d73c-402e-a540-c542d3e52be0 }"}
+		b %UseOcclusion{0}
+		f %Volume{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{5875418770357532346,4996830267798537556}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11917857706975296418,5749317488983347169}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0xCDCCCC3D}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3187889121148106166,5083001648337337649}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15188319616488702616,5360846915404808421}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9A9959C0,0,0xCECCCC3E}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14368749138969868966,5161500431746669519}}
+	s %t{"ezJoltDynamicActorComponent"}
+	u3 %v{8}
+	p
+	{
+		b %Active{1}
+		b %AllowSleeping{1}
+		f %AngularDamping{0xCDCC4C3E}
+		f %BuoyancyFactor{0xCDCC8C3F}
+		Vec3 %CenterOfMass{f{0,0,0}}
+		u1 %CollisionLayer{0}
+		b %ContinuousCollisionDetection{0}
+		b %CustomCenterOfMass{0}
+		f %Density{0x0000C842}
+		f %GravityFactor{0x0000803F}
+		b %Kinematic{1}
+		f %LinearDamping{0xCDCC4C3E}
+		f %Mass{0x00002041}
+		s %OnContact{""}
+		b %StartAsleep{0}
+		s %Surface{"{ 72115f7a-5947-4a21-899f-868368bd41d7 }"}
+		u1 %WeightCategory{0}
+		f %WeightScale{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{538214464406192816,5234845818878707775}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{14368749138969868966,5161500431746669519}}
+			Uuid{u4{5429067473435031441,5289852783360965596}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0xF304353F,0,0xF304353F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5429067473435031441,5289852783360965596}}
+	s %t{"ezJoltShapeCylinderComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		f %Height{0x0000E040}
+		f %Radius{0x00000040}
+	}
+}
+o
+{
+	Uuid %id{u4{15188319616488702616,5360846915404808421}}
+	s %t{"ezPointLightComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		b %CastShadows{0}
+		f %ConstantBias{0xCDCCCC3D}
+		ColorGamma %EffectiveColor{u1{255,255,255,255}}
+		f %Intensity{0x00004842}
+		f %Length{0x00000040}
+		ColorGamma %LightColor{u1{51,235,255,255}}
+		f %PenumbraSize{0xCDCC4C3D}
+		f %Radius{0x3D0A573E}
+		f %Range{0}
+		f %ShadowFadeOutRange{0}
+		f %SlopeBias{0x0000803E}
+		f %SpecularMultiplier{0}
+		u3 %Temperature{6550}
+		b %TransparentShadows{0}
+		b %UseColorTemperature{0}
+	}
+}
+o
+{
+	Uuid %id{u4{401351948169285522,5418591697787330556}}
+	s %t{"ezExposedSceneProperty"}
+	u3 %v{1}
+	p
+	{
+		s %Name{"ShowDebugInfo"}
+		Uuid %Object{u4{16466001873843383542,155403907647483730}}
+		s %PropertyPath{"Parameters[ShowDebugInfo]"}
+	}
+}
+o
+{
+	Uuid %id{u4{11917857706975296418,5749317488983347169}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x6319173D,0x8959F73E,0x0000803F,0x0000803F}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		VarArray %Materials{}
+		s %Mesh{"{ c75fd9fb-43d7-4023-a5c0-ccb045a9fd76 }"}
+		f %SortingDepthOffset{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2862066356846981310,5764241357456551925}}
+	s %t{"ezPrefabDocumentSettings"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ExposedProperties
+		{
+			Uuid{u4{401351948169285522,5418591697787330556}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezSceneDocumentRoot"}
+	u3 %v{2}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{990127621898115092,12306747505358774604}}
+		}
+		Uuid %Settings{u4{2862066356846981310,5764241357456551925}}
+	}
+}
+o
+{
+	Uuid %id{u4{18403753625828020801,9905316129259212650}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11957440047459065635,10183161396326683422}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x000080BF,0,0xB4CC4CBE}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11957440047459065635,10183161396326683422}}
+	s %t{"ezPointLightComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		b %CastShadows{0}
+		f %ConstantBias{0xCDCCCC3D}
+		ColorGamma %EffectiveColor{u1{255,255,255,255}}
+		f %Intensity{0x00004842}
+		f %Length{0}
+		ColorGamma %LightColor{u1{254,155,155,255}}
+		f %PenumbraSize{0xCDCC4C3D}
+		f %Radius{0}
+		f %Range{0}
+		f %ShadowFadeOutRange{0}
+		f %SlopeBias{0x0000803E}
+		f %SpecularMultiplier{0x0000803F}
+		u3 %Temperature{6550}
+		b %TransparentShadows{0}
+		b %UseColorTemperature{0}
+	}
+}
+o
+{
+	Uuid %id{u4{990127621898115092,12306747505358774604}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{3187889121148106166,5083001648337337649}}
+			Uuid{u4{18403753625828020801,9905316129259212650}}
+			Uuid{u4{5875418770357532346,4996830267798537556}}
+			Uuid{u4{538214464406192816,5234845818878707775}}
+		}
+		VarArray %Components
+		{
+			Uuid{u4{15771705246605106901,18423748970861364448}}
+			Uuid{u4{16466001873843383542,155403907647483730}}
+			Uuid{u4{13225573392848444618,18096444525933964277}}
+			Uuid{u4{15482374815228112554,4947689173245498325}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"<Prefab-Root>"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13225573392848444618,18096444525933964277}}
+	s %t{"ezMarkerComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		s %Marker{"Prey"}
+		f %Radius{0x0000A040}
+	}
+}
+o
+{
+	Uuid %id{u4{15771705246605106901,18423748970861364448}}
+	s %t{"ezAiVoxelNavigationComponent"}
+	u3 %v{5}
+	p
+	{
+		f %Acceleration{0x00007041}
+		b %Active{1}
+		b %ApplySteering{1}
+		f %BankAmount{0x000080C0}
+		f %CorridorCorrectionRate{0x0000803F}
+		s %DebugFlags{"ezAiVoxelNavigationDebugFlags::PrintState|ezAiVoxelNavigationDebugFlags::VisPath"}
+		f %Deceleration{0x0000A041}
+		f %LookAheadDistance{0x0000A041}
+		Angle %MaxAngularSpeed{f{0x368D2740}}
+		Angle %MaxBankAngle{f{0x920A863F}}
+		f %MaxPathOffset{0x00002041}
+		s %NavigationTarget{""}
+		f %ReachedDistance{0x0000A040}
+		f %Speed{0x0000D041}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{18145823255500990886,658922949661762930}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6914292285925798136,1108246313736053318}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8577194213068516669,1439152778878942207}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMarkerComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7306866003362116324,1480773640113041639}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezFmodComponent"}
+		s %PluginName{"ezEditorPluginFmod"}
+		VarArray %Properties{}
+		s %TypeName{"ezFmodEventComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{11638255232360359673,3108610646416571142}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezExposedSceneProperty"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14332645745114734426,3197497487504472660}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneDocumentSettingsBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezPrefabDocumentSettings"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14633628111157529947,3328384510238863063}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezMeshComponentBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{13180226495177211365,3486873224131216715}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEventMessageHandlerComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezScriptComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{17523044089822028024,3521005166208929094}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCategoryAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5109955776826617296,6026817826851389185}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEventMessageHandlerComponent"}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{11949321329899225443,6280821367752645242}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltShapeComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18327411855245510474,6668321287849544166}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAnchor"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7605758958972330253,6687734095884105025}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshComponentBase"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{13649880205026559927,7297274558339895637}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObject"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11005437603101136476,7368533338987833088}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBitflagsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6833120855194064360,7616979191365721209}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezJoltActorComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltDynamicActorComponent"}
+		u3 %TypeVersion{8}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3251891958765718680,9159887340540620231}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezDocumentRoot"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentRoot"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{1975187931105783413,9436176493045113306}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObjectHandle"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14543630447052729839,9459039542380974471}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezObjectMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{455663516835322266,10016785433957589977}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezTransformManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1059777785414581172,10096107093115669027}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginFmod"}
+		VarArray %Properties{}
+		s %TypeName{"ezFmodComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14700230518358869173,11472901527618371423}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettingsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2869469983493172804,11764438314605031013}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezOnComponentFinishedAction"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13157915159061735959,12012078319048480294}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezLightComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPointLightComponent"}
+		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{16777871838542487558,12116962178824346014}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezRenderComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6839391121561780669,12349512622905798822}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltActorComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{9604010176759229512,12868035041842190965}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPropertyAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17338863546649435593,13192242791875444156}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPointLightVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12814930320360971966,14780945004767832345}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezLightComponent"}
+		u3 %TypeVersion{6}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2971759590607246163,15191316629823599218}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCylinderVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7800924204755200005,16261481570329149190}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezJoltShapeComponent"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezJoltShapeCylinderComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18075037991921780250,16373560435556338007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15796815132701145913,16426079668733115146}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15209786411787426442,16782334254511558095}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezEditorPluginAi"}
+		VarArray %Properties{}
+		s %TypeName{"ezAiVoxelNavigationComponent"}
+		u3 %TypeVersion{5}
+	}
+}
+o
+{
+	Uuid %id{u4{14469700887475489738,16951777026318265606}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBasisAxis"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14207082430471941233,17000358661146427261}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13959370910449580650,17446532125027196114}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"ezEditorPluginJolt"}
+		VarArray %Properties{}
+		s %TypeName{"ezOnJoltContact"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6074073907547097165,17887383365336627774}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"ezEditorPluginAi"}
+		VarArray %Properties{}
+		s %TypeName{"ezAiVoxelNavigationDebugFlags"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}


### PR DESCRIPTION
Adds voxel-based 3D pathfinding to the AiPlugin, for objects that move freely through space (flying, underwater, spaceflight) rather than over a navmesh.

<img width="800" height="600" alt="voxel-nav" src="https://github.com/user-attachments/assets/da0f19eb-86b0-4fa6-a49b-a3ac8f9fb436" />

* ezVoxelGrid: occupancy grid stored as packed 4x4x4 bit blocks, filled by rasterizing collision geometry triangles.
* ezAiVoxelNavigation: A* with line-of-sight string-pulling. A search may span multiple disjoint grids; space not covered by any grid is treated as free.
* ezAiVoxelGridComponent / ezAiVoxelWorldModule: place and voxelize grids in a scene, and query them spatially.
* ezAiVoxelNavigationComponent: steers a game object along a path, keeping a voxel-validated path position as ground truth and a free-form, visual position held within a corridor around it.
* ezAiVoxelPathTestComponent: Component for testing 3D paths.
* ezAiSteeringUtils: turning, upright orientation and acceleration helpers shared between the navigation components.

Includes a Testing Chambers sample scene with hunter/prey AngelScript agents.

https://github.com/user-attachments/assets/3b719bf8-0983-416d-bd17-8ebaf5be3ff1

Based on the work of @JailbreakPapa in #1902.