### PR TITLE
Add editor command line options for project export and compilation

### DIFF
--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -993,10 +993,10 @@ ezResult ezCppProject::BuildCodeIfNecessary(const ezCppSettings& cfg)
   if (!ezCppProject::ExistsProjectCMakeListsTxt())
     return EZ_SUCCESS;
 
-  if (!ezCppProject::ExistsSolution(cfg) || ezCppProject::CheckCMakeCache(cfg).Failed())
-  {
-    EZ_SUCCEED_OR_RETURN(ezCppProject::RunCMake(cfg));
-  }
+  // Also re-runs CMake when the generated CMakeUserPresets.json no longer matches the current
+  // configuration - a missing solution and a stale cache are not the only reasons to regenerate, e.g.
+  // the SDK's output directories change when the editor is started from a different build.
+  EZ_SUCCEED_OR_RETURN(ezCppProject::RunCMakeIfNecessary(cfg));
 
   return CompileSolution(cfg);
 }
@@ -1240,6 +1240,57 @@ namespace
     }
   }
 
+  /// Reads the output directories of the SDK build that this application belongs to.
+  ///
+  /// A plugin has to be built into the same directories, otherwise the editor does not find it. They
+  /// cannot be derived from the SDK root: an SDK built with a custom output directory (a separate
+  /// workspace, CI) puts its binaries elsewhere, and then '<sdk>/Output/Bin' is a directory of some
+  /// other build, or does not exist. 'ezExportInfo.cmake' is written next to the binaries by the SDK
+  /// build itself and is therefore the authoritative answer.
+  ///
+  /// Returns EZ_FAILURE when the file is missing or unreadable, in which case the caller should not
+  /// specify the directories at all and let the plugin's CMakeLists.txt fall back to its default.
+  ezResult ReadSdkOutputDirectories(ezStringBuilder& out_sDllDir, ezStringBuilder& out_sLibDir)
+  {
+    ezStringBuilder sFile = ezOSFile::GetApplicationDirectory();
+    sFile.PathParentDirectory(); // strip the '<platform><compiler><config>' folder
+    sFile.AppendPath("ezExportInfo.cmake");
+    sFile.MakeCleanPath();
+
+    ezOSFile file;
+    EZ_SUCCEED_OR_RETURN(file.Open(sFile, ezFileOpenMode::Read));
+
+    ezStringBuilder sContent;
+    {
+      ezDataBuffer content;
+      file.ReadAll(content);
+      sContent = ezStringView((const char*)content.GetData(), content.GetCount());
+    }
+
+    auto ReadValue = [&](ezStringView sVariable, ezStringBuilder& out_sValue) -> ezResult
+    {
+      ezStringBuilder sPrefix("set(", sVariable, " ");
+
+      const char* szStart = sContent.FindSubString(sPrefix);
+      if (szStart == nullptr)
+        return EZ_FAILURE;
+
+      szStart += sPrefix.GetElementCount();
+
+      const char* szEnd = sContent.FindSubString(")", szStart);
+      if (szEnd == nullptr)
+        return EZ_FAILURE;
+
+      out_sValue.SetSubString_FromTo(szStart, szEnd);
+      out_sValue.Trim(" \t\r\n\"");
+      return out_sValue.IsEmpty() ? EZ_FAILURE : EZ_SUCCESS;
+    };
+
+    EZ_SUCCEED_OR_RETURN(ReadValue("EXPINP_OUTPUT_DIRECTORY_DLL", out_sDllDir));
+    EZ_SUCCEED_OR_RETURN(ReadValue("EXPINP_OUTPUT_DIRECTORY_LIB", out_sLibDir));
+    return EZ_SUCCESS;
+  }
+
 } // namespace
 
 ezCppProject::ModifyResult ezCppProject::ModifyCMakeUserPresetsJson(const ezCppSettings& cfg, ezVariantDictionary& inout_json)
