### PR TITLE
Infrastructure to suppress modal dialogs in unattended mode

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/WindowLayoutActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/WindowLayoutActions.cpp
@@ -327,6 +327,13 @@ void ezSaveLayoutMenuAction::Execute(const ezVariant& value)
   const QString sStateKey = QString("UserSlot_%1_State").arg(iSlot);
   const QString sExistingName = settings.value(sNameKey, QString()).toString();
 
+  // native window, so not covered by ezQtDialog
+  if (ezQtUiServices::SuppressModalWindow("Save Layout (name prompt)"))
+  {
+    settings.endGroup();
+    return;
+  }
+
   bool bOk = false;
   const QString sName = QInputDialog::getText(pContainer, QStringLiteral("Save Layout"), QStringLiteral("Layout name:"), QLineEdit::Normal, sExistingName, &bOk);
 

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserDlg.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserDlg.moc.h
@@ -2,9 +2,9 @@
 
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_AssetBrowserDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserDlg : public QDialog, public Ui_AssetBrowserDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserDlg : public ezQtDialog, public Ui_AssetBrowserDlg
 {
   Q_OBJECT
 

--- a/Code/Editor/EditorFramework/Assets/AssetImportDlg.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetImportDlg.moc.h
@@ -3,9 +3,9 @@
 #include <EditorFramework/Assets/AssetDocumentGenerator.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_AssetImportDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezQtAssetImportDlg : public QDialog, public Ui_AssetImportDlg
+class ezQtAssetImportDlg : public ezQtDialog, public Ui_AssetImportDlg
 {
   Q_OBJECT
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserDlg.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserDlg.cpp
@@ -68,7 +68,7 @@ void ezQtAssetBrowserDlg::Init(QWidget* pParent)
 }
 
 ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& preselectedAsset, ezStringView sVisibleFilters, ezStringView sWindowTitle, ezStringView sRequiredTag)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   {
     ezStringBuilder temp = sVisibleFilters;
@@ -113,7 +113,7 @@ ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& presele
 }
 
 ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, ezStringView sWindowTitle, ezStringView sPreselectedFileAbs, ezStringView sFileExtensions)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   m_sVisibleFilters = sFileExtensions;
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -132,6 +132,11 @@ void ezAssetDocumentGenerator::GetSupportsFileTypes(ezSet<ezString>& out_extensi
 
 void ezAssetDocumentGenerator::ImportAssets()
 {
+  // The file picker below is a native window, so it is not covered by ezQtDialog and would block
+  // indefinitely. Use the overload taking the file list when there is no user to pick them.
+  if (ezQtUiServices::SuppressModalWindow("Import Assets (file picker)"))
+    return;
+
   ezTempHybridArray<ezAssetDocumentGenerator*, 16> generators;
   CreateGenerators(generators);
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetImportDlg.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetImportDlg.cpp
@@ -11,7 +11,7 @@ enum Columns
 };
 
 ezQtAssetImportDlg::ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& ref_allImports)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
   , m_AllImports(ref_allImports)
 {
   setupUi(this);

--- a/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
@@ -78,7 +78,7 @@ private:
 };
 
 ezQtAssetProfilesDlg::ezQtAssetProfilesDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.moc.h
@@ -5,7 +5,7 @@
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>
 
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class ezAssetProfilesDocument;
 class ezPlatformProfile;
@@ -13,7 +13,7 @@ class ezQtDocumentTreeView;
 class ezDocument;
 struct ezDocumentObjectPropertyEvent;
 
-class EZ_EDITORFRAMEWORK_DLL ezQtAssetProfilesDlg : public QDialog, public Ui_ezQtAssetProfilesDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetProfilesDlg : public ezQtDialog, public Ui_ezQtAssetProfilesDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/CppProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/CppProjectDlg.cpp
@@ -13,7 +13,7 @@
 
 
 ezQtCppProjectDlg::ezQtCppProjectDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/CppProjectDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/CppProjectDlg.moc.h
@@ -5,9 +5,9 @@
 #include <EditorFramework/CodeGen/CppSettings.h>
 #include <EditorFramework/ui_CppProjectDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtCppProjectDlg : public QDialog, public Ui_ezQtCppProjectDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtCppProjectDlg : public ezQtDialog, public Ui_ezQtCppProjectDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
@@ -6,7 +6,7 @@
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 ezQtCreateProjectDlg::ezQtCreateProjectDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.moc.h
@@ -5,9 +5,9 @@
 #include <EditorFramework/EditorApp/Configuration/Plugins.h>
 #include <EditorFramework/ui_CreateProjectDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtCreateProjectDlg : public QDialog, public Ui_ezQtCreateProjectDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtCreateProjectDlg : public ezQtDialog, public Ui_ezQtCreateProjectDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/DashboardDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/DashboardDlg.cpp
