### PR TITLE
Changed ezStandardJSONWriter to not use MongoDB conventions anymore

### DIFF
--- a/Code/Engine/Foundation/IO/Implementation/StandardJSONWriter.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/StandardJSONWriter.cpp
@@ -216,172 +216,127 @@ void ezStandardJSONWriter::WriteTime(ezTime value)
   WriteDouble(value.GetSeconds());
 }
 
+void ezStandardJSONWriter::WriteFloatComponents(const float* pValues, ezUInt32 uiCount, ezStringView sComponentNames)
+{
+  EZ_ASSERT_DEBUG(uiCount <= sComponentNames.GetElementCount(), "Not enough component names for {} components.", uiCount);
+
+  BeginObject();
+
+  for (ezUInt32 i = 0; i < uiCount; ++i)
+  {
+    const char* szName = sComponentNames.GetStartPointer() + i;
+    AddVariableFloat(ezStringView(szName, szName + 1), pValues[i]);
+  }
+
+  EndObject();
+}
+
 void ezStandardJSONWriter::WriteColor(const ezColor& value)
 {
-  ezVec4 temp(value.r, value.g, value.b, value.a);
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1},{2},{3})", ezArgF(value.r, 4), ezArgF(value.g, 4), ezArgF(value.b, 4), ezArgF(value.a, 4));
-  else
-    s.SetFormat("({0}, {1}, {2}, {3})", ezArgF(value.r, 4), ezArgF(value.g, 4), ezArgF(value.b, 4), ezArgF(value.a, 4));
-
-  WriteBinaryData("color", &temp, sizeof(temp), s.GetData());
+  // The linear/gamma distinction is not part of the output, so a reader has to know which one it is
+  // getting from the context - same as for the component types below, which do not record their type
+  // either.
+  WriteFloatComponents(&value.r, 4, "rgba");
 }
 
 void ezStandardJSONWriter::WriteColorGamma(const ezColorGammaUB& value)
 {
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1},{2},{3})", value.r, value.g, value.b, value.a);
-  else
-    s.SetFormat("({0}, {1}, {2}, {3})", value.r, value.g, value.b, value.a);
-
-  WriteBinaryData("gamma", value.GetData(), sizeof(ezColorGammaUB), s.GetData());
+  BeginObject();
+  AddVariableUInt32("r", value.r);
+  AddVariableUInt32("g", value.g);
+  AddVariableUInt32("b", value.b);
+  AddVariableUInt32("a", value.a);
+  EndObject();
 }
 
 void ezStandardJSONWriter::WriteVec2(const ezVec2& value)
 {
-  ezVec2 temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1})", ezArgF(value.x, 4), ezArgF(value.y, 4));
-  else
-    s.SetFormat("({0}, {1})", ezArgF(value.x, 4), ezArgF(value.y, 4));
-
-  WriteBinaryData("vec2", &temp, sizeof(temp), s.GetData());
+  WriteFloatComponents(&value.x, 2, "xyzw");
 }
 
 void ezStandardJSONWriter::WriteVec3(const ezVec3& value)
 {
-  ezVec3 temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1},{2})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4));
-  else
-    s.SetFormat("({0}, {1}, {2})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4));
-
-  WriteBinaryData("vec3", &temp, sizeof(temp), s.GetData());
+  WriteFloatComponents(&value.x, 3, "xyzw");
 }
 
 void ezStandardJSONWriter::WriteVec4(const ezVec4& value)
 {
-  ezVec4 temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1},{2},{3})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4), ezArgF(value.w, 4));
-  else
-    s.SetFormat("({0}, {1}, {2}, {3})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4), ezArgF(value.w, 4));
-
-  WriteBinaryData("vec4", &temp, sizeof(temp), s.GetData());
+  WriteFloatComponents(&value.x, 4, "xyzw");
 }
 
 void ezStandardJSONWriter::WriteVec2I32(const ezVec2I32& value)
 {
-  CommaWriter cw(this);
-
-  ezVec2I32 temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(ezInt32));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1})", value.x, value.y);
-  else
-    s.SetFormat("({0}, {1})", value.x, value.y);
-
-  WriteBinaryData("vec2i", &temp, sizeof(temp), s.GetData());
+  BeginObject();
+  AddVariableInt32("x", value.x);
+  AddVariableInt32("y", value.y);
+  EndObject();
 }
 
 void ezStandardJSONWriter::WriteVec3I32(const ezVec3I32& value)
 {
-  CommaWriter cw(this);
-
-  ezVec3I32 temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(ezInt32));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1},{2})", value.x, value.y, value.z);
-  else
-    s.SetFormat("({0}, {1}, {2})", value.x, value.y, value.z);
-
-  WriteBinaryData("vec3i", &temp, sizeof(temp), s.GetData());
+  BeginObject();
+  AddVariableInt32("x", value.x);
+  AddVariableInt32("y", value.y);
+  AddVariableInt32("z", value.z);
+  EndObject();
 }
 
 void ezStandardJSONWriter::WriteVec4I32(const ezVec4I32& value)
 {
-  CommaWriter cw(this);
-
-  ezVec4I32 temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(ezInt32));
-
-  ezStringBuilder s;
-
-  if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.SetFormat("({0},{1},{2},{3})", value.x, value.y, value.z, value.w);
-  else
-    s.SetFormat("({0}, {1}, {2}, {3})", value.x, value.y, value.z, value.w);
-
-  WriteBinaryData("vec4i", &temp, sizeof(temp), s.GetData());
+  BeginObject();
+  AddVariableInt32("x", value.x);
+  AddVariableInt32("y", value.y);
+  AddVariableInt32("z", value.z);
+  AddVariableInt32("w", value.w);
+  EndObject();
 }
 
 void ezStandardJSONWriter::WriteQuat(const ezQuat& value)
 {
-  ezQuat temp = value;
+  WriteFloatComponents(&value.x, 4, "xyzw");
+}
 
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
+void ezStandardJSONWriter::WriteMatrix(const float* pValues, ezUInt32 uiRowsAndColumns)
+{
+  BeginArray();
 
-  WriteBinaryData("quat", &temp, sizeof(temp));
+  for (ezUInt32 uiRow = 0; uiRow < uiRowsAndColumns; ++uiRow)
+  {
+    BeginArray();
+
+    for (ezUInt32 uiColumn = 0; uiColumn < uiRowsAndColumns; ++uiColumn)
+    {
+      WriteFloat(pValues[uiRow * uiRowsAndColumns + uiColumn]);
+    }
+
+    EndArray();
+  }
+
+  EndArray();
 }
 
 void ezStandardJSONWriter::WriteMat3(const ezMat3& value)
 {
-  ezMat3 temp = value;
+  float f[9];
+  value.GetAsArray(f, ezMatrixLayout::RowMajor);
 
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
-
-  WriteBinaryData("mat3", &temp, sizeof(temp));
+  WriteMatrix(f, 3);
 }
 
 void ezStandardJSONWriter::WriteMat4(const ezMat4& value)
 {
-  ezMat4 temp = value;
+  float f[16];
+  value.GetAsArray(f, ezMatrixLayout::RowMajor);
 
-  ezEndianHelper::NativeToLittleEndian((ezUInt32*)&temp, sizeof(temp) / sizeof(float));
-
-  WriteBinaryData("mat4", &temp, sizeof(temp));
+  WriteMatrix(f, 4);
 }
 
 void ezStandardJSONWriter::WriteUuid(const ezUuid& value)
 {
-  CommaWriter cw(this);
+  ezStringBuilder s;
+  ezConversionUtils::ToString(value, s);
 
-  ezUuid temp = value;
-
-  ezEndianHelper::NativeToLittleEndian((ezUInt64*)&temp, sizeof(temp) / sizeof(ezUInt64));
-
-  WriteBinaryData("uuid", &temp, sizeof(temp));
+  WriteString(s);
 }
 
 void ezStandardJSONWriter::WriteAngle(ezAngle value)