@@ -1269,6 +1320,19 @@ ezCppProject::ModifyResult ezCppProject::ModifyCMakeUserPresetsJson(const ezCppS
       return ModifyResult::FAILURE;
 
     Modify(*cacheVariables, "EZ_SDK_DIR", ezFileSystem::GetSdkRootDirectory(), result);
+
+    // Without these the plugin is built into '<sdk>/Output/Bin', which is not where this application
+    // was loaded from when the SDK was built into a custom output directory. The plugin would compile
+    // and the editor would still not find it.
+    {
+      ezStringBuilder sDllDir, sLibDir;
+      if (ReadSdkOutputDirectories(sDllDir, sLibDir).Succeeded())
+      {
+        Modify(*cacheVariables, "EZ_OUTPUT_DIRECTORY_DLL", sDllDir, result);
+        Modify(*cacheVariables, "EZ_OUTPUT_DIRECTORY_LIB", sLibDir, result);
+      }
+    }
+
     Modify(*cacheVariables, "EZ_BUILDTYPE_ONLY", BUILDSYSTEM_BUILDTYPE, result);
     Modify(*cacheVariables, "CMAKE_BUILD_TYPE", BUILDSYSTEM_BUILDTYPE, result);
 

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -73,51 +73,21 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
   s_bCreateLaunchScripts = CreateLaunchScripts->isChecked();
   s_bOpenOutputFolder = OpenOutputFolder->isChecked();
 
-  if (CompileCpp->isChecked())
+  ezProjectExportOptions options;
+  options.m_bCompileCppPlugin = CompileCpp->isChecked();
+  options.m_bTransformAssets = s_bTransformAll;
+  options.m_bCreateLaunchScripts = s_bCreateLaunchScripts;
+
+  const ezString sDstFolder = Destination->text().toUtf8().data();
+
+  ezStringBuilder sLog;
+  const ezStatus res = ezProjectExport::ExportProjectComplete(sDstFolder, options, &sLog);
+
+  ExportLog->setPlainText(sLog.GetData());
+
+  if (res.Failed())
   {
-    if (ezCppProject::EnsureCppPluginReady().Failed())
-      return;
-  }
-
-  if (TransformAll->isChecked())
-  {
-    ezStatus stat = ezAssetCurator::GetSingleton()->TransformAllAssets();
-
-    if (stat.Failed())
-    {
-      ezQtUiServices::GetSingleton()->MessageBoxStatus(stat, "Asset transform failed");
-      return;
-    }
-  }
-
-  const ezString szDstFolder = Destination->text().toUtf8().data();
-
-  ezLogSystemToBuffer logFile;
-
-  auto WriteLogFile = [&]()
-  {
-    ezStringBuilder sTemp;
-    sTemp.Set(szDstFolder, "/ExportLog.txt");
-
-    ExportLog->setPlainText(logFile.m_sBuffer.GetData());
-
-    ezOSFile file;
-
-    if (file.Open(sTemp, ezFileOpenMode::Write).Failed())
-    {
-      ezQtUiServices::GetSingleton()->MessageBoxWarning(ezFmt("Failed to write export log '{0}'", sTemp));
-      return;
-    }
-
-    file.Write(logFile.m_sBuffer.GetData(), logFile.m_sBuffer.GetElementCount()).AssertSuccess();
-  };
-
-  ezLogSystemScope logScope(&logFile);
-  EZ_SCOPE_EXIT(WriteLogFile());
-
-  if (ezProjectExport::ExportProject(szDstFolder, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), ezQtEditorApp::GetSingleton()->GetFileSystemConfig(), s_bCreateLaunchScripts).Failed())
-  {
-    ezQtUiServices::GetSingleton()->MessageBoxWarning("Project export failed. See log for details.");
+    ezQtUiServices::GetSingleton()->MessageBoxStatus(res, "Project export failed. See log for details.");
   }
   else
   {
@@ -125,7 +95,7 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
 
     if (s_bOpenOutputFolder)
     {
-      ezQtUiServices::GetSingleton()->OpenInExplorer(szDstFolder, false);
+      ezQtUiServices::GetSingleton()->OpenInExplorer(sDstFolder, false);
     }
   }
 }

--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -1,5 +1,6 @@
 #include <Core/Configuration/PlatformProfile.h>
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/CodeGen/CppProject.h>
 #include <EditorFramework/CodeGen/CppSettings.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Project/ProjectExport.h>
