### PR TITLE
Don't write the Phantom flags into documents

### DIFF
--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
@@ -44,7 +44,7 @@ ezExposedParametersTypeRegistry::ezExposedParametersTypeRegistry()
   desc.m_sTypeName = "ezExposedParametersTypeBase";
   desc.m_sPluginName = "ExposedParametersTypes";
   desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
-  desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
+  desc.m_Flags = ezTypeFlags::Abstract | ezTypeFlags::Class;
   desc.m_uiTypeVersion = 0;
 
   m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -100,7 +100,7 @@ void ezExposedParametersTypeRegistry::UpdateExposedParametersType(ParamData& dat
   desc.m_sTypeName = name;
   desc.m_sPluginName = "ExposedParametersTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
-  desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
+  desc.m_Flags = ezTypeFlags::Class;
   desc.m_uiTypeVersion = 2;
 
   for (const auto* parameter : params.m_Parameters)
@@ -116,7 +116,7 @@ void ezExposedParametersTypeRegistry::UpdateExposedParametersType(ParamData& dat
       ezLog::Warning("The exposed parameter '{}' on type '{}' does not have a type defined as is skipped.", parameter->m_sName, name);
       continue;
     }
-    ezBitflags<ezPropertyFlags> flags = ezPropertyFlags::Phantom;
+    ezBitflags<ezPropertyFlags> flags;
     if (pType->IsDerivedFrom<ezEnumBase>())
       flags |= ezPropertyFlags::IsEnum;
     if (pType->IsDerivedFrom<ezBitflagsBase>())

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -88,7 +88,7 @@ namespace
         descEnum.m_sTypeName = def.m_sName;
         descEnum.m_sPluginName = "ShaderTypes";
         descEnum.m_sParentTypeName = ezGetStaticRTTI<ezEnumBase>()->GetTypeName();
-        descEnum.m_Flags = ezTypeFlags::IsEnum | ezTypeFlags::Phantom;
+        descEnum.m_Flags = ezTypeFlags::IsEnum;
         descEnum.m_uiTypeVersion = 1;
 
         ezArrayPtr<ezPropertyAttribute* const> noAttributes;
@@ -127,7 +127,7 @@ namespace
     descEnum.m_sTypeName = def.m_sName;
     descEnum.m_sPluginName = "ShaderTypes";
     descEnum.m_sParentTypeName = ezGetStaticRTTI<ezEnumBase>()->GetTypeName();
-    descEnum.m_Flags = ezTypeFlags::IsEnum | ezTypeFlags::Phantom;
+    descEnum.m_Flags = ezTypeFlags::IsEnum;
     descEnum.m_uiTypeVersion = 1;
 
     ezArrayPtr<ezPropertyAttribute* const> noAttributes;
@@ -250,7 +250,7 @@ ezShaderTypeRegistry::ezShaderTypeRegistry()
   desc.m_sTypeName = "ezShaderTypeBase";
   desc.m_sPluginName = "ShaderTypes";
   desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
-  desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
+  desc.m_Flags = ezTypeFlags::Abstract | ezTypeFlags::Class;
   desc.m_uiTypeVersion = 2;
 
   m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -344,7 +344,7 @@ void ezShaderTypeRegistry::UpdateShaderType(ShaderData& data)
   desc.m_sTypeName = data.m_sShaderPath;
   desc.m_sPluginName = "ShaderTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
-  desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
+  desc.m_Flags = ezTypeFlags::Class;
   desc.m_uiTypeVersion = 2;
 
   for (auto& enumDef : enumDefinitions)
@@ -360,7 +360,7 @@ void ezShaderTypeRegistry::UpdateShaderType(ShaderData& data)
       continue;
     }
 
-    ezBitflags<ezPropertyFlags> flags = ezPropertyFlags::Phantom;
+    ezBitflags<ezPropertyFlags> flags;
     if (pType->IsDerivedFrom<ezEnumBase>())
       flags |= ezPropertyFlags::IsEnum;
     if (pType->IsDerivedFrom<ezBitflagsBase>())
@@ -445,7 +445,7 @@ public:
       desc.m_sTypeName = "ezShaderTypeBase";
       desc.m_sPluginName = "ShaderTypes";
       desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
-      desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
+      desc.m_Flags = ezTypeFlags::Abstract | ezTypeFlags::Class;
       desc.m_uiTypeVersion = 1;
 
       context.RegisterObject(ezUuid::MakeStableUuidFromString(desc.m_sTypeName.GetData()), ezGetStaticRTTI<ezReflectedTypeDescriptor>(), &desc);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
@@ -234,7 +234,7 @@ void ezVisualShaderTypeRegistry::LoadNodeData()
     desc.m_sTypeName = "ezVisualShaderNodeBase";
     desc.m_sPluginName = "VisualShaderTypes";
     desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
-    desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
+    desc.m_Flags = ezTypeFlags::Abstract | ezTypeFlags::Class;
     desc.m_uiTypeVersion = 1;
 
     m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -246,7 +246,7 @@ void ezVisualShaderTypeRegistry::LoadNodeData()
     desc.m_sTypeName = "ezVisualShaderSamplerPin";
     desc.m_sPluginName = "VisualShaderTypes";
     desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