@@ -391,7 +346,16 @@ void ezStandardJSONWriter::WriteAngle(ezAngle value)
 
 void ezStandardJSONWriter::WriteDataBuffer(const ezDataBuffer& value)
 {
-  WriteBinaryData("data", value.GetData(), value.GetCount());
+  // Hex, because Foundation has no base64 encoder. This doubles the size of the data, so consider
+  // writing a reference to the data instead of the data itself.
+  ezStringBuilder sHex;
+
+  for (ezUInt8 uiByte : value)
+  {
+    sHex.AppendFormat("{}", ezArgU(uiByte, 2, true, 16));
+  }
+
+  WriteString(sHex);
 }
 
 void ezStandardJSONWriter::BeginVariable(ezStringView sName)
@@ -521,6 +485,22 @@ void ezStandardJSONWriter::BeginObject(ezStringView sName)
   ++m_iIndentation;
 
   OutputIndentation();
+}
+
+void ezStandardJSONWriter::WriteRawJson(ezStringView sJson)
+{
+  // places the separating comma and marks the value as written, exactly as for any other value
+  CommaWriter cw(this);
+
+  // not OutputEscapedString(), because the text is JSON already and must not be quoted or escaped
+  OutputString(sJson);
+}
+
+void ezStandardJSONWriter::AddVariableRawJson(ezStringView sName, ezStringView sJson)
+{
+  BeginVariable(sName);
+  WriteRawJson(sJson);
+  EndVariable();
 }
 
 void ezStandardJSONWriter::EndAll()

