### PR TITLE
Spline fixes

### DIFF
--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineTangentManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineTangentManipulatorAdapter.cpp
@@ -96,7 +96,10 @@ void ezSplineTangentManipulatorAdapter::UpdateGizmoTransform()
     return;
 
   auto& cp = m_Spline.m_ControlPoints[m_uiNodeIndex];
-  const ezTransform ownerTransform = GetObjectTransform();
+  ezTransform ownerTransform = GetObjectTransform();
+
+  // Remove scale since is does not have any effect on tangents
+  ownerTransform.m_vScale.Set(1.0f);
 
   const ezVec3 forwardDir = m_bIsTangentIn ? ezSimdConversion::ToVec3(cp.m_vPosTangentIn) : ezSimdConversion::ToVec3(cp.m_vPosTangentOut);
   const ezVec3 upDir = ezSimdConversion::ToVec3(cp.m_vUpDirAndRoll);

--- a/Code/Engine/Core/Graphics/Implementation/Spline.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Spline.cpp
@@ -213,13 +213,13 @@ void ezSpline::CalculateUpDirAndAutoTangents(const ezSimdVec4f& vGlobalUpDir, co
 
       const ezSimdVec4f upDir = [&]()
       {
-        if (!forwardDir.IsEqual(vGlobalUpDir, ezMath::HugeEpsilon<float>()).AllSet<3>())
+        if (forwardDir.Dot<3>(vGlobalUpDir).Abs() < 0.99f)
           return vGlobalUpDir;
 
         if (i > 0)
         {
           auto& prevCp = m_ControlPoints[i - 1];
-          if (!forwardDir.IsEqual(prevCp.m_vUpDirAndRoll, ezMath::HugeEpsilon<float>()).AllSet<3>())
+          if (forwardDir.Dot<3>(prevCp.m_vUpDirAndRoll).Abs() < 0.99f)
           {
             return prevCp.m_vUpDirAndRoll;
           }
@@ -237,6 +237,8 @@ void ezSpline::CalculateUpDirAndAutoTangents(const ezSimdVec4f& vGlobalUpDir, co
       cp.m_vUpDirAndRoll.SetW(roll);
       cp.m_vUpDirTangentIn.SetZero();
       cp.m_vUpDirTangentOut.SetZero();
+
+      EZ_ASSERT_DEBUG(cp.m_vUpDirAndRoll.IsValid<4>(), "Invalid up dir");
     }
   }
 

--- a/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
@@ -453,15 +453,15 @@ void ezSplineComponent::UpdateFromNodeObjects()
 
     auto& cp = points.ExpandAndGetRef();
     cp.SetPosition(localNodeTransform.m_Position);
-    cp.SetTangentIn(ezSimdConversion::ToVec3(pNodeComponent->GetCustomTangentIn()), pNodeComponent->GetTangentModeIn());
+    cp.SetTangentIn(pNodeComponent->GetFinalCustomTangentIn(), pNodeComponent->GetTangentModeIn());
 
     if (pNodeComponent->GetLinkCustomTangents() && pNodeComponent->GetTangentModeIn() == ezSplineTangentMode::Custom && pNodeComponent->GetTangentModeOut() == ezSplineTangentMode::Custom)
     {
-      cp.SetTangentOut(ezSimdConversion::ToVec3(-pNodeComponent->GetCustomTangentIn()), pNodeComponent->GetTangentModeOut());
+      cp.SetTangentOut(-pNodeComponent->GetFinalCustomTangentIn(), pNodeComponent->GetTangentModeOut());
     }
     else
     {
-      cp.SetTangentOut(ezSimdConversion::ToVec3(pNodeComponent->GetCustomTangentOut()), pNodeComponent->GetTangentModeOut());
+      cp.SetTangentOut(pNodeComponent->GetFinalCustomTangentOut(), pNodeComponent->GetTangentModeOut());
     }
 
     cp.SetRoll(pNodeComponent->GetRoll());
@@ -760,16 +760,11 @@ void ezSplineNodeComponent::SetCustomTangentOut(const ezVec3& vTangent)
 
 void ezSplineNodeComponent::SetLinkCustomTangents(bool bLink)
 {
-  if (bLink != GetLinkCustomTangents())
+  if (m_bLinkCustomTangents != bLink)
   {
-    SetUserFlag(0, bLink);
+    m_bLinkCustomTangents = bLink;
     SplineChanged();
   }
-}
-
-bool ezSplineNodeComponent::GetLinkCustomTangents() const
-{
-  return GetUserFlag(0);
 }
 
 void ezSplineNodeComponent::OnMsgTransformChanged(ezMsgTransformChanged& msg)
@@ -828,6 +823,20 @@ void ezSplineNodeComponent::SplineChanged()
 
   ezMsgSplineChanged msg;
   GetOwner()->SendEventMessage(msg, this);
+}
+
+ezSimdVec4f ezSplineNodeComponent::GetFinalCustomTangentIn() const
+{
+  ezSimdVec4f t = ezSimdConversion::ToVec3(m_vCustomTangentIn);
+  t = GetOwner()->GetLocalRotationSimd() * t;
+  return t;
+}
+
+ezSimdVec4f ezSplineNodeComponent::GetFinalCustomTangentOut() const
+{
+  ezSimdVec4f t = ezSimdConversion::ToVec3(m_vCustomTangentOut);
+  t = GetOwner()->GetLocalRotationSimd() * t;
+  return t;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/RendererCore/Components/SplineComponent.h
+++ b/Code/Engine/RendererCore/Components/SplineComponent.h
@@ -244,7 +244,7 @@ public:
   const ezVec3& GetCustomTangentOut() const { return m_vCustomTangentOut; }          // [ property ]
 
   void SetLinkCustomTangents(bool bLink);                                            // [ property ]
-  bool GetLinkCustomTangents() const;                                                // [ property ]
+  bool GetLinkCustomTangents() const { return m_bLinkCustomTangents; }               // [ property ]
 
 protected:
   friend class ezSplineComponent;
@@ -257,6 +257,9 @@ protected:
 
   void SplineChanged();
 
+  ezSimdVec4f GetFinalCustomTangentIn() const;
+  ezSimdVec4f GetFinalCustomTangentOut() const;
+
   ezAngle m_Roll;
   ezEnum<ezSplineTangentMode> m_TangentModeIn;
   ezEnum<ezSplineTangentMode> m_TangentModeOut;
@@ -266,5 +269,6 @@ protected:
   ezVec3 m_vCustomTangentIn = ezVec3::MakeZero();
   ezVec3 m_vCustomTangentOut = ezVec3::MakeZero();
 
+  bool m_bLinkCustomTangents = false;
   bool m_bEditDummy = false;
 };


### PR DESCRIPTION
* Custom spline tangents now take the node object's rotation into account. The manipulator gizmo already acted that way but the engine side did not respect that.
* Fixed up dir calculation producing NaNs in some cases