### PR TITLE
Add build-specific plugin package dependencies

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
@@ -142,25 +142,25 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
       m_PackageDependencies[i] = pElement->GetPrimitivesString()[i];
   }
 
-  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDevDependencies"))
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDependenciesDev"))
   {
-    m_PackageDevDependencies.SetCount(pElement->GetNumPrimitives());
+    m_PackageDependenciesDev.SetCount(pElement->GetNumPrimitives());
     for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
-      m_PackageDevDependencies[i] = pElement->GetPrimitivesString()[i];
+      m_PackageDependenciesDev[i] = pElement->GetPrimitivesString()[i];
   }
 
-  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDebugDependencies"))
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDependenciesDebug"))
   {
-    m_PackageDebugDependencies.SetCount(pElement->GetNumPrimitives());
+    m_PackageDependenciesDebug.SetCount(pElement->GetNumPrimitives());
     for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
-      m_PackageDebugDependencies[i] = pElement->GetPrimitivesString()[i];
+      m_PackageDependenciesDebug[i] = pElement->GetPrimitivesString()[i];
   }
 
-  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageShippingDependencies"))
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDependenciesShipping"))
   {
-    m_PackageShippingDependencies.SetCount(pElement->GetNumPrimitives());
+    m_PackageDependenciesShipping.SetCount(pElement->GetNumPrimitives());
     for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
-      m_PackageShippingDependencies[i] = pElement->GetPrimitivesString()[i];
+      m_PackageDependenciesShipping[i] = pElement->GetPrimitivesString()[i];
   }
 
   if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "DataDirectories"))

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
@@ -142,6 +142,20 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
       m_PackageDependencies[i] = pElement->GetPrimitivesString()[i];
   }
 
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDevDebugDependencies"))
+  {
+    m_PackageDevDebugDependencies.SetCount(pElement->GetNumPrimitives());
+    for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
+      m_PackageDevDebugDependencies[i] = pElement->GetPrimitivesString()[i];
+  }
+
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageShippingDependencies"))
+  {
+    m_PackageShippingDependencies.SetCount(pElement->GetNumPrimitives());
+    for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
+      m_PackageShippingDependencies[i] = pElement->GetPrimitivesString()[i];
+  }
+  
   if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "DataDirectories"))
   {
     m_DataDirectories.SetCount(pElement->GetNumPrimitives());

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
@@ -142,11 +142,18 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
       m_PackageDependencies[i] = pElement->GetPrimitivesString()[i];
   }
 
-  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDevDebugDependencies"))
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDevDependencies"))
   {
-    m_PackageDevDebugDependencies.SetCount(pElement->GetNumPrimitives());
+    m_PackageDevDependencies.SetCount(pElement->GetNumPrimitives());
     for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
-      m_PackageDevDebugDependencies[i] = pElement->GetPrimitivesString()[i];
+      m_PackageDevDependencies[i] = pElement->GetPrimitivesString()[i];
+  }
+
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageDebugDependencies"))
+  {
+    m_PackageDebugDependencies.SetCount(pElement->GetNumPrimitives());
+    for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
+      m_PackageDebugDependencies[i] = pElement->GetPrimitivesString()[i];
   }
 
   if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "PackageShippingDependencies"))
@@ -155,7 +162,7 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
     for (ezUInt32 i = 0; i < pElement->GetNumPrimitives(); ++i)
       m_PackageShippingDependencies[i] = pElement->GetPrimitivesString()[i];
   }