--- a/Code/Engine/Foundation/IO/JSONWriter.h
+++ b/Code/Engine/Foundation/IO/JSONWriter.h
@@ -285,17 +285,16 @@ private:
 };
 
 
-/// \brief Standard-compliant JSON writer implementation with MongoDB-style binary data extension.
+/// \brief Standard-compliant JSON writer implementation.
 ///
-/// StandardJSONWriter produces fully compliant JSON output that can be read by any standard JSON parser.
-/// It extends the base functionality with support for binary data using MongoDB's binary data convention,
-/// allowing ezEngine-specific types to be represented in a standardized way.
+/// Produces fully compliant JSON that any standard parser reads. The ez types that JSON has no
+/// representation for are written as ordinary objects, arrays and strings - a vector as
+/// {"x":1,"y":2,"z":3}, a matrix as an array of rows, a uuid as its hyphenated string form, an angle
+/// in degrees. Which ez type a value came from is therefore not recorded, so a reader has to know
+/// what it is reading; in particular ezColor (linear) and ezColorGammaUB (gamma, 0-255) are
+/// indistinguishable from the JSON alone.
 ///
-/// Binary data handling:
-/// - ezEngine types (Vec2, Vec3, matrices, etc.) encoded as MongoDB binary objects
-/// - Format: {"$type": "typename", "$binary": "hexdata"}
-/// - Little-endian hex encoding for cross-platform compatibility
-/// - Custom data types supported via WriteBinaryData()
+/// WriteBinaryData() writes MongoDB-style {"$type":..,"$binary":"hexdata"} for callers that want raw bytes.
 class EZ_FOUNDATION_DLL ezStandardJSONWriter : public ezJSONWriter
 {
 public:
@@ -338,46 +337,46 @@ public:
   /// \brief Writes the time value as a double (i.e. redirects to WriteDouble()).
   virtual void WriteTime(ezTime value) override; // [tested]
 
-  /// \brief Outputs the value via WriteVec4().
+  /// \brief Writes {"r":..,"g":..,"b":..,"a":..} with the linear float components.
   virtual void WriteColor(const ezColor& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteVec4().
+  /// \brief Writes {"r":..,"g":..,"b":..,"a":..} with the gamma space components, i.e. 0 to 255.
   virtual void WriteColorGamma(const ezColorGammaUB& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..}.
   virtual void WriteVec2(const ezVec2& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..,"z":..}.
   virtual void WriteVec3(const ezVec3& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..,"z":..,"w":..}.
   virtual void WriteVec4(const ezVec4& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..}.
   virtual void WriteVec2I32(const ezVec2I32& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..,"z":..}.
   virtual void WriteVec3I32(const ezVec3I32& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..,"z":..,"w":..}.
   virtual void WriteVec4I32(const ezVec4I32& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes {"x":..,"y":..,"z":..,"w":..}, the same layout the property system uses.
   virtual void WriteQuat(const ezQuat& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes the matrix row by row, as an array of arrays.
   virtual void WriteMat3(const ezMat3& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes the matrix row by row, as an array of arrays.
   virtual void WriteMat4(const ezMat4& value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes the hyphenated string form, i.e. what ezConversionUtils::ToString() produces.
   virtual void WriteUuid(const ezUuid& value) override; // [tested]
 
-  /// \brief \copydoc ezJSONWriter::WriteFloat()
+  /// \brief Writes the angle in degrees (i.e. redirects to WriteFloat()).
   virtual void WriteAngle(ezAngle value) override; // [tested]
 
-  /// \brief Outputs the value via WriteBinaryData().
+  /// \brief Writes the bytes as a hex string, which is twice the size of the data.
   virtual void WriteDataBuffer(const ezDataBuffer& value) override; // [tested]
 
   /// \brief Implements the MongoDB way of writing binary data. First writes a "$type" variable, then a "$binary" variable that represents the raw
@@ -402,6 +401,19 @@ public:
   /// \brief \copydoc ezJSONWriter::EndObject()
   virtual void EndObject() override; // [tested]
 
+  /// \brief Writes text that is already valid JSON in place, without any escaping of special characters.
+  ///
+  /// For values that were authored as JSON elsewhere and are embedded in this document.
+  /// Anything else, in particular a plain string or data from outside, produces a malformed document,
+  /// use WriteString() for that instead.
+  ///
+  /// Counts as one value, so it can be used wherever WriteBool() and friends can. Indentation and the
+  /// whitespace mode do not apply to the embedded text.
+  void WriteRawJson(ezStringView sJson); // [tested]
+
+  /// \brief Shorthand for "BeginVariable(sName); WriteRawJson(sJson); EndVariable();"
+  void AddVariableRawJson(ezStringView sName, ezStringView sJson); // [tested]
+
   /// \brief Closes every object and array that is still open, so that the output becomes valid JSON.
   ///
   /// For code that has to stop writing part way through - a lookup failed, the data turned out to be
@@ -414,6 +426,14 @@ public:
 
 protected:
   void End();
+
+  /// \brief Writes an object with one float member per component, e.g. {"x":1,"y":2}.
+  ///
+  /// \param sComponentNames One character per component, in order, e.g. "xyzw" or "rgba".
+  void WriteFloatComponents(const float* pValues, ezUInt32 uiCount, ezStringView sComponentNames);
+
+  /// \brief Writes a square matrix row by row, as an array of arrays.
+  void WriteMatrix(const float* pValues, ezUInt32 uiRowsAndColumns);
 
   enum State
   {

--- a/Code/UnitTests/FoundationTest/IO/JSONWriterTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/JSONWriterTest.cpp
@@ -154,7 +154,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
     val[1] = 0x99AABBCCDDEEFF00;
     ezMemoryUtils::Copy(reinterpret_cast<ezUInt64*>(&guid), val, 2);
 
-    StreamComparer sc("\"uuid_var\" : { \"$t\" : \"uuid\", \"$b\" : \"0x887766554433221100FFEEDDCCBBAA99\" }");
+    StreamComparer sc("\"uuid_var\" : \"{ 55667788-3344-1122-00ff-eeddccbbaa99 }\"");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -177,8 +177,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableColor")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"color\", \"$v\" : \"(1.0000, 2.0000, 3.0000, 4.0000)\", \"$b\" : "
-                      "\"0x0000803F000000400000404000008040\" }");
+    StreamComparer sc("\"var1\" : {\n  \"r\" : 1,\n  \"g\" : 2,\n  \"b\" : 3,\n  \"a\" : 4\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -186,9 +185,19 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
     js.AddVariableColor("var1", ezColor(1, 2, 3, 4));
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableColorGamma")
+  {
+    StreamComparer sc("\"var1\" : {\n  \"r\" : 1,\n  \"g\" : 2,\n  \"b\" : 3,\n  \"a\" : 4\n}");
+
+    ezStandardJSONWriter js;
+    js.SetOutputStream(&sc);
+
+    js.AddVariableColorGamma("var1", ezColorGammaUB(1, 2, 3, 4));
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableVec2")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"vec2\", \"$v\" : \"(1.0000, 2.0000)\", \"$b\" : \"0x0000803F00000040\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -198,7 +207,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableVec3")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"vec3\", \"$v\" : \"(1.0000, 2.0000, 3.0000)\", \"$b\" : \"0x0000803F0000004000004040\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2,\n  \"z\" : 3\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -208,8 +217,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableVec4")
   {
-    StreamComparer sc(
-      "\"var1\" : { \"$t\" : \"vec4\", \"$v\" : \"(1.0000, 2.0000, 3.0000, 4.0000)\", \"$b\" : \"0x0000803F000000400000404000008040\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2,\n  \"z\" : 3,\n  \"w\" : 4\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -219,7 +227,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableVec2I32")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"vec2i\", \"$v\" : \"(1, 2)\", \"$b\" : \"0x0100000002000000\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -229,7 +237,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableVec3I32")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"vec3i\", \"$v\" : \"(1, 2, 3)\", \"$b\" : \"0x010000000200000003000000\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2,\n  \"z\" : 3\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -239,7 +247,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableVec4I32")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"vec4i\", \"$v\" : \"(1, 2, 3, 4)\", \"$b\" : \"0x01000000020000000300000004000000\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2,\n  \"z\" : 3,\n  \"w\" : 4\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -249,7 +257,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableDataBuffer")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"data\", \"$b\" : \"0xFF00DA\" }");
+    StreamComparer sc("\"var1\" : \"ff00da\"");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -263,7 +271,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableQuat")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"quat\", \"$b\" : \"0x0000803F000000400000404000008040\" }");
+    StreamComparer sc("\"var1\" : {\n  \"x\" : 1,\n  \"y\" : 2,\n  \"z\" : 3,\n  \"w\" : 4\n}");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -273,7 +281,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableMat3")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"mat3\", \"$b\" : \"0x0000803F000080400000E040000000400000A04000000041000040400000C04000001041\" }");
+    StreamComparer sc("\"var1\" : [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -283,9 +291,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableMat4")
   {
-    StreamComparer sc("\"var1\" : { \"$t\" : \"mat4\", \"$b\" : "
-                      "\"0x0000803F0000A0400000104100005041000000400000C0400000204100006041000040400000E04000003041000070410000804000000041"
-                      "0000404100008041\" }");
+    StreamComparer sc("\"var1\" : [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ], [ 13, 14, 15, 16 ] ]");
 
     ezStandardJSONWriter js;
     js.SetOutputStream(&sc);
@@ -310,6 +316,36 @@ EZ_CREATE_SIMPLE_TEST(IO, StandardJSONWriter)
     js.AddVariableVariant("var3", ezVariant(21.25));
     js.AddVariableVariant("var4", ezVariant(true));
     js.AddVariableVariant("var5", ezVariant("pups"));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "AddVariableRawJson")
+  {
+    StreamComparer sc("\
+{\n\
+  \"schema\" : {\"type\":\"object\"},\n\
+  \"after\" : 23,\n\
+  \"array\" : [ 1, [2,3], \"four\" ]\n\
+}");
+
+    ezStandardJSONWriter js;
+    js.SetOutputStream(&sc);
+
+    js.BeginObject();
+
+    // spliced in unchanged: no quotes, no escaping, and the writer's own whitespace mode does not
+    // reach inside it
+    js.AddVariableRawJson("schema", "{\"type\":\"object\"}");
+
+    // the raw value counts as a value, so the following member is separated by a comma as usual
+    js.AddVariableInt32("after", 23);
+
+    js.BeginArray("array");
+    js.WriteInt32(1);
+    js.WriteRawJson("[2,3]");
+    js.WriteString("four");
+    js.EndArray();
+
+    js.EndObject();
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Arrays")


### PR DESCRIPTION
We haven't used this as serialization for years, and since it isn't that common, it's more useful to write data in a more typical way.

Also added functions to embed raw JSON.