### PR TITLE
improved process of downloading project from git

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -590,13 +590,10 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
   // if it is a git repository, clone it
   if (sType == "git" && !sUrl.IsEmpty())
   {
-    ezProgressRange progress("Downloading Project", 2, true);
-    progress.SetStepWeighting(0, 0.8f);
-    progress.SetStepWeighting(1, 0.2f);
-
     {
       QStringList args;
       args << "clone";
+      args << "--progress"; // it appears that this flag forces non-buffered I/O so it flushes output immediately after each write
       args << ezMakeQString(sUrl);
       args << ezMakeQString(sName);
 
@@ -606,6 +603,7 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
 
       ezProgressRange cloneProgress("Downloading Project", true);
       bool bRecursion = false;
+      bool bFirstProgress = true;
 
       QObject::connect(&proc, &QProcess::readyReadStandardOutput, [&]()
         {
@@ -624,7 +622,15 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
             ezInt32 p;
             if (ezConversionUtils::StringToInt(str, p).Succeeded())
             {
-              cloneProgress.SetCompletion(p / 100.0f);
+              // skip "Counting objects: 100% (1/1), done."
+              if (bFirstProgress && p == 100) {
+                bFirstProgress = false;
+              }
+              else
+              {
+                // here we have "Receiving objects:   2% (72/3593)"
+                cloneProgress.SetCompletion(p / 100.0f);
+              }
             }
           }
 
@@ -651,7 +657,10 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
         return ezStatus(ezFmt("Running 'git' to download the remote project failed."));
       }
 
-      proc.waitForFinished(60 * 1000);
+      while (!proc.waitForFinished())
+      {
+        // wait indefinitely
+      }
 
       if (proc.exitStatus() != QProcess::ExitStatus::NormalExit)
       {

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -597,74 +597,97 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
       args << ezMakeQString(sUrl);
       args << ezMakeQString(sName);
 
-      QProcess proc;
-      proc.setWorkingDirectory(sTargetDir.GetData());
-      proc.setProcessChannelMode(QProcess::MergedChannels);
-
       ezProgressRange cloneProgress("Downloading Project", true);
-      bool bRecursion = false;
-      bool bFirstProgress = true;
 
-      QObject::connect(&proc, &QProcess::readyReadStandardOutput, [&]()
+      ezProcessOptions po;
+      po.m_sWorkingDirectory = sTargetDir.GetData();
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+      po.m_sProcess = "git.exe";
+#else
+      po.m_sProcess = "git";
+#endif
+      po.AddArgument("clone");
+      po.AddArgument("--progress"); // it appears that this flag forces non-buffered I/O so it flushes output immediately after each write
+      po.AddArgument(sUrl);
+      po.AddArgument(sName);
+
+      ezProcessGroup pgroup;
+
+      ezString s_last_stderr_line;
+
+      ezDeque<ezString> strings = {};
+      ezMutex mutex;
+
+      // this function called on a separate thread
+      po.m_onStdError = [&](ezStringView out)
         {
-          if (bRecursion)
-            return;
-
-          bRecursion = true;
-
-          auto data = proc.readAllStandardOutput();
-          ezStringBuilder str = data.toStdString().c_str();
-          if (const char* szPercent = str.FindLastSubString("%"))
-          {
-            str.SetSubString_FromTo(szPercent - 3, szPercent);
-            str.Trim();
-
-            ezInt32 p;
-            if (ezConversionUtils::StringToInt(str, p).Succeeded())
-            {
-              // skip "Counting objects: 100% (1/1), done."
-              if (bFirstProgress && p == 100) {
-                bFirstProgress = false;
-              }
-              else
-              {
-                // here we have "Receiving objects:   2% (72/3593)"
-                cloneProgress.SetCompletion(p / 100.0f);
-              }
-            }
-          }
-
-          if (cloneProgress.WasCanceled())
-          {
-            proc.close();
-          }
-
-          bRecursion = false;
-          //
-        });
+          EZ_LOCK(mutex);
+          strings.PushBack(out);
+        };
 
       QApplication::setOverrideCursor(Qt::WaitCursor);
       EZ_SCOPE_EXIT(QApplication::restoreOverrideCursor());
 
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
-      proc.start("git.exe", args);
-#else
-      proc.start("git", args);
-#endif
-
-      if (!proc.waitForStarted())
+      ezResult res = pgroup.Launch(po);
+      if (res.Failed())
       {
+        pgroup.TerminateAll().IgnoreResult();
         return ezStatus(ezFmt("Running 'git' to download the remote project failed."));
       }
 
-      while (!proc.waitForFinished())
+      while (true)
       {
-        // wait indefinitely
+        // Process stderr output from git to update the progress bar.
+        if (strings.GetCount() > 0)
+        {
+          EZ_LOCK(mutex);
+          for (const auto& line : strings)
+          {
+            ezString data = line;
+            ezStringBuilder str = data.GetData();
+
+            if (const char* szPercent = str.FindLastSubString("%"))
+            {
+              str.SetSubString_FromTo(szPercent - 3, szPercent);
+              str.Trim();
+
+              ezInt32 p;
+              if (ezConversionUtils::StringToInt(str, p).Succeeded())
+              {
+                double f_completion = p / 100.0;
+                if (f_completion < cloneProgress.GetProgressbar()->GetCompletion())
+                {
+                  cloneProgress.GetProgressbar()->Reset();
+                }
+                cloneProgress.SetCompletion(f_completion);
+              }
+            }
+            s_last_stderr_line = line;
+          }
+          strings.Clear();
+        }
+
+        if (cloneProgress.WasCanceled())
+        {
+          pgroup.TerminateAll().IgnoreResult();
+          break;
+        }
+
+        qApp->processEvents();
+
+        if (pgroup.GetProcesses()[0].GetState() == ezProcessState::Finished)
+          break;
       }
 
-      if (proc.exitStatus() != QProcess::ExitStatus::NormalExit)
+      res = pgroup.WaitToFinish();
+
+      if (cloneProgress.WasCanceled())
       {
-        return ezStatus(ezFmt("Failed to git clone the remote project '{}' from '{}'", sName, sUrl));
+        return ezStatus("Project downloading cancelled by user. Please remove the incomplete project directory manually.");
+      }
+      else if (pgroup.GetProcesses()[0].GetExitCode() != 0)
+      {
+        return ezStatus(ezFmt("Failed to git clone the remote project '{}' from '{}'\n{}", sName, sUrl, s_last_stderr_line));
       }
 
       ezLog::Success("Cloned remote project '{}' from '{}' to '{}'", sName, sUrl, sTargetDir);

--- a/Code/Engine/Foundation/Platform/Win/Process_Platform.inl
+++ b/Code/Engine/Foundation/Platform/Win/Process_Platform.inl
@@ -99,6 +99,10 @@ struct ezPipeWin
             while (szCurrentPos < szEndPos)
             {
               const char* szFound = ezStringUtils::FindSubString(szCurrentPos, "\n", szEndPos);
+              if (!szFound)
+              {
+                szFound = ezStringUtils::FindSubString(szCurrentPos, "\r", szEndPos);
+              }
               if (szFound)
               {
                 if (overflowBuffer.IsEmpty())

--- a/Code/Engine/Foundation/Utilities/Implementation/Progress.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/Progress.cpp
@@ -37,6 +37,18 @@ void ezProgress::SetCompletion(float fCompletion)
   }
 }
 
+void ezProgress::Reset()
+{
+  m_fCurrentCompletion = 0.0f;
+  m_fLastReportedCompletion = 0.0f;
+
+  ezProgressEvent e;
+  e.m_pProgressbar = this;
+  e.m_Type = ezProgressEvent::Type::ProgressChanged;
+
+  m_Events.Broadcast(e, 1);
+}
+
 void ezProgress::SetActiveRange(ezProgressRange* pRange)
 {
   if (m_pActiveRange == nullptr && pRange != nullptr)

--- a/Code/Engine/Foundation/Utilities/Progress.h
+++ b/Code/Engine/Foundation/Utilities/Progress.h
@@ -41,8 +41,11 @@ public:
   /// \brief Returns the current overall progress in [0; 1] range.
   float GetCompletion() const;
 
-  /// \brief Sets the current overall progress in [0; 1] range. Should not be called directly, typically called by ezProgreesRange.
+  /// \brief Sets the current overall progress in [0; 1] range. Should not be called directly, typically called by ezProgressRange.
   void SetCompletion(float fCompletion);
+
+  /// \brief Resets the progress bar to 0% completion.
+  void Reset();
 
   /// \brief Returns the current 'headline' text for the progress bar
   ezStringView GetMainDisplayText() const;

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/QtProgressbar.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/QtProgressbar.cpp
@@ -61,7 +61,7 @@ void ezQtProgressbar::ProgressbarEventHandler(const ezProgressEvent& e)
       m_pDialog->setLabelText(QString::fromUtf8(sText.GetData()));
       EZ_ASSERT_DEV(m_pDialog != nullptr, "Progress dialog was destroyed while being in use");
 
-      const ezUInt32 uiProMille = ezMath::Clamp<ezUInt32>((ezUInt32)(e.m_pProgressbar->GetCompletion() * 1000.0), 0, 1000);
+      const ezUInt32 uiProMille = ezMath::Clamp<ezUInt32>((ezUInt32)(e.m_pProgressbar->GetCompletion() * 1000.0f), 0, 1000);
       m_pDialog->setValue(uiProMille);
 
       if (m_pDialog->wasCanceled())
@@ -86,7 +86,7 @@ void ezQtProgressbar::EnsureCreated()
 
   m_pDialog = new QProgressDialog("                                                                                ", "Cancel", 0, 1000, QApplication::activeWindow());
 
-  m_pDialog->setWindowModality(Qt::WindowModal);
+  m_pDialog->setWindowModality(Qt::ApplicationModal);
   m_pDialog->setMinimumDuration((int)500);
   m_pDialog->setAutoReset(false);
   m_pDialog->setAutoClose(false);
@@ -102,6 +102,10 @@ void ezQtProgressbar::EnsureCreated()
   };
 
   m_OnDialogDestroyed = QObject::connect(m_pDialog, &QObject::destroyed, ClearDialog);
+  QObject::connect(m_pDialog, &QProgressDialog::canceled, [this]()
+  {
+    m_pProgress->UserClickedCancel();
+  });
 }
 
 void ezQtProgressbar::EnsureDestroyed()


### PR DESCRIPTION
i had an issue when downloading Store sample. progress bar was not updating and after 60 secs ezEngine tried to open downloaded project but failed, because cloning was still in progress.

in code we see that ezEngine waits only 60 secs for git cloning to finish then it tries to open the cloned project.
i changed it so it now waits indefinitely. this change fixed the problem.

I also made progress bar to actually show the cloning progress.

Tested only on Windows.