@@ -490,6 +491,77 @@ void ezProjectExport::AddPackageDependenciesToFileList(DirectoryMapping& ref_fil
       }
     }
   }
+}
+
+ezStatus ezProjectExport::ExportProjectComplete(ezStringView sTargetDirectory, const ezProjectExportOptions& options, ezStringBuilder* out_pLog)
+{
+  if (sTargetDirectory.IsEmpty())
+    return ezStatus("No target directory given.");
+
+  if (!ezPathUtils::IsAbsolutePath(sTargetDirectory))
+    return ezStatus(ezFmt("The target directory '{}' is not an absolute path.", sTargetDirectory));
+
+  const ezString sTargetDir = sTargetDirectory;
+
+  ezLogSystemToBuffer logBuffer;
+  ezStatus result = ezStatus(EZ_SUCCESS);
+
+  {
+    ezLogSystemScope logScope(&logBuffer);
+
+    if (options.m_bCompileCppPlugin)
+    {
+      // Does nothing if the project has no C++ code at all. Failing here would leave the export with
+      // binaries that don't match the code, so it is not something to continue past.
+      if (ezCppProject::EnsureCppPluginReady().Failed())
+      {
+        result = ezStatus("Building the project's C++ plugin failed.");
+      }
+    }
+
+    if (result.Succeeded() && options.m_bTransformAssets)
+    {
+      const ezStatus stat = ezAssetCurator::GetSingleton()->TransformAllAssets();
+
+      if (stat.Failed())
+      {
+        result = ezStatus(ezFmt("Transforming all assets failed: {}", stat.GetMessageString()));
+      }
+    }
+
+    if (result.Succeeded())
+    {
+      if (ezProjectExport::ExportProject(sTargetDir, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), ezQtEditorApp::GetSingleton()->GetFileSystemConfig(), options.m_bCreateLaunchScripts).Failed())
+      {
+        result = ezStatus("Project export failed.");
+      }
+    }
+  }
+
+  if (out_pLog != nullptr)
+  {
+    *out_pLog = logBuffer.m_sBuffer;
+  }
+
+  // Written last, and only when the directory is there: a failure early on means ExportProject() never
+  // got as far as creating it, and an otherwise empty folder containing just a log would look like a
+  // half finished export.
+  if (ezOSFile::ExistsDirectory(sTargetDir))
+  {
+    ezStringBuilder sLogFile(sTargetDir, "/ExportLog.txt");
+
+    ezOSFile file;
+    if (file.Open(sLogFile, ezFileOpenMode::Write).Succeeded())
+    {
+      file.Write(logBuffer.m_sBuffer.GetData(), logBuffer.m_sBuffer.GetElementCount()).IgnoreResult();
+    }
+    else
+    {
+      ezLog::Warning("Failed to write the export log '{}'.", sLogFile);
+    }
+  }
+
+  return result;
 }
 
 ezResult ezProjectExport::ExportProject(const char* szTargetDirectory, const ezPlatformProfile* pPlatformProfile, const ezApplicationFileSystemConfig& dataDirs, bool bCreateLaunchScripts)

--- a/Code/Editor/EditorFramework/Project/ProjectExport.h
+++ b/Code/Editor/EditorFramework/Project/ProjectExport.h
@@ -5,6 +5,7 @@
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/IO/Stream.h>
 #include <Foundation/Logging/Log.h>
+#include <Foundation/Types/Status.h>
 
 struct ezPathPatternFilter;
 class ezAssetCurator;
@@ -14,8 +15,39 @@ class ezProgressRange;
 
 //////////////////////////////////////////////////////////////////////////
 
