### PR TITLE
Fix precision-loss warning caused by implicit conversion

### DIFF
--- a/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
@@ -88,7 +88,7 @@ void ezQuatTemplate<Type>::GetRotationAxisAndAngle(ezVec3Template<Type>& out_vAx
   }
   else
   {
-    const Type ds = 1.0 / s;
+    const Type ds = (Type)1.0 / s;
     out_vAxis.x = x * ds;
     out_vAxis.y = y * ds;
     out_vAxis.z = z * ds;

--- a/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
@@ -88,7 +88,7 @@ void ezQuatTemplate<Type>::GetRotationAxisAndAngle(ezVec3Template<Type>& out_vAx
   }
   else
   {
-    const Type ds = (Type)1.0 / s;
+    const Type ds = (Type)(1.0 / s);
     out_vAxis.x = x * ds;
     out_vAxis.y = y * ds;
     out_vAxis.z = z * ds;


### PR DESCRIPTION
Visual Studio 2022. When building with Tracy support disabled (`EZ_3RDPARTY_TRACY_SUPPORT=OFF`), I get a precision-loss warning that is treated as an error.

This change fixes the warning, and my build completes successfully. However, I would note that it may lower the precision. The original code uses double precision for the division, and the equivalent code would require `(Type)(1.0 / s)`.

I’m not sure whether this could be a problem, but quaternion arithmetic might be delicate.