-  
+
   if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "DataDirectories"))
   {
     m_DataDirectories.SetCount(pElement->GetNumPrimitives());

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
@@ -32,9 +32,9 @@ struct EZ_EDITORFRAMEWORK_DLL ezPluginBundle
   ezHybridArray<ezString, 1> m_EditorEnginePlugins;         ///< List of all the DLLs to load into the editor's engine process.
   ezHybridArray<ezString, 1> m_RuntimePlugins;              ///< List of all the DLLs to load into the runtime. These will also get packaged.
   ezHybridArray<ezString, 1> m_PackageDependencies;         ///< Additional files to include in packages. E.g. indirect DLL dependencies.
-  ezHybridArray<ezString, 1> m_PackageDevDependencies;      ///< Additional files to include in packages only for Dev builds. E.g. indirect DLL dependencies specific to Dev builds.
-  ezHybridArray<ezString, 1> m_PackageDebugDependencies;    ///< Additional files to include in packages only for Debug builds. E.g. indirect DLL dependencies specific to Debug builds.
-  ezHybridArray<ezString, 1> m_PackageShippingDependencies; ///< Additional files to include in packages only for Shipping builds. E.g. indirect DLL dependencies specific to Shipping builds.
+  ezHybridArray<ezString, 1> m_PackageDependenciesDev;      ///< Additional files to include in packages only for Dev builds. E.g. indirect DLL dependencies specific to Dev builds.
+  ezHybridArray<ezString, 1> m_PackageDependenciesDebug;    ///< Additional files to include in packages only for Debug builds. E.g. indirect DLL dependencies specific to Debug builds.
+  ezHybridArray<ezString, 1> m_PackageDependenciesShipping; ///< Additional files to include in packages only for Shipping builds. E.g. indirect DLL dependencies specific to Shipping builds.
   ezHybridArray<ezString, 1> m_DataDirectories;             ///< Special-directory paths (e.g. ">sdk/Data/Plugins/KrautPlugin") to mount as data directories when this bundle is active.
   ezHybridArray<ezString, 1> m_RequiredBundles;             ///< The file names (without path or extension) of other bundles that are required for this bundle to work.
   ezHybridArray<ezString, 1> m_ExclusiveFeatures;           ///< If two bundles have the same string in this list, they can't be activated at the same time. So for example only one bundle with the feature 'Sound' or 'Physics' may be activated simultaneously. Only enforced by the UI.

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
@@ -32,8 +32,9 @@ struct EZ_EDITORFRAMEWORK_DLL ezPluginBundle
   ezHybridArray<ezString, 1> m_EditorEnginePlugins;         ///< List of all the DLLs to load into the editor's engine process.
   ezHybridArray<ezString, 1> m_RuntimePlugins;              ///< List of all the DLLs to load into the runtime. These will also get packaged.
   ezHybridArray<ezString, 1> m_PackageDependencies;         ///< Additional files to include in packages. E.g. indirect DLL dependencies.
-  ezHybridArray<ezString, 1> m_PackageDevDebugDependencies; ///< Additional files to include in packages only for Dev and Debug builds. E.g. indirect DLL dependencies specific to Dev/Debug builds.
-  ezHybridArray<ezString, 1> m_PackageShippingDependencies; ///< Additional files to include in packages only for Shipping builds. E.g. indirect DLL dependencies indirect DLL specific to Shipping builds.
+  ezHybridArray<ezString, 1> m_PackageDevDependencies;      ///< Additional files to include in packages only for Dev builds. E.g. indirect DLL dependencies specific to Dev builds.
+  ezHybridArray<ezString, 1> m_PackageDebugDependencies;    ///< Additional files to include in packages only for Debug builds. E.g. indirect DLL dependencies specific to Debug builds.
+  ezHybridArray<ezString, 1> m_PackageShippingDependencies; ///< Additional files to include in packages only for Shipping builds. E.g. indirect DLL dependencies specific to Shipping builds.
   ezHybridArray<ezString, 1> m_DataDirectories;             ///< Special-directory paths (e.g. ">sdk/Data/Plugins/KrautPlugin") to mount as data directories when this bundle is active.
   ezHybridArray<ezString, 1> m_RequiredBundles;             ///< The file names (without path or extension) of other bundles that are required for this bundle to work.
   ezHybridArray<ezString, 1> m_ExclusiveFeatures;           ///< If two bundles have the same string in this list, they can't be activated at the same time. So for example only one bundle with the feature 'Sound' or 'Physics' may be activated simultaneously. Only enforced by the UI.

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
@@ -24,19 +24,21 @@ struct EZ_EDITORFRAMEWORK_DLL ezPluginBundle
   ezTimestamp m_LastModificationTime;
 
   // General Bundle Description
-  bool m_bMandatory = false;                        ///< if set, the bundle is always used and not even displayed in the UI
-  bool m_bAllowEnableReload = false;                ///< If false, the "Enable Reload" option is not available for this bundle. Only set to true for plugins that are loaded purely dynamically at runtime and not linked against directly.
-  ezString m_sDisplayName;                          ///< The string for displaying the bundle in UI
-  ezString m_sDescription;                          ///< A proper description what this bundle is for, so that users know when to use it.
-  ezHybridArray<ezString, 1> m_EditorPlugins;       ///< List of all the DLLs (without extension) to load into the editor process.
-  ezHybridArray<ezString, 1> m_EditorEnginePlugins; ///< List of all the DLLs to load into the editor's engine process.
-  ezHybridArray<ezString, 1> m_RuntimePlugins;      ///< List of all the DLLs to load into the runtime. These will also get packaged.
-  ezHybridArray<ezString, 1> m_PackageDependencies; ///< Additional files to include in packages. E.g. indirect DLL dependencies.
-  ezHybridArray<ezString, 1> m_DataDirectories;     ///< Special-directory paths (e.g. ">sdk/Data/Plugins/KrautPlugin") to mount as data directories when this bundle is active.
-  ezHybridArray<ezString, 1> m_RequiredBundles;     ///< The file names (without path or extension) of other bundles that are required for this bundle to work.
-  ezHybridArray<ezString, 1> m_ExclusiveFeatures;   ///< If two bundles have the same string in this list, they can't be activated at the same time. So for example only one bundle with the feature 'Sound' or 'Physics' may be activated simultaneously. Only enforced by the UI.
-  ezHybridArray<ezString, 1> m_EnabledInTemplates;  ///< In which project templates this plugin should be active by default.
-  ezString m_sCMakeTargetName;                      ///< The CMake target name for linking user plugins against this plugin.
+  bool m_bMandatory = false;                                ///< if set, the bundle is always used and not even displayed in the UI
+  bool m_bAllowEnableReload = false;                        ///< If false, the "Enable Reload" option is not available for this bundle. Only set to true for plugins that are loaded purely dynamically at runtime and not linked against directly.
+  ezString m_sDisplayName;                                  ///< The string for displaying the bundle in UI
+  ezString m_sDescription;                                  ///< A proper description what this bundle is for, so that users know when to use it.
+  ezHybridArray<ezString, 1> m_EditorPlugins;               ///< List of all the DLLs (without extension) to load into the editor process.
+  ezHybridArray<ezString, 1> m_EditorEnginePlugins;         ///< List of all the DLLs to load into the editor's engine process.
+  ezHybridArray<ezString, 1> m_RuntimePlugins;              ///< List of all the DLLs to load into the runtime. These will also get packaged.
+  ezHybridArray<ezString, 1> m_PackageDependencies;         ///< Additional files to include in packages. E.g. indirect DLL dependencies.
+  ezHybridArray<ezString, 1> m_PackageDevDebugDependencies; ///< Additional files to include in packages only for Dev and Debug builds. E.g. indirect DLL dependencies specific to Dev/Debug builds.
+  ezHybridArray<ezString, 1> m_PackageShippingDependencies; ///< Additional files to include in packages only for Shipping builds. E.g. indirect DLL dependencies indirect DLL specific to Shipping builds.
+  ezHybridArray<ezString, 1> m_DataDirectories;             ///< Special-directory paths (e.g. ">sdk/Data/Plugins/KrautPlugin") to mount as data directories when this bundle is active.
+  ezHybridArray<ezString, 1> m_RequiredBundles;             ///< The file names (without path or extension) of other bundles that are required for this bundle to work.
+  ezHybridArray<ezString, 1> m_ExclusiveFeatures;           ///< If two bundles have the same string in this list, they can't be activated at the same time. So for example only one bundle with the feature 'Sound' or 'Physics' may be activated simultaneously. Only enforced by the UI.
+  ezHybridArray<ezString, 1> m_EnabledInTemplates;          ///< In which project templates this plugin should be active by default.
+  ezString m_sCMakeTargetName;                              ///< The CMake target name for linking user plugins against this plugin.
 
   /// \brief Reads the bundle description, but not the state.
   ezResult ReadBundleFromDDL(ezOpenDdlReader& ref_ddl);

--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -508,6 +508,17 @@ ezResult ezProjectExport::ExportProject(const char* szTargetDirectory, const ezP
         binariesFilter.AddFilter(dep, true);
       }
 
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+      for (const auto& dep : it.Value().m_PackageDevDebugDependencies)
+      {
+        binariesFilter.AddFilter(dep, true);
+      }
+#else
+      for (const auto& dep : it.Value().m_PackageShippingDependencies)
+      {
+        binariesFilter.AddFilter(dep, true);
+      }
+#endif
       for (const auto& dep : it.Value().m_RuntimePlugins)
       {
         ezStringBuilder tmp = dep;

--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -509,17 +509,17 @@ ezResult ezProjectExport::ExportProject(const char* szTargetDirectory, const ezP
       }
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
-      for (const auto& dep : it.Value().m_PackageDebugDependencies)
+      for (const auto& dep : it.Value().m_PackageDependenciesDebug)
       {
         binariesFilter.AddFilter(dep, true);
       }
 #elif EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-      for (const auto& dep : it.Value().m_PackageDevDependencies)
+      for (const auto& dep : it.Value().m_PackageDependenciesDev)
       {
         binariesFilter.AddFilter(dep, true);
       }
 #else
-      for (const auto& dep : it.Value().m_PackageShippingDependencies)
+      for (const auto& dep : it.Value().m_PackageDependenciesShipping)
       {
         binariesFilter.AddFilter(dep, true);
       }

--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -508,8 +508,13 @@ ezResult ezProjectExport::ExportProject(const char* szTargetDirectory, const ezP
         binariesFilter.AddFilter(dep, true);
       }
 
-#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-      for (const auto& dep : it.Value().m_PackageDevDebugDependencies)
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+      for (const auto& dep : it.Value().m_PackageDebugDependencies)
+      {
+        binariesFilter.AddFilter(dep, true);
+      }
+#elif EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+      for (const auto& dep : it.Value().m_PackageDevDependencies)
       {
         binariesFilter.AddFilter(dep, true);
       }

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
@@ -9,7 +9,8 @@ PluginInfo
 	string %EditorEnginePlugins{"ezEnginePluginRmlUi"}
 	string %RuntimePlugins{"ezRmlUiPlugin"}
 	string %PackageDependencies{"freetype.dll", "RmlCore.dll"}
-	string %PackageDevDebugDependencies{"RmlDebugger.dll"}
+	string %PackageDevDependencies{"RmlDebugger.dll"}
+	string %PackageDebugDependencies{"RmlDebugger.dll"}
 	string %DataDirectories{">sdk/Data/Plugins/RmlUiPlugin"}
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
@@ -9,6 +9,7 @@ PluginInfo
 	string %EditorEnginePlugins{"ezEnginePluginRmlUi"}
 	string %RuntimePlugins{"ezRmlUiPlugin"}
 	string %PackageDependencies{"freetype.dll", "RmlCore.dll"}
+	string %PackageDevDebugDependencies{"RmlDebugger.dll"}
 	string %DataDirectories{">sdk/Data/Plugins/RmlUiPlugin"}
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
@@ -9,8 +9,8 @@ PluginInfo
 	string %EditorEnginePlugins{"ezEnginePluginRmlUi"}
 	string %RuntimePlugins{"ezRmlUiPlugin"}
 	string %PackageDependencies{"freetype.dll", "RmlCore.dll"}
-	string %PackageDevDependencies{"RmlDebugger.dll"}
-	string %PackageDebugDependencies{"RmlDebugger.dll"}
+	string %PackageDependenciesDev{"RmlDebugger.dll"}
+	string %PackageDependenciesDebug{"RmlDebugger.dll"}
 	string %DataDirectories{">sdk/Data/Plugins/RmlUiPlugin"}
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}


### PR DESCRIPTION
Added separate dependency lists for Dev/Debug and Shipping builds. Also added `RmlDebugger.dll` to the RmlUi bundle as a Dev/Debug dependency.