+/// The steps around ezProjectExport::ExportProjectComplete(), all of which can be skipped.
+///
+/// The defaults are what the 'Export Project' dialog starts out with, ie. do everything.
+struct EZ_EDITORFRAMEWORK_DLL ezProjectExportOptions
+{
+  /// Build the project's C++ plugin first, so that the exported binaries match the current code.
+  /// Has no effect on a project without C++ code.
+  bool m_bCompileCppPlugin = true;
+
+  /// Transform all assets first. Without this, assets that were modified since the last transform are
+  /// exported in their previous state, and assets never transformed for the active profile are missing
+  /// from the export entirely.
+  bool m_bTransformAssets = true;
+
+  /// See ezProjectExport::ExportProject().
+  bool m_bCreateLaunchScripts = true;
+};
+
 struct EZ_EDITORFRAMEWORK_DLL ezProjectExport
 {
+  /// Runs the full export, as triggered by the 'Export Project' dialog.
+  ///
+  /// Does the optional steps in ezProjectExportOptions, then ExportProject() for the currently active
+  /// asset profile and the editor's data directory configuration. The target directory is *cleared*
+  /// first - see ExportProject().
+  ///
+  /// Everything that the export logs is captured and written to 'ExportLog.txt' in the target directory,
+  /// and returned through out_pLog when that is not null. That means it does not show up in the editor's
+  /// log window, so the returned status is the only indication of failure a caller gets without reading
+  /// the log.
+  static ezStatus ExportProjectComplete(ezStringView sTargetDirectory, const ezProjectExportOptions& options, ezStringBuilder* out_pLog = nullptr);
+
+
   /// Exports the project to szTargetDirectory.
   ///
   /// If bCreateLaunchScripts is true, .bat files for launching the exported project are written to the target

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -9,6 +9,7 @@
 #include <EditorFramework/CodeGen/CppProject.h>
 #include <EditorFramework/CodeGen/CppSettings.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorFramework/Project/ProjectExport.h>
 #include <Foundation/Application/Application.h>
 #include <Foundation/System/CrashHandler.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
@@ -26,6 +27,21 @@ Example:\n\
 ",
   "");
 ezCommandLineOptionBool opt_Compile("_EditorProcessor", "-compile", "If specified, the C++ project will be generated and compiled.", false);
+ezCommandLineOptionBool opt_Recompile("_EditorProcessor", "-recompile", "Like -compile, but re-runs CMake and compiles unconditionally.\n\
+\n\
+Use this when files were added to or removed from the C++ source directory, which -compile does not notice.\n\
+",
+  false);
+ezCommandLineOptionPath opt_Export("_EditorProcessor", "-export", "If specified, the project is exported to the given (absolute) directory.\n\
+\n\
+The target directory is deleted first. The C++ project is built and all assets are transformed beforehand,\n\
+the latter unless -transform already did so in the same run. An 'ExportLog.txt' is written into the target\n\
+directory.\n\
+\n\
+Example:\n\
+  -export \"C:/Temp/MyGame\"\n\
+",
+  "");
 
 class ezEditorProcessorApplication : public ezApplication
 {
@@ -194,9 +210,11 @@ public:
     SetErrorMode(dwMode | SEM_NOGPFAULTERRORBOX);
 #endif
     const ezString sTransformProfile = opt_Transform.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
-    const bool bCompile = opt_Compile.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
+    const bool bRecompile = opt_Recompile.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
+    const bool bCompile = opt_Compile.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified) || bRecompile;
     const bool bResave = opt_Resave.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
-    const bool bBackgroundMode = sTransformProfile.IsEmpty() && !bResave && !bCompile;
+    const ezString sExportDir = opt_Export.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
+    const bool bBackgroundMode = sTransformProfile.IsEmpty() && !bResave && !bCompile && sExportDir.IsEmpty();
     const ezString sOutputDir = opt_OutputDir.GetOptionValue(ezCommandLineOption::LogMode::Always);
     const ezBitflags<ezQtEditorApp::StartupFlags> startupFlags = bBackgroundMode ? ezQtEditorApp::StartupFlags::Headless | ezQtEditorApp::StartupFlags::Background : ezQtEditorApp::StartupFlags::Headless;
     ezQtEditorApp::GetSingleton()->StartupEditor(startupFlags, sOutputDir);
@@ -217,14 +235,32 @@ public:
       return;
     }
 
