### PR TITLE
Fixed that pins didn't get transferred to a pasted Expression node

### DIFF
--- a/Code/Tools/Libs/ToolsFoundation/VisualGraph/Implementation/VisualGraphObjectManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/VisualGraph/Implementation/VisualGraphObjectManager.cpp
@@ -914,13 +914,6 @@ void ezVisualGraphObjectManager::StructureEventHandler(const ezDocumentObjectStr
     {
       if (IsNode(e.m_pObject))
       {
-        auto& nodeInternal = m_ObjectToNode[e.m_pObject->GetGuid()];
-        if (nodeInternal.m_Inputs.IsEmpty() && nodeInternal.m_Outputs.IsEmpty())
-        {
-          InternalCreatePins(e.m_pObject, nodeInternal);
-          // TODO: Sanity check pins (duplicate names etc).
-        }
-
         ezVisualGraphObjectManagerEvent e2(ezVisualGraphObjectManagerEvent::Type::BeforeNodeAdded, e.m_pObject);
         m_NodeEvents.Broadcast(e2);
       }
@@ -928,6 +921,16 @@ void ezVisualGraphObjectManager::StructureEventHandler(const ezDocumentObjectStr
     break;
     case ezDocumentObjectStructureEvent::Type::AfterObjectAdded:
     {
+      if (IsNode(e.m_pObject))
+      {
+        auto& nodeInternal = m_ObjectToNode[e.m_pObject->GetGuid()];
+        if (nodeInternal.m_Inputs.IsEmpty() && nodeInternal.m_Outputs.IsEmpty())
+        {
+          InternalCreatePins(e.m_pObject, nodeInternal);
+          // TODO: Sanity check pins (duplicate names etc).
+        }
+      }
+
       if (IsNode(e.m_pObject) || IsComment(e.m_pObject))
       {
         ezVisualGraphObjectManagerEvent e2(ezVisualGraphObjectManagerEvent::Type::AfterNodeAdded, e.m_pObject);


### PR DESCRIPTION
1. create Visual Script
2. add Expression node
3. create some input/output pins
4. copy that node (ctrl+c)
5. paste (ctrl+v)
6. there are no pins on pasted node.

<img width="302" height="401" alt="image" src="https://github.com/user-attachments/assets/7a2fc233-ef0f-4ad2-ba91-2c628fbf26bd" />


### error
also if you copy/paste Expression node _together with nodes connected to its pins_ - you will get an error:

<img width="548" height="395" alt="image" src="https://github.com/user-attachments/assets/501569be-dea9-46a0-937e-8aa5cec0f4b6" />

### The fix:
move `InternalCreatePins` from BeforeObjectAdded event to AfterObjectAdded event.

### Comments
I don't really know why my fix works, because i'm not an expert. Just tried some idea and it happened to do the job. Please check and correct my fix if it is breaking something.