@@ -7,7 +7,7 @@
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 ezQtDashboardDlg::ezQtDashboardDlg(QWidget* pParent, DashboardTab activeTab)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/DashboardDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/DashboardDlg.moc.h
@@ -4,9 +4,9 @@
 
 #include <EditorFramework/ui_DashboardDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtDashboardDlg : public QDialog, public Ui_ezQtDashboardDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtDashboardDlg : public ezQtDialog, public Ui_ezQtDashboardDlg
 {
   Q_OBJECT
 

--- a/Code/Editor/EditorFramework/Dialogs/DataDirsDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/DataDirsDlg.cpp
@@ -4,7 +4,7 @@
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 
 ezQtDataDirsDlg::ezQtDataDirsDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/DataDirsDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/DataDirsDlg.moc.h
@@ -3,9 +3,9 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_DataDirsDlg.h>
 #include <Foundation/Application/Config/FileSystemConfig.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtDataDirsDlg : public QDialog, public Ui_ezQtDataDirsDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtDataDirsDlg : public ezQtDialog, public Ui_ezQtDataDirsDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/EditDynamicEnumsDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/EditDynamicEnumsDlg.cpp
@@ -4,7 +4,7 @@
 #include <GuiFoundation/UIServices/DynamicStringEnum.h>
 
 ezQtEditDynamicEnumsDlg::ezQtEditDynamicEnumsDlg(ezDynamicStringEnum* pEnum, QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   m_pEnum = pEnum;
   m_Values = m_pEnum->GetAllValidValues();

--- a/Code/Editor/EditorFramework/Dialogs/EditDynamicEnumsDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/EditDynamicEnumsDlg.moc.h
@@ -4,11 +4,11 @@
 
 #include <EditorFramework/ui_EditDynamicEnumsDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class ezDynamicStringEnum;
 
-class EZ_EDITORFRAMEWORK_DLL ezQtEditDynamicEnumsDlg : public QDialog, public Ui_ezQtEditDynamicEnumsDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtEditDynamicEnumsDlg : public ezQtDialog, public Ui_ezQtEditDynamicEnumsDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -21,7 +21,7 @@ bool ezQtExportProjectDlg::s_bCreateLaunchScripts = true;
 bool ezQtExportProjectDlg::s_bOpenOutputFolder = true;
 
 ezQtExportProjectDlg::ezQtExportProjectDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.moc.h
@@ -2,9 +2,9 @@
 
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_ExportProjectDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezQtExportProjectDlg : public QDialog, public Ui_ExportProjectDlg
+class ezQtExportProjectDlg : public ezQtDialog, public Ui_ExportProjectDlg
 {
   Q_OBJECT
 

--- a/Code/Editor/EditorFramework/Dialogs/InputConfigDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/InputConfigDlg.cpp
@@ -28,7 +28,7 @@ void UpdateInputDynamicEnumValues()
 }
 
 ezQtInputConfigDlg::ezQtInputConfigDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/InputConfigDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/InputConfigDlg.moc.h
@@ -5,11 +5,11 @@
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Containers/Set.h>
 #include <GameEngine/Configuration/InputConfig.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class QTreeWidgetItem;
 
-class EZ_EDITORFRAMEWORK_DLL ezQtInputConfigDlg : public QDialog, public Ui_InputConfigDialog
+class EZ_EDITORFRAMEWORK_DLL ezQtInputConfigDlg : public ezQtDialog, public Ui_InputConfigDialog
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/LaunchFileserveDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/LaunchFileserveDlg.cpp
@@ -4,7 +4,7 @@
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 
 ezQtLaunchFileserveDlg::ezQtLaunchFileserveDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 }

--- a/Code/Editor/EditorFramework/Dialogs/LaunchFileserveDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/LaunchFileserveDlg.moc.h
@@ -3,9 +3,9 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_LaunchFileserveDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtLaunchFileserveDlg : public QDialog, public Ui_ezQtLaunchFileserveDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtLaunchFileserveDlg : public ezQtDialog, public Ui_ezQtLaunchFileserveDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/PluginSelectionDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/PluginSelectionDlg.cpp
@@ -6,7 +6,7 @@
 #include <Foundation/IO/OpenDdlWriter.h>
 
 ezQtPluginSelectionDlg::ezQtPluginSelectionDlg(ezPluginBundleSet* pPluginSet, QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/PluginSelectionDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/PluginSelectionDlg.moc.h
@@ -4,9 +4,9 @@
 
 #include <EditorFramework/EditorApp/Configuration/Plugins.h>
 #include <EditorFramework/ui_PluginSelectionDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtPluginSelectionDlg : public QDialog, public Ui_PluginSelectionDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtPluginSelectionDlg : public ezQtDialog, public Ui_PluginSelectionDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.cpp
@@ -39,7 +39,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPreferencesDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezQtPreferencesDlg::ezQtPreferencesDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.moc.h
@@ -3,13 +3,13 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_PreferencesDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class ezPreferencesDocument;
 class ezPreferences;
 class ezQtDocumentTreeView;
 
-class EZ_EDITORFRAMEWORK_DLL ezQtPreferencesDlg : public QDialog, public Ui_ezQtPreferencesDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtPreferencesDlg : public ezQtDialog, public Ui_ezQtPreferencesDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.cpp
@@ -31,7 +31,7 @@ bool ezQtRemoteConnectionDlg::Address::IsEmpty() const
 }
 
 ezQtRemoteConnectionDlg::ezQtRemoteConnectionDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.moc.h
@@ -3,9 +3,9 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_RemoteConnectionDlg.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtRemoteConnectionDlg : public QDialog, public Ui_ezQtRemoteConnectionDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtRemoteConnectionDlg : public ezQtDialog, public Ui_ezQtRemoteConnectionDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/SnapSettingsDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/SnapSettingsDlg.cpp
@@ -4,7 +4,7 @@
 #include <EditorFramework/Gizmos/SnapProvider.h>
 
 ezQtSnapSettingsDlg::ezQtSnapSettingsDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/SnapSettingsDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/SnapSettingsDlg.moc.h
@@ -2,10 +2,11 @@
 
 #include <EditorFramework/ui_SnapSettingsDlg.h>
 #include <Foundation/Containers/HybridArray.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class QAbstractButton;
 
-class ezQtSnapSettingsDlg : public QDialog, public Ui_SnapSettingsDlg
+class ezQtSnapSettingsDlg : public ezQtDialog, public Ui_SnapSettingsDlg
 {
   Q_OBJECT
 

--- a/Code/Editor/EditorFramework/Dialogs/TagsDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/TagsDlg.cpp
@@ -4,7 +4,7 @@
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 
 ezQtTagsDlg::ezQtTagsDlg(const ezVariant& startup, QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Editor/EditorFramework/Dialogs/TagsDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/TagsDlg.moc.h
@@ -4,10 +4,10 @@
 #include <EditorFramework/ui_TagsDlg.h>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <ToolsFoundation/Settings/ToolsTagRegistry.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtTagsDlg : public QDialog, public Ui_ezQtTagsDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtTagsDlg : public ezQtDialog, public Ui_ezQtTagsDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/Dialogs/WindowCfgDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/WindowCfgDlg.cpp
@@ -6,7 +6,7 @@
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 ezQtWindowCfgDlg::ezQtWindowCfgDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
   LoadDescs();

--- a/Code/Editor/EditorFramework/Dialogs/WindowCfgDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/WindowCfgDlg.moc.h
@@ -4,9 +4,9 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_WindowCfgDlg.h>
 #include <Foundation/Application/Config/FileSystemConfig.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class EZ_EDITORFRAMEWORK_DLL ezQtWindowCfgDlg : public QDialog, public Ui_ezQtWindowCfgDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtWindowCfgDlg : public ezQtDialog, public Ui_ezQtWindowCfgDlg
 {
 public:
   Q_OBJECT

--- a/Code/Editor/EditorFramework/EditorApp/DocumentsGUI.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/DocumentsGUI.cpp
@@ -6,6 +6,11 @@
 
 void ezQtEditorApp::GuiCreateOrOpenDocument(bool bCreate)
 {
+  // The file picker below is a native window, so it is not covered by ezQtDialog. Automated callers
+  // have to name the document, i.e. go through CreateDocument()/OpenDocument() directly.
+  if (ezQtUiServices::SuppressModalWindow(bCreate ? "Create Document (file picker)" : "Open Document (file picker)"))
+    return;
+
   const ezString sAllFilters = BuildDocumentTypeFileFilter(bCreate);
 
   if (sAllFilters.IsEmpty())

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -582,6 +582,11 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
 
   static QString sPreviousFolder = ezOSFile::GetUserDocumentsFolder().GetData();
 
+  // native window, so not covered by ezQtDialog - there is no automated path for downloading a remote
+  // project, the target folder has to come from a user
+  if (ezQtUiServices::SuppressModalWindow("Remote project download folder (file picker)"))
+    return ezStatus("A remote project needs a download folder, which cannot be chosen without a user present.");
+
   QString sSelectedDir = QFileDialog::getExistingDirectory(QApplication::activeWindow(), QLatin1String("Choose Folder"), sPreviousFolder, QFileDialog::Option::ShowDirsOnly | QFileDialog::Option::DontResolveSymlinks);
 
   if (sSelectedDir.isEmpty())
@@ -625,10 +630,10 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
 
       // this function called on a separate thread
       po.m_onStdError = [&](ezStringView out)
-        {
-          EZ_LOCK(mutex);
-          strings.PushBack(out);
-        };
+      {
+        EZ_LOCK(mutex);
+        strings.PushBack(out);
+      };
 
       QApplication::setOverrideCursor(Qt::WaitCursor);
       EZ_SCOPE_EXIT(QApplication::restoreOverrideCursor());

--- a/Code/Editor/EditorFramework/EditorApp/ProjectsGUI.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/ProjectsGUI.cpp
@@ -6,11 +6,17 @@
 
 void ezQtEditorApp::GuiOpenDashboard()
 {
+  if (ezQtUiServices::SuppressModalWindow("ezQtDashboardDlg"))
+    return;
+
   QMetaObject::invokeMethod(this, "SlotQueuedGuiOpenDashboard", Qt::ConnectionType::QueuedConnection);
 }
 
 void ezQtEditorApp::GuiOpenDocsAndCommunity()
 {
+  if (ezQtUiServices::SuppressModalWindow("ezQtDashboardDlg (documentation)"))
+    return;
+
   QMetaObject::invokeMethod(this, "SlotQueuedGuiOpenDocsAndCommunity", Qt::ConnectionType::QueuedConnection);
 }
 
@@ -22,6 +28,9 @@ bool ezQtEditorApp::GuiCreateProject(bool bImmediate /*= false*/)
   }
   else
   {
+    if (ezQtUiServices::SuppressModalWindow("ezQtCreateProjectDlg"))
+      return false;
+
     QMetaObject::invokeMethod(this, "SlotQueuedGuiCreateOrOpenProject", Qt::ConnectionType::QueuedConnection, Q_ARG(bool, true));
     return true;
   }
@@ -35,6 +44,9 @@ bool ezQtEditorApp::GuiOpenProject(bool bImmediate /*= false*/)
   }
   else
   {
+    if (ezQtUiServices::SuppressModalWindow("Open Project (file picker)"))
+      return false;
+
     QMetaObject::invokeMethod(this, "SlotQueuedGuiCreateOrOpenProject", Qt::ConnectionType::QueuedConnection, Q_ARG(bool, false));
     return true;
   }
@@ -74,6 +86,10 @@ bool ezQtEditorApp::GuiCreateOrOpenProject(bool bCreate)
   }
   else
   {
+    // native window, so not covered by ezQtDialog - see CreateOrOpenProject() for opening a known path
+    if (ezQtUiServices::SuppressModalWindow("Open Project (file picker)"))
+      return false;
+
     sFile = QFileDialog::getOpenFileName(QApplication::activeWindow(), QLatin1String("Open Project"), sDir, QLatin1String(szFilter), nullptr, QFileDialog::Option::DontResolveSymlinks).toUtf8().data();
   }
 

--- a/Code/EditorPlugins/AI/EditorPluginAi/Dialogs/AiProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/AI/EditorPluginAi/Dialogs/AiProjectSettingsDlg.cpp
@@ -11,7 +11,7 @@
 void UpdateGroundTypeDynamicEnumValues();
 
 ezQtAiProjectSettingsDlg::ezQtAiProjectSettingsDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/AI/EditorPluginAi/Dialogs/AiProjectSettingsDlg.moc.h
+++ b/Code/EditorPlugins/AI/EditorPluginAi/Dialogs/AiProjectSettingsDlg.moc.h
@@ -3,9 +3,9 @@
 #include <AiPlugin/Navigation/NavMesh.h>
 #include <EditorPluginAi/EditorPluginAiDLL.h>
 #include <EditorPluginAi/ui_AiProjectSettingsDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezQtAiProjectSettingsDlg : public QDialog, public Ui_AiProjectSettingsDlg
+class ezQtAiProjectSettingsDlg : public ezQtDialog, public Ui_AiProjectSettingsDlg
 {
 public:
   Q_OBJECT

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.cpp
@@ -6,7 +6,7 @@
 #include <QFileDialog>
 
 ezMeshImportDlg::ezMeshImportDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.moc.h
@@ -2,9 +2,9 @@
 
 #include <EditorPluginAssets/EditorPluginAssetsDLL.h>
 #include <EditorPluginAssets/ui_MeshImportDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezMeshImportDlg : public QDialog, public Ui_MeshImportDlg
+class ezMeshImportDlg : public ezQtDialog, public Ui_MeshImportDlg
 {
   Q_OBJECT
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/ShaderTemplateDlg.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/ShaderTemplateDlg.cpp
@@ -7,7 +7,7 @@
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 ezQtShaderTemplateDlg::ezQtShaderTemplateDlg(QWidget* pParent, const ezDocument* pSceneDoc)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/ShaderTemplateDlg.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/ShaderTemplateDlg.moc.h
@@ -2,11 +2,11 @@
 
 #include <EditorPluginAssets/EditorPluginAssetsDLL.h>
 #include <EditorPluginAssets/ui_ShaderTemplateDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class ezDocument;
 
-class ezQtShaderTemplateDlg : public QDialog, public Ui_ShaderTemplateDlg
+class ezQtShaderTemplateDlg : public ezQtDialog, public Ui_ShaderTemplateDlg
 {
   Q_OBJECT
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/Dialogs/FmodProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/Dialogs/FmodProjectSettingsDlg.cpp
@@ -5,7 +5,7 @@
 #include <QInputDialog>
 
 ezQtFmodProjectSettingsDlg::ezQtFmodProjectSettingsDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/Dialogs/FmodProjectSettingsDlg.moc.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/Dialogs/FmodProjectSettingsDlg.moc.h
@@ -3,9 +3,9 @@
 #include <EditorPluginFmod/EditorPluginFmodDLL.h>
 #include <EditorPluginFmod/ui_FmodProjectSettingsDlg.h>
 #include <FmodPlugin/FmodSingleton.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezQtFmodProjectSettingsDlg : public QDialog, public Ui_FmodProjectSettingsDlg
+class ezQtFmodProjectSettingsDlg : public ezQtDialog, public Ui_FmodProjectSettingsDlg
 {
 public:
   Q_OBJECT

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
@@ -10,7 +10,7 @@ void UpdateWeightCategoryDynamicEnumValues();
 void UpdateImpulseTypeDynamicEnumValues();
 
 ezQtJoltProjectSettingsDlg::ezQtJoltProjectSettingsDlg(const ezVariant& startup, QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.moc.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.moc.h
@@ -7,9 +7,9 @@
 #include <GameEngine/Physics/CollisionFilter.h>
 #include <GameEngine/Physics/ImpulseType.h>
 #include <GameEngine/Physics/WeightCategory.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezQtJoltProjectSettingsDlg : public QDialog, public Ui_JoltProjectSettingsDlg
+class ezQtJoltProjectSettingsDlg : public ezQtDialog, public Ui_JoltProjectSettingsDlg
 {
 public:
   Q_OBJECT

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.cpp
@@ -26,7 +26,7 @@ float ezQtDeltaTransformDlg::s_fNaturalDeviationZ = 10.0f;
 bool ezQtDeltaTransformDlg::s_bUseCurrentSnapSettings = false;
 
 ezQtDeltaTransformDlg::ezQtDeltaTransformDlg(QWidget* pParent, ezSceneDocument* pSceneDoc)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   m_pSceneDocument = pSceneDoc;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.moc.h
@@ -2,11 +2,11 @@
 
 #include <EditorPluginScene/EditorPluginSceneDLL.h>
 #include <EditorPluginScene/ui_DeltaTransformDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class ezSceneDocument;
 
-class ezQtDeltaTransformDlg : public QDialog, public Ui_DeltaTransformDlg
+class ezQtDeltaTransformDlg : public ezQtDialog, public Ui_DeltaTransformDlg
 {
   Q_OBJECT
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DuplicateDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DuplicateDlg.cpp
@@ -16,7 +16,7 @@ float ezQtDuplicateDlg::s_fRevolveRadius = 1.0f;
 
 
 ezQtDuplicateDlg::ezQtDuplicateDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DuplicateDlg.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DuplicateDlg.moc.h
@@ -3,9 +3,9 @@
 #include <EditorPluginScene/EditorPluginSceneDLL.h>
 #include <EditorPluginScene/ui_DuplicateDlg.h>
 
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
-class ezQtDuplicateDlg : public QDialog, public Ui_DuplicateDlg
+class ezQtDuplicateDlg : public ezQtDialog, public Ui_DuplicateDlg
 {
   Q_OBJECT
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
@@ -14,7 +14,7 @@ bool ezQtExportAndRunDlg::s_bCompileCpp = true;
 static int s_iLastPlayerApp = 0;
 
 ezQtExportAndRunDlg::ezQtExportAndRunDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.moc.h
@@ -3,11 +3,11 @@
 #include <EditorFramework/CodeGen/CppSettings.h>
 #include <EditorPluginScene/EditorPluginSceneDLL.h>
 #include <EditorPluginScene/ui_ExportAndRunDlg.h>
-#include <QDialog>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 class ezSceneDocument;
 
-class ezQtExportAndRunDlg : public QDialog, public Ui_ExportAndRunDlg
+class ezQtExportAndRunDlg : public ezQtDialog, public Ui_ExportAndRunDlg
 {
   Q_OBJECT
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExtractGeometryDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExtractGeometryDlg.cpp
@@ -13,7 +13,7 @@ int ezQtExtractGeometryDlg::s_iCoordinateSystem = 1;
 
 ezQtExtractGeometryDlg::ezQtExtractGeometryDlg(QWidget* pParent)
 
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExtractGeometryDlg.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExtractGeometryDlg.moc.h
@@ -4,10 +4,11 @@
 #include <EditorPluginScene/ui_ExtractGeometryDlg.h>
 #include <Foundation/Math/Declarations.h>
 #include <Foundation/Math/Mat3.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 
 #include <QPushButton>
 
-class ezQtExtractGeometryDlg : public QDialog, public Ui_ExtractGeometryDlg
+class ezQtExtractGeometryDlg : public ezQtDialog, public Ui_ExtractGeometryDlg
 {
   Q_OBJECT
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ColorGradientEditDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ColorGradientEditDlg.cpp
@@ -10,7 +10,7 @@
 QByteArray ezQtColorGradientEditDlg::s_LastDialogGeometry;
 
 ezQtColorGradientEditDlg::ezQtColorGradientEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pGradientObject, QWidget* pParent, ezStringView sTitle)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   m_pObjectAccessor = pObjectAccessor;
   m_pGradientObject = pGradientObject;

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ColorGradientEditDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ColorGradientEditDlg.moc.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <Foundation/Tracks/ColorGradient.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_ColorGradientEditDlg.h>
-#include <QDialog>
 
 class ezObjectAccessorBase;
 class ezDocumentObject;
 
-class EZ_GUIFOUNDATION_DLL ezQtColorGradientEditDlg : public QDialog, public Ui_ColorGradientEditDlg
+class EZ_GUIFOUNDATION_DLL ezQtColorGradientEditDlg : public ezQtDialog, public Ui_ColorGradientEditDlg
 {
   Q_OBJECT
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.cpp
@@ -9,7 +9,7 @@
 QByteArray ezQtCurveEditDlg::s_LastDialogGeometry;
 
 ezQtCurveEditDlg::ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, QWidget* pParent, ezStringView sTitle)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   m_pObjectAccessor = pObjectAccessor;
   m_pCurveObject = pCurveObject;

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include <Foundation/Tracks/CurveEditData.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_CurveEditDlg.h>
-#include <QDialog>
 
 class ezCurveGroupData;
 class ezObjectAccessorBase;
 class ezDocumentObject;
 
-class EZ_GUIFOUNDATION_DLL ezQtCurveEditDlg : public QDialog, Ui_CurveEditDlg
+class EZ_GUIFOUNDATION_DLL ezQtCurveEditDlg : public ezQtDialog, Ui_CurveEditDlg
 {
   Q_OBJECT
 public:

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/Dialog.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/Dialog.cpp
@@ -1,0 +1,22 @@
+#include <GuiFoundation/GuiFoundationPCH.h>
+
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+
+ezQtDialog::ezQtDialog(QWidget* pParent)
+  : QDialog(pParent)
+{
+}
+
+int ezQtDialog::exec()
+{
+  if (ezQtUiServices::IsUnattended())
+  {
+    // The Qt class name rather than a hand written string, so that no dialog can report a stale name, and
+    // adding a dialog needs no further work. It is also what a caller would search the code base for.
+    ezQtUiServices::ReportSuppressedDialog(metaObject()->className());
+    return QDialog::Rejected;
+  }
+
+  return QDialog::exec();
+}

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/Dialog.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/Dialog.moc.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <QDialog>
+
+/// Base class for the editor's modal dialogs, which does nothing except refuse to block when no user is present.
+///
+/// A QDialog::exec() runs a nested event loop and only returns once someone closes the window. In an
+/// unattended session (see ezQtUiServices::IsUnattended()) no one ever does, so the application hangs for
+/// good - it cannot even be asked to quit, because that request would be handled by the very event loop
+/// that is stuck. Deriving from this class turns that into a rejected dialog plus a log message.
+///
+/// Derive from it instead of QDialog for anything that is exec()ed. Dialogs that are only ever show()n
+/// don't block and don't need it, but there is no harm in deriving anyway, and doing so uniformly means
+/// nobody has to check which kind a dialog is when adding an exec() call later.
+///
+/// Note that this only unblocks the caller - it does not make the dialog's functionality available to an
+/// automated caller. Whatever the dialog would have configured has to be reachable some other way for
+/// that, e.g. through a dedicated function that takes the same settings as arguments.
+class EZ_GUIFOUNDATION_DLL ezQtDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  ezQtDialog(QWidget* pParent);
+
+  /// Shows the dialog modally, unless no user is present, in which case it reports itself as suppressed
+  /// (see ezQtUiServices::ReportSuppressedDialog()) and returns QDialog::Rejected without showing anything.
+  virtual int exec() override;
+};

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
@@ -6,7 +6,7 @@
 #include <ToolsFoundation/Project/ToolsProject.h>
 
 ezQtModifiedDocumentsDlg::ezQtModifiedDocumentsDlg(QWidget* pParent, const ezHybridArray<ezDocument*, 32>& modifiedDocs)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   m_ModifiedDocs = modifiedDocs;
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.moc.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_ModifiedDocumentsDlg.h>
-#include <QDialog>
 #include <ToolsFoundation/Document/Document.h>
 
-class EZ_GUIFOUNDATION_DLL ezQtModifiedDocumentsDlg : public QDialog, public Ui_DocumentList
+class EZ_GUIFOUNDATION_DLL ezQtModifiedDocumentsDlg : public ezQtDialog, public Ui_DocumentList
 {
 public:
   Q_OBJECT

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/PickDocumentObjectDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/PickDocumentObjectDlg.cpp
@@ -5,7 +5,7 @@
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
 
 ezQtPickDocumentObjectDlg::ezQtPickDocumentObjectDlg(QWidget* pParent, const ezArrayPtr<Element>& objects, const ezUuid& currentObject)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
   , m_Objects(objects)
   , m_CurrentObject(currentObject)
 {

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/PickDocumentObjectDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/PickDocumentObjectDlg.moc.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <Foundation/Strings/String.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_PickDocumentObjectDlg.h>
-#include <QDialog>
 
 class ezDocumentObject;
 
-class EZ_GUIFOUNDATION_DLL ezQtPickDocumentObjectDlg : public QDialog, public Ui_PickDocumentObjectDlg
+class EZ_GUIFOUNDATION_DLL ezQtPickDocumentObjectDlg : public ezQtDialog, public Ui_PickDocumentObjectDlg
 {
   Q_OBJECT
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.cpp
@@ -9,7 +9,7 @@
 #include <ToolsFoundation/Utilities/SearchPatternFilter.h>
 
 ezQtShortcutEditorDlg::ezQtShortcutEditorDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.moc.h
@@ -4,13 +4,13 @@
 #include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_ShortcutEditorDlg.h>
-#include <QDialog>
 
 struct ezActionDescriptor;
 
-class EZ_GUIFOUNDATION_DLL ezQtShortcutEditorDlg : public QDialog, public Ui_ShortcutEditor
+class EZ_GUIFOUNDATION_DLL ezQtShortcutEditorDlg : public ezQtDialog, public Ui_ShortcutEditor
 {
 public:
   Q_OBJECT

--- a/Code/Tools/Libs/GuiFoundation/UIServices/ColorDialog.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/ColorDialog.moc.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <Foundation/Math/Color.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/UIServices/ColorDlgWidgets.moc.h>
 #include <GuiFoundation/ui_ColorDialog.h>
-#include <QDialog>
 
 class QLineEdit;
 class ezQtDoubleSpinBox;
@@ -12,7 +12,7 @@ class QPushButton;
 class QSlider;
 
 
-class EZ_GUIFOUNDATION_DLL ezQtColorDialog : public QDialog, Ui_ColorDialog
+class EZ_GUIFOUNDATION_DLL ezQtColorDialog : public ezQtDialog, Ui_ColorDialog
 {
   Q_OBJECT
 public:

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/ColorDialog.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/ColorDialog.cpp
@@ -27,7 +27,7 @@ void ezQtUiServices::ShowColorDialog(
 }
 
 ezQtColorDialog::ezQtColorDialog(const ezColor& initial, QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/MessageBoxes.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/MessageBoxes.cpp
@@ -45,7 +45,7 @@ void ezQtUiServices::MessageBoxInformation(const ezFormatString& msg, ezStringVi
   ezStringBuilder tmp;
 
   if (IsUnattended())
-    ezLog::Info(msg.GetText(tmp));
+    ReportSuppressedDialog(ezStringBuilder("Information: ", msg.GetText(tmp)));
   else
   {
     QMessageBox box(QApplication::activeWindow());
@@ -84,7 +84,7 @@ void ezQtUiServices::MessageBoxWarning(const ezFormatString& msg)
   ezStringBuilder tmp;
 
   if (IsUnattended())
-    ezLog::Warning(msg.GetText(tmp));
+    ReportSuppressedDialog(ezStringBuilder("Warning: ", msg.GetText(tmp)));
   else
   {
     QMessageBox::warning(QApplication::activeWindow(), ezApplication::GetApplicationInstance()->GetApplicationName().GetData(), QString::fromUtf8(msg.GetTextCStr(tmp)), QMessageBox::StandardButton::Ok);
@@ -96,7 +96,7 @@ QMessageBox::StandardButton ezQtUiServices::MessageBoxQuestion(const ezFormatStr
   if (IsUnattended())
   {
     ezStringBuilder tmp;
-    ezLog::Info("Question answered automatically, no user present: {}", msg.GetText(tmp));
+    ReportSuppressedDialog(ezStringBuilder("Question, answered automatically: ", msg.GetText(tmp)));
 
     return unattendedButton;
   }

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/QtProgressbar.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/QtProgressbar.cpp
@@ -103,9 +103,7 @@ void ezQtProgressbar::EnsureCreated()
 
   m_OnDialogDestroyed = QObject::connect(m_pDialog, &QObject::destroyed, ClearDialog);
   QObject::connect(m_pDialog, &QProgressDialog::canceled, [this]()
-  {
-    m_pProgress->UserClickedCancel();
-  });
+    { m_pProgress->UserClickedCancel(); });
 }
 
 void ezQtProgressbar::EnsureDestroyed()

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/QtWaitForOperationDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/QtWaitForOperationDlg.cpp
@@ -4,7 +4,7 @@
 #include <QTimer>
 
 ezQtWaitForOperationDlg::ezQtWaitForOperationDlg(QWidget* pParent)
-  : QDialog(pParent)
+  : ezQtDialog(pParent)
 {
   setupUi(this);
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -3,6 +3,7 @@
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/FileSystem/FileWriter.h>
+#include <Foundation/Logging/Log.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <Foundation/Time/Stopwatch.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
@@ -24,6 +25,7 @@ ezMap<ezString, QImage> ezQtUiServices::s_ImagesCache;
 ezMap<ezString, QPixmap> ezQtUiServices::s_PixmapsCache;
 bool ezQtUiServices::s_bHeadless;
 bool ezQtUiServices::s_bUnattended;
+ezHybridArray<ezString, 4> ezQtUiServices::s_SuppressedDialogs;
 ezQtUiServices::TickEvent ezQtUiServices::s_LastTickEvent;
 
 static ezQtUiServices* g_pInstance = nullptr;
@@ -73,6 +75,50 @@ bool ezQtUiServices::IsUnattended()
 void ezQtUiServices::SetUnattended()
 {
   s_bUnattended = true;
+}
+
+void ezQtUiServices::ReportSuppressedDialog(ezStringView sDescription)
+{
+  ezLog::Warning("Dialog not shown, because no user is present: {}", sDescription);
+
+  // A suppressed dialog often means an operation didn't do what it was asked to, and code reacting to
+  // that may well open the next one. Dropping the excess keeps the first, most relevant entries.
+  constexpr ezUInt32 uiMaxEntries = 16;
+
+  if (s_SuppressedDialogs.GetCount() < uiMaxEntries)
+  {
+    s_SuppressedDialogs.PushBack(sDescription);
+  }
+}
+
+bool ezQtUiServices::SuppressModalWindow(ezStringView sDescription)
+{
+  if (!IsUnattended())
+    return false;
+
+  ReportSuppressedDialog(sDescription);
+  return true;
+}
+
+ezArrayPtr<const ezString> ezQtUiServices::GetSuppressedDialogs()
+{
+  return s_SuppressedDialogs;
+}
+
+void ezQtUiServices::ClearSuppressedDialogs()
+{
+  s_SuppressedDialogs.Clear();
+}
+
+ezQtScopedUnattended::ezQtScopedUnattended()
+{
+  m_bPrevUnattended = ezQtUiServices::s_bUnattended;
+  ezQtUiServices::s_bUnattended = true;
+}
+
+ezQtScopedUnattended::~ezQtScopedUnattended()
+{
+  ezQtUiServices::s_bUnattended = m_bPrevUnattended;
 }
 
 void ezQtUiServices::SaveState()

--- a/Code/Tools/Libs/GuiFoundation/UIServices/QtWaitForOperationDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/QtWaitForOperationDlg.moc.h
@@ -2,13 +2,14 @@
 
 #include <Foundation/Strings/String.h>
 #include <Foundation/Types/Delegate.h>
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_QtWaitForOperationDlg.h>
 
 class QWinTaskbarProgress;
 class QWinTaskbarButton;
 
-class EZ_GUIFOUNDATION_DLL ezQtWaitForOperationDlg : public QDialog, public Ui_QtWaitForOperationDlg
+class EZ_GUIFOUNDATION_DLL ezQtWaitForOperationDlg : public ezQtDialog, public Ui_QtWaitForOperationDlg
 {
   Q_OBJECT
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -2,6 +2,7 @@
 
 #include <Foundation/Communication/Event.h>
 #include <Foundation/Configuration/Singleton.h>
+#include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Strings/FormatString.h>
 #include <Foundation/Time/Time.h>
 #include <Foundation/Types/Status.h>
@@ -82,10 +83,44 @@ public:
   /// Set if the application runs without a user present, e.g. driven by a script or an AI agent.
   ///
   /// The UI is still shown, but everything that would block waiting for input must not be displayed. The
-  /// message box functions below therefore only log their message and return their unattended answer. Code
-  /// that opens a modal dialog directly (file pickers, custom ezQtDialog, ...) has to check this itself,
-  /// otherwise it stalls the application indefinitely.
+  /// message box functions below therefore only log their message and return their unattended answer, and
+  /// ezQtDialog::exec() returns without showing anything. Code that opens a modal window in some other way
+  /// (QFileDialog, QInputDialog, ...) has to check this itself, otherwise it stalls the application
+  /// indefinitely.
+  ///
+  /// This is one-way, for a process that is unattended for its entire runtime (the '-unattended' command
+  /// line option). To make only part of a normal editor session unattended, use ezQtScopedUnattended.
   static void SetUnattended();
+
+  /// Records that a dialog or message box was not shown, because IsUnattended() is set.
+  ///
+  /// Whoever triggered the operation would otherwise have no way to tell a suppressed dialog apart from
+  /// the operation simply doing nothing. sDescription should identify what was suppressed well enough to
+  /// act on it, i.e. the dialog's class name or the text of the message box.
+  ///
+  /// Called by ezQtDialog and the MessageBox* functions; call it manually when suppressing a modal window
+  /// that goes through neither.
+  static void ReportSuppressedDialog(ezStringView sDescription);
+
+  /// Checks whether a modal window may be opened at all, and records its suppression when it may not.
+  ///
+  /// For modal windows that do not go through ezQtDialog and therefore have to check for themselves:
+  /// QFileDialog, QInputDialog, QMessageBox used directly, and anything else that enters a nested event
+  /// loop. Returns true when the window must NOT be shown - the caller then continues as if the user had
+  /// cancelled it, which for a file picker means an empty selection.
+  ///
+  /// Only worth adding where an automated caller can actually reach the window, i.e. in code triggered by
+  /// a global ezAction. A picker that only opens from a button inside another dialog is already covered,
+  /// because that dialog never opens.
+  static bool SuppressModalWindow(ezStringView sDescription);
+
+  /// The dialogs suppressed since the last ClearSuppressedDialogs(), oldest first.
+  ///
+  /// The list has an upper bound, so that a loop opening dialogs cannot grow it without limit. Once that
+  /// is reached, further entries are dropped, not rotated.
+  static ezArrayPtr<const ezString> GetSuppressedDialogs();
+
+  static void ClearSuppressedDialogs();
 
   /// Shows a non-modal color dialog. The Qt slots are called when the selected color is changed or when the dialog is closed and the result
   /// accepted or rejected.
@@ -195,6 +230,27 @@ private:
   static ezMap<ezString, QPixmap> s_PixmapsCache;
   static bool s_bHeadless;
   static bool s_bUnattended;
+  static ezHybridArray<ezString, 4> s_SuppressedDialogs;
   static TickEvent s_LastTickEvent;
   bool m_bIsDrawingATM = false;
+
+  friend class ezQtScopedUnattended;
+};
+
+/// Makes the enclosed code run as if no user were present, see ezQtUiServices::IsUnattended().
+///
+/// For automated calls into an editor that a user is otherwise sitting in front of - an MCP tool call,
+/// for instance. Their dialogs must not block, while the same dialogs opened by the user's own menu
+/// clicks still have to appear, so the state cannot be set globally.
+///
+/// Scopes nest and restore the previous state. Note that this does not undo ezQtUiServices::SetUnattended()
+/// or headless mode: those stay in effect for the whole process.
+class EZ_GUIFOUNDATION_DLL ezQtScopedUnattended
+{
+public:
+  ezQtScopedUnattended();
+  ~ezQtScopedUnattended();
+
+private:
+  bool m_bPrevUnattended;
 };

--- a/Data/Samples/Testing Chambers/RuntimeConfigs/DataDirectories.ddl
+++ b/Data/Samples/Testing Chambers/RuntimeConfigs/DataDirectories.ddl
@@ -12,12 +12,6 @@ DataDir
 }
 DataDir
 {
-	string %Path{">project/"}
-	string %RootName{"project"}
-	bool %Writable{true}
-}
-DataDir
-{
 	string %Path{">sdk/Data/Plugins/KrautPlugin"}
 	string %RootName{""}
 	bool %Writable{false}
@@ -45,4 +39,10 @@ DataDir
 	string %Path{">sdk/Data/Plugins/TerrainPlugin"}
 	string %RootName{""}
 	bool %Writable{false}
+}
+DataDir
+{
+	string %Path{">project/"}
+	string %RootName{"project"}
+	bool %Writable{true}
 }


### PR DESCRIPTION
Allows CI and other automations to detect and continue when a modal dialog would have otherwise blocked the app from continuing.

ezQtDialog adds early out in "unattended" mode (e.g. headless).