-    if (!sTransformProfile.IsEmpty() || bCompile)
+    if (!sTransformProfile.IsEmpty() || bCompile || !sExportDir.IsEmpty())
     {
       // before we transform any assets or if specifically asked, make sure the C++ code is built
       {
         ezCppSettings cppSettings;
         if (cppSettings.Load().Succeeded())
         {
-          if (ezCppProject::BuildCodeIfNecessary(cppSettings).Failed())
+          // -recompile exists because BuildCodeIfNecessary() only runs CMake when the solution is missing
+          // or its cache is outdated, which does not cover source files being added or removed.
+          ezResult res = EZ_SUCCESS;
+
+          if (bRecompile)
+          {
+            res = ezCppProject::RunCMake(cppSettings);
+
+            if (res.Succeeded())
+            {
+              res = ezCppProject::CompileSolution(cppSettings);
+            }
+          }
+          else
+          {
+            res = ezCppProject::BuildCodeIfNecessary(cppSettings);
+          }
+
+          if (res.Failed())
           {
             SetReturnCode(3);
             return;
@@ -234,36 +270,71 @@ public:
         }
       }
 
-      if (!sTransformProfile.IsEmpty())
+      if (!sTransformProfile.IsEmpty() || !sExportDir.IsEmpty())
       {
-        bool bTransform = true;
+        // Both steps need the editor to be idle, so they share one handler - and they have to run in this
+        // order, because an export picks up whatever the last transform produced.
+        bool bWorkPending = true;
 
-        ezQtEditorApp::GetSingleton()->connect(ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(), [this, &bTransform, &sTransformProfile]()
+        ezQtEditorApp::GetSingleton()->connect(ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(), [this, &bWorkPending, &sTransformProfile, &sExportDir]()
           {
-          if (!bTransform)
+          if (!bWorkPending)
             return;
 
-          bTransform = false;
+          bWorkPending = false;
 
-          const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(sTransformProfile);
+          bool bTransformed = false;
 
-          if (uiPlatform == ezInvalidIndex)
+          if (!sTransformProfile.IsEmpty())
           {
-            ezLog::Error("Asset platform config '{0}' is unknown", sTransformProfile);
-          }
-          else
-          {
-            ezStatus status = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform));
-            if (status.Failed())
+            const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(sTransformProfile);
+
+            if (uiPlatform == ezInvalidIndex)
             {
-              status.LogFailure();
+              ezLog::Error("Asset platform config '{0}' is unknown", sTransformProfile);
               SetReturnCode(1);
+            }
+            else
+            {
+              // so that a following export writes the assets of the profile that was just transformed,
+              // rather than those of whatever profile the project happens to start up with
+              ezAssetCurator::GetSingleton()->SetActiveAssetProfileByIndex(uiPlatform);
+
+              ezStatus status = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform));
+              if (status.Failed())
+              {
+                status.LogFailure();
+                SetReturnCode(1);
+              }
+
+              bTransformed = true;
             }
 
             if (opt_SaveProfilingData.GetOptionValue(ezCommandLineOption::LogMode::Always))
             {
               ezActionContext context;
               ezActionManager::ExecuteAction("Engine", "Editor.SaveProfiling", context).IgnoreResult();
+            }
+          }
+
+          if (!sExportDir.IsEmpty() && GetReturnCode() == 0)
+          {
+            ezProjectExportOptions options;
+            // both already done above: the C++ plugin by the block before the event loop, the assets by
+            // the transform step, for the explicitly requested profile
+            options.m_bCompileCppPlugin = false;
+            options.m_bTransformAssets = !bTransformed;
+
+            const ezStatus status = ezProjectExport::ExportProjectComplete(sExportDir, options);
+
+            if (status.Failed())
+            {
+              status.LogFailure();
+              SetReturnCode(4);
+            }
+            else
+            {
+              ezLog::Success("Exported project to '{}'.", sExportDir);
             }
           }
 

--- a/Data/Samples/Asteroids/CppSource/CMakeLists.txt
+++ b/Data/Samples/Asteroids/CppSource/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 3
+#ez-version 4
 cmake_minimum_required(VERSION 3.21)
 
 # Set CMake policies
@@ -14,9 +14,16 @@ if(PROJECT_IS_TOP_LEVEL)
 
 	message(STATUS "EZ_SDK_DIR is set to '${EZ_SDK_DIR}'")
 
-	# fix output directory
-	set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
-	set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	# Where the SDK's binaries are. The plugin has to be built into the same directories, or the editor
+	# does not find it. The editor passes them in through CMakeUserPresets.json, because an SDK can be
+	# built into a directory other than the default one below.
+	if (NOT EZ_OUTPUT_DIRECTORY_LIB)
+		set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
+	endif()
+
+	if (NOT EZ_OUTPUT_DIRECTORY_DLL)
+		set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	endif()
 
 	include("${EZ_SDK_DIR}/ezCMakeConfig.cmake")
 	get_property(EZ_CMAKE_RELPATH GLOBAL PROPERTY EZ_CMAKE_RELPATH)

--- a/Data/Samples/PacMan/CppSource/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 3
+#ez-version 4
 cmake_minimum_required(VERSION 3.21)
 
 # Set CMake policies
@@ -14,9 +14,16 @@ if(PROJECT_IS_TOP_LEVEL)
 
 	message(STATUS "EZ_SDK_DIR is set to '${EZ_SDK_DIR}'")
 
-	# fix output directory
-	set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
-	set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	# Where the SDK's binaries are. The plugin has to be built into the same directories, or the editor
+	# does not find it. The editor passes them in through CMakeUserPresets.json, because an SDK can be
+	# built into a directory other than the default one below.
+	if (NOT EZ_OUTPUT_DIRECTORY_LIB)
+		set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
+	endif()
+
+	if (NOT EZ_OUTPUT_DIRECTORY_DLL)
+		set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	endif()
 
 	include("${EZ_SDK_DIR}/ezCMakeConfig.cmake")
 	get_property(EZ_CMAKE_RELPATH GLOBAL PROPERTY EZ_CMAKE_RELPATH)

--- a/Data/Samples/RTS/CppSource/CMakeLists.txt
+++ b/Data/Samples/RTS/CppSource/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 3
+#ez-version 4
 cmake_minimum_required(VERSION 3.21)
 
 # Set CMake policies
@@ -14,9 +14,16 @@ if(PROJECT_IS_TOP_LEVEL)
 
 	message(STATUS "EZ_SDK_DIR is set to '${EZ_SDK_DIR}'")
 
-	# fix output directory
-	set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
-	set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	# Where the SDK's binaries are. The plugin has to be built into the same directories, or the editor
+	# does not find it. The editor passes them in through CMakeUserPresets.json, because an SDK can be
+	# built into a directory other than the default one below.
+	if (NOT EZ_OUTPUT_DIRECTORY_LIB)
+		set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
+	endif()
+
+	if (NOT EZ_OUTPUT_DIRECTORY_DLL)
+		set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	endif()
 
 	include("${EZ_SDK_DIR}/ezCMakeConfig.cmake")
 	get_property(EZ_CMAKE_RELPATH GLOBAL PROPERTY EZ_CMAKE_RELPATH)

--- a/Data/Tools/ezEditor/CppProject/CppSource/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 3
+#ez-version 4
 cmake_minimum_required(VERSION 3.21)
 
 # Set CMake policies
@@ -14,9 +14,16 @@ if(PROJECT_IS_TOP_LEVEL)
 
 	message(STATUS "EZ_SDK_DIR is set to '${EZ_SDK_DIR}'")
 
-	# fix output directory
-	set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
-	set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	# Where the SDK's binaries are. The plugin has to be built into the same directories, or the editor
+	# does not find it. The editor passes them in through CMakeUserPresets.json, because an SDK can be
+	# built into a directory other than the default one below.
+	if (NOT EZ_OUTPUT_DIRECTORY_LIB)
+		set (EZ_OUTPUT_DIRECTORY_LIB "${EZ_SDK_DIR}/Output/Lib" CACHE PATH "Where to store the compiled .lib files." FORCE)
+	endif()
+
+	if (NOT EZ_OUTPUT_DIRECTORY_DLL)
+		set (EZ_OUTPUT_DIRECTORY_DLL "${EZ_SDK_DIR}/Output/Bin" CACHE PATH "Where to store the compiled .dll files." FORCE)
+	endif()
 
 	include("${EZ_SDK_DIR}/ezCMakeConfig.cmake")
 	get_property(EZ_CMAKE_RELPATH GLOBAL PROPERTY EZ_CMAKE_RELPATH)


### PR DESCRIPTION
Project export and C++ compilation can now be automated via editor(processor) command line options.