### PR TITLE
Fix detection for unconventional compiler version strings

### DIFF
--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -121,7 +121,16 @@ namespace
     if (splitResult.IsEmpty())
       return EZ_FAILURE;
 
-    ezStringView version = splitResult.PeekBack();
+    ezStringView version;
+    do
+    {
+      version = splitResult.PeekBack();
+      if (version.FindSubString("."))
+      {
+        break;
+      }
+      splitResult.PopBack();
+    } while (!splitResult.IsEmpty());
     splitResult.Clear();
     version.Split(false, splitResult, ".");
     if (splitResult.GetCount() < 3)


### PR DESCRIPTION
The compiler validation test was failing under a seemingly standard Linux GCC install because my GCC build prints out `gcc (GCC) 16.1.1 20260728` at the first line of the `--version` command, which is what `TestCompilerExecutable` expects to always have the comma-separated version number at its end, even though this is not the case for every GCC build, it seems.

Adding the following error log at the version parsing code in `TestCompilerExecutable` at [`CppProject.cpp:129`](https://github.com/ezEngine/ezEngine/blob/cef97fb33eb0520c017bb393392d28f99ef7b48e/Code/Editor/EditorFramework/CodeGen/CppProject.cpp#L129),
```cpp
ezStringView version = splitResult.PeekBack();
splitResult.Clear();
version.Split(false, splitResult, ".");
if (splitResult.GetCount() < 3)
{
  ezLog::Error("\"{}\" compiler version split result count ({}): \"{}\" from \"{}\"", sName, splitResult.GetCount(), version, sStdout.GetView());
  return EZ_FAILURE;
}
```

Produces the following log message if the compiler's `--version` command does not contain a standard comma-separated version string:
```
Error: "gcc" compiler version split result count (1): "20260728" from "gcc (GCC) 16.1.1 20260728
Copyright (C) 2026 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

"
```

This PR then fixes this by selecting the last element of `splitResult` and removing one by one until it finds a satisfying version string. That is one containing a comma, which is what the following `version.Split` already assumes. If not found, the `splitResult` will have less than 3 elements anyway, and will correctly fail on invalid/unexpected input just the same as the parsing code already does.

You may also just re-assign `sStdout` in the same function with a likewise faulty version string if you want to easily reproduce the bug (or check that the PR does not cause regressions for any previously working compiler version string formats).