-    desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
+    desc.m_Flags = ezTypeFlags::Class;
     desc.m_uiTypeVersion = 1;
 
     m_pSamplerPinType = ezPhantomRttiManager::RegisterType(desc);
@@ -264,7 +264,7 @@ const ezRTTI* ezVisualShaderTypeRegistry::GenerateTypeFromDesc(const ezVisualSha
   desc.m_sTypeName = temp;
   desc.m_sPluginName = "VisualShaderTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
-  desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
+  desc.m_Flags = ezTypeFlags::Class;
   desc.m_uiTypeVersion = 1;
   desc.m_Properties = nd.m_Properties;
 
@@ -491,7 +491,7 @@ void ezVisualShaderTypeRegistry::ExtractNodePins(const ezOpenDdlReaderElement* p
       {
         pin.m_PropertyDesc.m_sName = pin.m_sName;
         pin.m_PropertyDesc.m_Category = ezPropertyCategory::Member;
-        pin.m_PropertyDesc.m_Flags.SetValue((ezUInt16)ezPropertyFlags::Phantom | (ezUInt16)ezPropertyFlags::StandardType);
+        pin.m_PropertyDesc.m_Flags.SetValue((ezUInt16)ezPropertyFlags::StandardType);
 
         // For "auto" type pins, use float as the fallback type for the property GUI
         const ezRTTI* pPropertyType = pin.m_pDataType != nullptr ? pin.m_pDataType : ezGetStaticRTTI<float>();
@@ -520,7 +520,7 @@ void ezVisualShaderTypeRegistry::ExtractNodeProperties(const ezOpenDdlReaderElem
 
       ezReflectedPropertyDescriptor prop;
       prop.m_Category = ezPropertyCategory::Member;
-      prop.m_Flags.SetValue((ezUInt16)ezPropertyFlags::Phantom | (ezUInt16)ezPropertyFlags::StandardType);
+      prop.m_Flags.SetValue((ezUInt16)ezPropertyFlags::StandardType);
 
       if (!pElement->HasName())
       {

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -313,7 +313,7 @@ void ezVisualScriptNodeRegistry::UpdateNodeTypes()
     desc.m_sTypeName = "ezVisualScriptNodeBase";
     desc.m_sPluginName = szPluginName;
     desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
-    desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
+    desc.m_Flags = ezTypeFlags::Abstract | ezTypeFlags::Class;
 
     m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
   }
@@ -2070,7 +2070,7 @@ void ezVisualScriptNodeRegistry::FillDesc(ezReflectedTypeDescriptor& desc, ezStr
   desc.m_sTypeName = sTypeNameFull;
   desc.m_sPluginName = szPluginName;
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
-  desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
+  desc.m_Flags = ezTypeFlags::Class;
 
   // Color
   {

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
@@ -130,7 +130,9 @@ void ezPhantomRTTI::SetAttributes(ezDynamicArray<const ezPropertyAttribute*>& at
 
 void ezPhantomRTTI::UpdateType(ezReflectedTypeDescriptor& desc)
 {
-  ezRTTI::UpdateType(ezRTTI::FindTypeByName(desc.m_sParentTypeName), 0, desc.m_uiTypeVersion, ezVariantType::Invalid, desc.m_Flags);
+  // ezRTTI::UpdateType overwrites the type flags, so Phantom has to be added here just like in the constructor,
+  // otherwise a type would stop being phantom when it is registered a second time with a changed descriptor
+  ezRTTI::UpdateType(ezRTTI::FindTypeByName(desc.m_sParentTypeName), 0, desc.m_uiTypeVersion, ezVariantType::Invalid, desc.m_Flags | ezTypeFlags::Phantom);
 
   m_sPluginNameStorage = desc.m_sPluginName;
   m_sPluginName = m_sPluginNameStorage.GetData();

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ToolsReflectionUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ToolsReflectionUtils.cpp
@@ -242,7 +242,9 @@ void ezToolsReflectionUtils::GetReflectedTypeDescriptorFromRtti(const ezRTTI* pR
       case ezPropertyCategory::Map:
       {
         const ezRTTI* pPropRtti = prop->GetSpecificType();
-        out_desc.m_Properties.PushBack(ezReflectedPropertyDescriptor(prop->GetCategory(), prop->GetPropertyName(), pPropRtti->GetTypeName(), prop->GetFlags(), prop->GetAttributes()));
+        ezBitflags<ezPropertyFlags> flags = prop->GetFlags();
+        flags.Remove(ezPropertyFlags::Phantom);
+        out_desc.m_Properties.PushBack(ezReflectedPropertyDescriptor(prop->GetCategory(), prop->GetPropertyName(), pPropRtti->GetTypeName(), flags, prop->GetAttributes()));
       }
       break;
 
@@ -261,7 +263,9 @@ void ezToolsReflectionUtils::GetReflectedTypeDescriptorFromRtti(const ezRTTI* pR
   for (ezUInt32 i = 0; i < uiFuncCount; ++i)
   {
     const ezAbstractFunctionProperty* prop = rttiFunc[i];
-    out_desc.m_Functions.PushBack(ezReflectedFunctionDescriptor(prop->GetPropertyName(), prop->GetFlags(), prop->GetFunctionType(), prop->GetAttributes()));
+    ezBitflags<ezPropertyFlags> funcFlags = prop->GetFlags();
+    funcFlags.Remove(ezPropertyFlags::Phantom);
+    out_desc.m_Functions.PushBack(ezReflectedFunctionDescriptor(prop->GetPropertyName(), funcFlags, prop->GetFunctionType(), prop->GetAttributes()));
     ezReflectedFunctionDescriptor& desc = out_desc.m_Functions.PeekBack();
     desc.m_ReturnValue = ezFunctionArgumentDescriptor(prop->GetReturnType() ? prop->GetReturnType()->GetTypeName() : "", prop->GetReturnFlags());
     const ezUInt32 uiArguments = prop->GetArgumentCount();
@@ -282,6 +286,10 @@ void ezToolsReflectionUtils::GetMinimalReflectedTypeDescriptorFromRtti(const ezR
   out_desc.m_sTypeName = pRtti->GetTypeName();
   out_desc.m_sPluginName = pRtti->GetPluginName();
   out_desc.m_Flags = pRtti->GetTypeFlags() | ezTypeFlags::Minimal;
+  // Phantom describes how a type is represented in the current process, not the type itself: it is added by
+  // ezPhantomRTTI and the ezPhantom*Property classes when a descriptor is registered, so it must not travel
+  // with the descriptor (it would be written into every document that references a phantom type).
+  out_desc.m_Flags.Remove(ezTypeFlags::Phantom);
   out_desc.m_uiTypeVersion = pRtti->GetTypeVersion();
   const ezRTTI* pParentRtti = pRtti->GetParentType();
   out_desc.m_sParentTypeName = pParentRtti ? pParentRtti->GetTypeName() : nullptr;

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedType.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedType.h
@@ -56,6 +56,8 @@ struct EZ_TOOLSFOUNDATION_DLL ezReflectedPropertyDescriptor : public ezAttribute
   ezString m_sName; ///< The name of this property. E.g. what ezAbstractProperty::GetPropertyName() returns.
   ezString m_sType; ///< The name of the type of the property. E.g. ezAbstractProperty::GetSpecificType().GetTypeName()
 
+  /// ezPropertyFlags::Phantom is not part of a descriptor: it is added by the ezPhantom*Property classes when the
+  /// descriptor is registered, so setting it here has no effect other than writing it into serialized documents.
   ezBitflags<ezPropertyFlags> m_Flags;
   ezVariant m_ConstantValue;
 };
@@ -99,6 +101,8 @@ struct EZ_TOOLSFOUNDATION_DLL ezReflectedTypeDescriptor : public ezAttributeHold
   ezString m_sPluginName;
   ezString m_sParentTypeName;
 
+  /// ezTypeFlags::Phantom is not part of a descriptor: ezPhantomRTTI adds it to every type it creates, so setting it
+  /// here has no effect other than writing it into serialized documents.
   ezBitflags<ezTypeFlags> m_Flags;
   ezDynamicArray<ezReflectedPropertyDescriptor> m_Properties;
   ezDynamicArray<ezReflectedFunctionDescriptor> m_Functions;

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -376,6 +376,9 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectedTypeReloading)
       const ezRTTI* NewInnerHandle = ezPhantomRttiManager::RegisterType(descInner);
       EZ_TEST_BOOL(NewInnerHandle == pRttiInnerP);
 
+      // updating a type must not make it stop being phantom - descriptors don't carry that flag
+      EZ_TEST_BOOL(NewInnerHandle->GetTypeFlags().IsSet(ezTypeFlags::Phantom));
+
       // Check that the new property is present.
       AccessorPropertyTest(innerAccessor, "IP2", ezVariant::Type::Vector4);
 


### PR DESCRIPTION
ezTypeFlags::Phantom states that a type came from another process and is represented by ezPhantomRTTI. That is a property of the process, not of the type, so it shouldn't get serialized.

It ended up there because ezPhantomRTTI and the ezPhantom*Property classes add the flag to themselves. Several registries additionally set the flag by hand on the descriptors they pass to ezPhantomRttiManager::RegisterType, which was redundant.

The result was misleading data in every document that references a phantom type, e.g. a material listing a shader parameter as

```
s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
s %Name{"MetallicValue"}
s %Type{"float"}
```

which reads as if 'float' were a phantom type.

Nothing ever evaluated the flag on a descriptor, so this is benign, but confusing.

ezToolsReflectionUtils now strips both flags when it builds a descriptor from an ezRTTI. Behavior is unchanged: types registered from such a descriptor still become phantom, because ezPhantomRTTI adds the flag itself.

ezPhantomRTTI::UpdateType has to add the flag as well: ezRTTI::UpdateType overwrites the type flags, so without this a type would stop being phantom when it is registered a second time with a changed descriptor, after which its full definition would no longer be embedded into documents. Added a check in the ReflectedTypeReloading test.