### PR TITLE
Added MCP servers for editor and running games

### DIFF
--- a/.claude/skills/ez-mcp/SKILL.md
+++ b/.claude/skills/ez-mcp/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: ez-mcp
+description: Drive a running ezEditor or ezPlayer/game from an agent over MCP - launch one with a port, then call tools to inspect and change a live project. Use for ezEngine tasks that need the running app rather than files on disk. Triggers - ezEditor, ezPlayer, ezEditorProcessor, MCP server, editor-mcpport, mcpport, transform asset, asset dependencies, asset browser, open document, edit scene, build a scene, game object, component, prefab, property grid, selection, reflected types, RTTI, CVar, editor action, play the game, screenshot, inject input, press key, step frames, export project, create project, build the C++ plugin.
+---
+
+# Driving ezEditor and the game over MCP
+
+Two hosts, same protocol, **separate ports and separate tool lists**:
+
+| Host | Started with | Answers about |
+| --- | --- | --- |
+| **Editor** (`ezEditor.exe`) | `-editor-mcpport <n>` | assets, documents, scene contents, reflected types, editor actions, the C++ plugin |
+| **Game** (`ezPlayer.exe`, or the engine process the editor plays in) | `-mcpport <n>` | what is rendered and simulated: screenshots, input, frames, the clock |
+
+Neither is a registered project MCP server: neither runs most of the time and the port is per run. Start
+one, then talk to it. For anything the file system already answers, read the files instead.
+
+## Launching
+
+```shell
+# editor
+ezEditor.exe -project "Data/Samples/PacMan" -unattended -editor-mcpport 7399
+# game, standalone - no editor needed
+ezPlayer.exe -project <project-folder> -scene <path/to/Scene.ezBinScene> -profile Default -mcpport 7401
+```
+
+Binaries are in `Workspace/<workspace>-output/Bin/WinVs2026Dev64/`.
+
+- **`-unattended` is required for the editor.** Otherwise a modal dialog during startup (e.g. "compile
+  the C++ plugin?") hangs it before it serves anything. Tool calls suppress dialogs themselves; startup
+  does not.
+- Launch detached (`start ""` / `Start-Process`); it runs until told to quit.
+- Startup takes seconds - **poll the port**, do not sleep a fixed time.
+- Pick a port other than the default 7391 so a user's own editor keeps working.
+- Without `-mcpport` the game starts **no** server at all.
+- `-editor-mcpport` and `-mcpport` are separate names on purpose: the editor forwards its whole command
+  line to its engine process, which takes `-editor-mcpport` + 1. Read that port from the editor's
+  `app_info` as `engineMcpPort` rather than computing it.
+- `-project` or `-createProject` keeps the dashboard away.
+
+## Calling tools
+
+```shell
+curl -s -X POST http://127.0.0.1:7399/mcp -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"project_info","arguments":{}}}'
+```
+
+`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` returns every tool with its full description and input
+schema. **Read that list before guessing** - the descriptions carry the argument semantics and the
+warnings, plugins can add tools, and the two hosts do not have the same list. Results are JSON in
+`content[0].text`; failures carry `"isError":true` and a sentence saying what to do instead.
+
+To register a running host for the session:
+`claude mcp add --transport http ez-editor http://127.0.0.1:7399/mcp`.
+
+## What is there
+
+Both hosts: `app_info`, `app_ping`, `app_quit`, `app_command_line_options`, `log_read`, `log_write`,
+`cvar_list`, `cvar_set`, `rtti_find_types`, `rtti_type_info`, `rtti_type_properties`,
+`rtti_derived_types` - each answering for *its own* process.
+
+| Editor only | |
+| --- | --- |
+| Project | `project_info`, `project_export` |
+| C++ plugin | `cpp_status`, `cpp_generate`, `cpp_build` |
+| Assets | `asset_types`, `asset_find`, `asset_info`, `asset_uses`, `asset_thumbnail`, `asset_transform`, `asset_health`, `asset_history`, `asset_processor`, `asset_importers`, `asset_import` |
+| Documents | `document_types`, `document_list`, `document_open`, `document_create`, `document_save`, `document_close`, `document_focus`, `document_delete` |
+| Contents | `object_tree`, `object_properties`, `object_modify`, `object_undo` |
+| Selection | `selection_get`, `selection_set` |
+| Actions | `action_list`, `action_state`, `action_execute` |
+
+| Game only | |
+| --- | --- |
+| Rendering | `app_screenshot` |
+| Time | `game_info`, `game_wait`, `game_pause`, `game_speed` |
+| Input | `input_slots`, `input_set`, `input_sequence` |
+
+Start with `project_info` on the editor (paths and asset states are relative to what it reports), and
+with `game_info` on the game.
+
+## Editing a document
+
+Nothing works on a closed document, and nothing opens implicitly:
+
+1. `asset_find` → path or guid. Its paths start with the data directory name
+   (`Testing Chambers/Scenes/DynamicFog.ezScene`) - that is the form other tools want.
+2. `document_open` with `focus` false, unless the user is meant to look at it.
+3. `object_tree` → guids. Asset documents have one top level object, so `object_properties` with only
+   `document` already reads an asset's whole configuration. Scenes have many.
+4. `object_properties` / `object_modify`.
+5. `document_save` - nothing saves on its own, and the asset system sees nothing until it is saved.
+
+A scene's game objects and components live in the same hierarchy, told apart by the parent property they
+sit in. Building one is all `object_modify`:
+
+```
+addObject   property "Children",   type "ezGameObject"          -> child object
+addObject   property "Components", type "ezPointLightComponent"  -> component on it
+set         property "Name" / "LocalPosition" / any component property
+moveObject  newParent <guid>    | duplicateObject | deleteObject  (each takes everything below it)
+```
+
+`rtti_derived_types` of `ezComponent` lists component types; `rtti_type_properties` gives property
+names, value types and enum values before writing any. Vectors and colours go in as they come out
+(`{"x":1,"y":2,"z":3}` or `[1,2,3]`). `selection_set` is worth calling even when it changes nothing - it
+is how the user sees which object is meant, and `selection_get` answers "this object".
+
+## Driving the game
+
+`gameStateActive` false in `game_info` means nothing is being played - normal for the editor's engine
+process until play-the-game runs, and why input does nothing and screenshots time out.
+
+- Start it from the **editor** port: `action_execute` `Scene.GameMode.Play` with the scene document;
+  `Scene.GameMode.Stop` ends it. Both are asynchronous (the editor asks the engine process), so `Stop`
+  reads as disabled for a moment and `game_info` on the game port is the better confirmation.
+- **`app_screenshot` returns a path, not the image.** Read that file. A rendered frame is the evidence a
+  change works; "did not crash" is not.
+- **`input_set` then `game_wait`** - input is consumed one frame at a time, so setting a slot alone does
+  nothing. `input_sequence` does a whole set/wait/text/clear chain in one call. Injected values merge
+  with the real keyboard, larger wins, so a human is never locked out.
+- **`game_pause` stops the engine clock, not necessarily the game's own simulation.**
+- `cvar_list` is worth far more here than in the editor: render passes, physics and AI visualisation are
+  mostly CVars.
+
+## Editor actions
+
+`action_execute` runs global actions by name. Actions of scope `Document` or `Window` need a `document`
+argument (guid or path, already open); so do `action_list` and `action_state`, and that is the only way
+to read their per-document enabled state. Passing `document` to `action_list` also flips `globalOnly`
+off, so `{"contains":"GameMode","document":"…","includeState":true}` is the usual way to find them.
+`Window` actions additionally need a window (`document_open` with `focus` true).
+
+## C++ plugin
+
+`cpp_status` first: `hasCppProject` false means no C++ code at all and `cpp_generate` creates it;
+`compilerUsable` false means CMake will refuse and `cpp_generate` with `useSdkCompiler` is the fix.
+After editing sources call `cpp_build`, with `force` when files were added, removed or renamed (CMake
+collects them at generation time). Both return the full build log - on failure it is the only place the
+compiler errors are. Then check `pluginBinary` / `pluginBinaryExists`: a build that reports success
+without producing the library means the plugin is not in use. Headless equivalent:
+`ezEditorProcessor.exe -project <path> -compile` (`-recompile` forces CMake too).
+
+## Creating a project
+
+No tool for it - a different set of plugins is loaded, so it happens at launch:
+
+```shell
+ezEditor.exe -createProject "C:/Projects/MyGame" -projectTemplate "Basic FPS" -unattended -editor-mcpport 7399
+```
+
+The directory must be empty or absent; the project opens right away. Without `-projectTemplate` the
+project is blank, using `-pluginTemplate` (default `General3D`). `-listTemplates` logs the valid names.
+`ezEditorProcessor.exe` takes the same options and quits when done - better when no editor is wanted
+afterwards.
+
+## Rules that are not obvious
+
+- **Every call blocks its host.** One at a time, on the main thread. No progress, no cancel.
+- **Some calls run for minutes**: `asset_transform` over a project, `project_export`, `cpp_build`,
+  `cpp_generate`. Give curl a timeout in tens of minutes.
+- **`app_ping` tells "busy" from "hung".** It answers only when the main thread is free, so silence
+  during a long call is expected and silence afterwards is not. Take the process id from `app_info` up
+  front - a hung host must be killed by pid, and `app_quit` will not get through either.
+- **`log_read` only sees its own process.** The editor cannot see what the engine logged, or vice versa.
+  `app_info` reports `engineLogFilePattern` for when that process has died.
+- **A failed assert comes back as a tool error** with file, line and expression. That is an engine bug,
+  not bad arguments - retrying will not help. The host keeps answering but has continued past a check
+  meant to stop it, so restart it before trusting anything further, and report the text.
+- **Check `app_info`'s `buildTimestamp` before concluding a tool is missing.** A binary built before a
+  feature returns the same `tools/list` as one that never had it.
+- **`cvar_set` on a `requiresRestart` CVar does not change what the engine reads.** The response returns
+  `pendingValue` separately; re-reading keeps showing the old `value`, and that is not a failed write.
+- **Quit before rebuilding**: `app_quit` (with `discardChanges` if documents are modified), or the plugin
+  DLLs stay locked and the build fails.
+- **Nothing saves implicitly.** `object_modify` only marks the document modified; `object_undo` reverts.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .claude/*
 !.claude/settings.json
 !.claude/commands
+!.claude/skills
 .idea/
 /build
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -246,8 +246,15 @@ bool ezEngineProcessGameApplication::ProcessIPCMessages(bool bPendingOpInProgres
     else
     {
       EZ_PROFILE_SCOPE("WaitForMessages");
+
+      // A plugin may have work that no IPC message is going to announce - see m_HasPendingExternalWork.
+      // Waiting with a short timeout then keeps the frame loop turning, at the cost of a wake-up every
+      // 20 ms while such work is outstanding. When nothing is pending this still blocks indefinitely,
+      // so an idle engine process costs nothing.
+      const bool bExternalWork = m_HasPendingExternalWork.IsValid() && m_HasPendingExternalWork();
+
       // Only suspend and wait if no more pending ops need to be done.
-      m_IPC.WaitForMessages();
+      m_IPC.WaitForMessages(bExternalWork ? ezTime::MakeFromMilliseconds(20) : ezTime::MakeZero());
     }
   }
   return true;

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -45,12 +45,12 @@ bool ezProcessCommunicationChannel::ProcessMessages()
 }
 
 
-void ezProcessCommunicationChannel::WaitForMessages()
+void ezProcessCommunicationChannel::WaitForMessages(ezTime timeout /*= ezTime::MakeZero()*/)
 {
   if (!m_pProtocol)
     return;
 
-  m_pProtocol->WaitForMessages().IgnoreResult();
+  m_pProtocol->WaitForMessages(timeout).IgnoreResult();
 }
 
 void ezProcessCommunicationChannel::OnIpcProtocolEvent(const ezIpcProcessMessageProtocol::Event& msg)

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
@@ -29,7 +29,12 @@ public:
 
   /// \brief Returns true if any message was processed
   bool ProcessMessages();
-  void WaitForMessages();
+
+  /// \brief Blocks until a message arrives.
+  ///
+  /// \param timeout Zero blocks indefinitely. Pass a short one when the caller has other work that a
+  ///        message is not going to wake it up for.
+  void WaitForMessages(ezTime timeout = ezTime::MakeZero());
 
   struct Event
   {

--- a/Code/EditorPlugins/Mcp/CMakeLists.txt
+++ b/Code/EditorPlugins/Mcp/CMakeLists.txt
@@ -1,0 +1,1 @@
+ez_add_all_subdirs()

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/CMakeLists.txt
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/CMakeLists.txt
@@ -1,0 +1,20 @@
+ez_cmake_init()
+
+ez_requires_editor()
+
+# Get the name of this folder as the project name
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
+
+ez_create_target(LIBRARY ${PROJECT_NAME})
+
+# No 'Network' component: the MCP server speaks plain sockets now, in the Mcp library, so that the same
+# server can run inside the engine process, which has no Qt. Qt is still needed for the tools themselves.
+ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets)
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+  EditorFramework
+  Mcp
+)
+
+ez_copy_plugin_bundle(${PROJECT_NAME} "Mcp")

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcp.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcp.cpp
@@ -1,0 +1,170 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <Mcp/McpServer.h>
+#include <Mcp/McpToolRegistry.h>
+
+#include <Foundation/Utilities/CommandLineOptions.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+
+/// The port to listen on.
+///
+/// Exists so that several editors can run at the same time, each answering on its own port: with a
+/// single fixed port the second editor just fails to bind. That matters for automated testing, where
+/// one editor is launched per project and has to be addressable independently of any other.
+///
+/// Spelled '-editor-mcpport' rather than '-mcpport' because the editor forwards its whole command line
+/// to the engine process it starts, which serves MCP as well. One name for both would have meant both
+/// processes reading the same number and fighting over the port; two names mean the engine process can
+/// derive its own from this one without anything being passed explicitly.
+///
+/// The default is what a client connects to when nothing else was agreed on, so changing it means
+/// changing the documented URL as well (see the 'ez-mcp' skill). Ports below 1024 are excluded
+/// because they need elevation on most systems, and 0 because 'any free port' cannot be put into a
+/// client's URL.
+static ezCommandLineOptionInt s_opt_McpPort("_Mcp", "-editor-mcpport",
+  "The port that the editor's MCP server listens on, on 127.0.0.1.\n"
+  "Pass a distinct port per editor to run several at the same time.\n"
+  "The engine process that runs the game serves MCP on this port + 1, unless it is given '-mcpport'.",
+  7391, 1024, 0xFFFF);
+
+static ezMcpServer* s_pServer = nullptr;
+static ezEventSubscriptionID s_TickSubscription = 0;
+
+static void ToolsProjectEventHandler(const ezToolsProjectEvent& e);
+static void TickEventHandler(const ezQtUiServices::TickEvent& e);
+
+/// \brief Runs one tool call inside the editor's unattended mode, and turns a failed assert into an error.
+///
+/// This is the editor's half of what ezMcpToolRegistry used to do itself. It stays here, in the plugin,
+/// because none of it means anything in a game process.
+static void ExecuteWrapper(ezStringView sToolName, ezMcpToolResult& ref_result, ezDelegate<void()> execute)
+{
+  // Only for the duration of the call: the user typically *is* sitting in front of this editor, so their
+  // own menu clicks must keep opening dialogs. It is the agent's call that must not block on one - see
+  // ezQtDialog. What got suppressed is reported afterwards, otherwise a suppressed dialog is
+  // indistinguishable from the operation having done nothing.
+  ezQtScopedUnattended unattended;
+  ezQtUiServices::ClearSuppressedDialogs();
+  ezQtUiServices::ClearFailedAsserts();
+
+  execute();
+
+  // An assert that fires during a tool call no longer stops the editor - the handler installed by
+  // ezQtUiServices records it and lets execution continue - but whatever the tool produced afterwards
+  // was produced by code that had already declared its own assumptions broken. Reporting it as an error
+  // is the only honest answer, and it replaces what used to be a hung editor and a lost session.
+  const ezArrayPtr<const ezString> asserts = ezQtUiServices::GetFailedAsserts();
+
+  if (!asserts.IsEmpty())
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("Tool '{}' triggered {} failed assert(s). Its result is not trustworthy and the editor may now be in a broken "
+                     "state - restart it before relying on anything further. This is a bug in the editor or in the tool, not "
+                     "something the arguments can be changed to avoid; report it with the text below.\n",
+      sToolName, asserts.GetCount());
+
+    for (const ezString& sAssert : asserts)
+    {
+      sError.AppendFormat("\n{}", sAssert);
+    }
+
+    ref_result.SetError(sError);
+  }
+}
+
+void OnLoadPlugin()
+{
+  // s_Events is static, so this works before any project has been opened
+  ezToolsProject::s_Events.AddEventHandler(ToolsProjectEventHandler);
+
+  ezMcpToolRegistry::SetExecuteWrapper(&ExecuteWrapper);
+
+  // create the tool providers already now, rather than when the server starts, so that the log tool
+  // sees everything that happens during editor startup
+  ezMcpToolRegistry::UpdateProviders();
+}
+
+void OnUnloadPlugin()
+{
+  ezToolsProject::s_Events.RemoveEventHandler(ToolsProjectEventHandler);
+
+  if (s_TickSubscription != 0)
+  {
+    ezQtUiServices::s_TickEvent.RemoveEventHandler(s_TickSubscription);
+    s_TickSubscription = 0;
+  }
+
+  EZ_DEFAULT_DELETE(s_pServer);
+
+  ezMcpToolRegistry::SetExecuteWrapper({});
+  ezMcpToolRegistry::Clear();
+}
+
+EZ_PLUGIN_ON_LOADED()
+{
+  OnLoadPlugin();
+}
+
+EZ_PLUGIN_ON_UNLOADED()
+{
+  OnUnloadPlugin();
+}
+
+static void TickEventHandler(const ezQtUiServices::TickEvent& e)
+{
+  // BeforeFrame, not StartFrame: StartFrame is only broadcast when some handler asked for a frame to be
+  // drawn, so an editor with nothing to redraw would never reach it and every tool call would hang.
+  // BeforeFrame is driven by a plain timer and always fires. It is also outside the frame proper, which
+  // is closer to where the Qt socket callback used to run a tool call than the middle of a redraw is.
+  if (e.m_Type != ezQtUiServices::TickEvent::Type::BeforeFrame)
+    return;
+
+  // The transport reads requests on its own thread but never answers one there: a tool call may touch
+  // any part of the editor, none of which is thread safe. This is where the answering happens, so if
+  // this stops being called, clients simply wait.
+  if (s_pServer != nullptr)
+  {
+    s_pServer->ProcessPendingRequests();
+  }
+}
+
+static void ToolsProjectEventHandler(const ezToolsProjectEvent& e)
+{
+  // the server is tied to the open project, because everything it will eventually expose is
+  // project specific
+
+  if (e.m_Type == ezToolsProjectEvent::Type::ProjectOpened)
+  {
+    if (s_pServer == nullptr)
+    {
+      s_pServer = EZ_DEFAULT_NEW(ezMcpServer, "ezEditor");
+    }
+
+    const ezUInt16 uiPort = static_cast<ezUInt16>(s_opt_McpPort.GetOptionValue(ezCommandLineOption::LogMode::FirstTimeIfSpecified));
+
+    if (s_pServer->Start(uiPort).Succeeded())
+    {
+      if (s_TickSubscription == 0)
+      {
+        s_TickSubscription = ezQtUiServices::s_TickEvent.AddEventHandler(&TickEventHandler);
+      }
+    }
+    else
+    {
+      // Said out loud because there is nothing else to notice it by: without a server there is no
+      // log_read either, so an agent that cannot connect has no way to find out why. The usual cause is
+      // another editor already holding the port.
+      ezLog::Error("MCP: The server could not listen on port {}. This editor is not reachable through MCP. Another editor may already "
+                   "be using that port - pass a different '-editor-mcpport'.",
+        uiPort);
+    }
+  }
+
+  if (e.m_Type == ezToolsProjectEvent::Type::ProjectClosing)
+  {
+    if (s_pServer != nullptr)
+    {
+      s_pServer->Stop();
+    }
+  }
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcpDLL.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcpDLL.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Configuration/Plugin.h>
+
+// Configure the DLL Import/Export Define
+#if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)
+#  ifdef BUILDSYSTEM_BUILDING_EDITORPLUGINMCP_LIB
+#    define EZ_EDITORPLUGINMCP_DLL EZ_DECL_EXPORT
+#  else
+#    define EZ_EDITORPLUGINMCP_DLL EZ_DECL_IMPORT
+#  endif
+#else
+#  define EZ_EDITORPLUGINMCP_DLL
+#endif

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcpPCH.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcpPCH.cpp
@@ -1,0 +1,1 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcpPCH.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/EditorPluginMcpPCH.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+
+// <StaticLinkUtil::StartHere>
+// all include's before this will be left alone and not replaced by the StaticLinkUtil
+// all include's AFTER this will be removed by the StaticLinkUtil and updated by what is actually used throughout the library
+
+#include <EditorPluginMcp/EditorPluginMcpDLL.h>
+
+
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Strings/StringBuilder.h>
+#include <ToolsFoundation/Project/ToolsProject.h>

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/Mcp.ezPluginBundle
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/Mcp.ezPluginBundle
@@ -1,0 +1,21 @@
+// for a description of the options see:
+// https://ezengine.net/pages/docs/editor/editor-plugins.html
+
+PluginInfo
+{
+	string %DisplayName{"MCP Server"}
+	string %Description{"Exposes the editor and the running game to AI agents through an MCP server over HTTP."}
+	string %EditorPlugins{"ezEditorPluginMcp"}
+	// deliberately an editor-engine plugin rather than a runtime plugin: this way the engine process that the
+	// editor runs the game in loads the server, but it never enters the project's RuntimeConfigs/Plugins.ddl
+	// and is never packaged on export - MCP is a development-only feature and must not reach a shipping build.
+	// The other host, a standalone game (ezPlayer), loads it on demand instead, see
+	// ezGameApplication::Init_LoadRequiredPlugins.
+	string %EditorEnginePlugins{"ezMcpPlugin"}
+	string %RuntimePlugins{}
+	string %PackageDependencies{}
+	string %RequiredPlugins{}
+	string %ExclusiveFeatures{}
+	string %EnabledInTemplates{}
+	bool %Mandatory{true}
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpDocument.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpDocument.cpp
@@ -1,0 +1,152 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <EditorPluginMcp/McpDocument.h>
+#include <Mcp/McpTool.h>
+
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+#include <ToolsFoundation/Object/DocumentObjectManager.h>
+
+ezDocument* ezMcpDocument::Find(ezStringView sIdentifier)
+{
+  if (sIdentifier.IsEmpty())
+    return nullptr;
+
+  // TryConvertStringToUuid() rather than ConvertStringToUuid(), which asserts on anything that is not
+  // already a uuid and so cannot be used to find out whether the input is one. The input here is a
+  // path just as often as a guid.
+  if (ezUuid guid; ezConversionUtils::TryConvertStringToUuid(sIdentifier, guid).Succeeded())
+  {
+    // A guid that is not open is not a path either, so there is nothing else to try.
+    return ezDocumentManager::GetDocumentByGuid(guid);
+  }
+
+  ezStringBuilder sPath = sIdentifier;
+  sPath.MakeCleanPath();
+
+  if (sPath.IsEmpty())
+    return nullptr;
+
+  // Matched against the open documents' own paths rather than resolved through the data directories
+  // first. Only documents that are already open can match, so their paths are the complete set of right
+  // answers - and going through ezQtEditorApp::MakeParentDataDirectoryRelativePathAbsolute() instead
+  // would dereference ezSubAsset::m_pAssetInfo, which is null for an asset the curator knows but has no
+  // file information for. That crashed the editor when a path was passed for a document that had just
+  // been closed.
+  for (ezDocumentManager* pManager : ezDocumentManager::GetAllDocumentManagers())
+  {
+    if (ezPathUtils::IsAbsolutePath(sPath))
+    {
+      if (ezDocument* pDoc = pManager->GetDocumentByPath(sPath))
+        return pDoc;
+
+      continue;
+    }
+
+    // A relative path matches when it is a trailing path component sequence of the absolute one, so
+    // both "Testing Chambers/Prefabs/Barrel.ezPrefab" and "Prefabs/Barrel.ezPrefab" find it.
+    for (ezDocument* pDoc : pManager->GetAllOpenDocuments())
+    {
+      if (pDoc == nullptr)
+        continue;
+
+      ezStringBuilder sDocPath = pDoc->GetDocumentPath();
+      sDocPath.MakeCleanPath();
+
+      if (sDocPath.EndsWith_NoCase(sPath))
+      {
+        // Guards against 'Barrel.ezPrefab' matching 'BigBarrel.ezPrefab': what precedes the match has
+        // to be a path separator, not more filename.
+        const ezUInt32 uiDocLen = sDocPath.GetElementCount();
+        const ezUInt32 uiPathLen = sPath.GetElementCount();
+
+        if (uiDocLen == uiPathLen || sDocPath.GetData()[uiDocLen - uiPathLen - 1] == '/')
+          return pDoc;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void ezMcpDocument::SetNotOpenError(ezMcpToolResult& out_result, ezStringView sIdentifier)
+{
+  // Names both accepted forms and the tool that lists what is open, because an agent that guessed a
+  // path wrong otherwise has no way to find out what it should have passed.
+  ezStringBuilder s;
+  s.SetFormat("No open document matches '{}'. Pass the guid or the path of a document that is currently open - "
+              "'document_list' returns both for every open document. To open a document that is not open yet, use 'document_open'.",
+    sIdentifier);
+
+  out_result.SetError(s);
+}
+
+const ezDocumentObject* ezMcpDocument::ResolveObject(const ezDocument* pDocument, ezStringView sObjectGuid, ezStringBuilder& out_sError)
+{
+  const ezDocumentObjectManager* pManager = pDocument->GetObjectManager();
+
+  if (!sObjectGuid.IsEmpty())
+  {
+    if (!ezConversionUtils::IsStringUuid(sObjectGuid))
+    {
+      out_sError.SetFormat("'{}' is not a valid object guid. Omit 'object' to address the document's top level object.", sObjectGuid);
+      return nullptr;
+    }
+
+    const ezUuid guid = ezConversionUtils::ConvertStringToUuid(sObjectGuid);
+    const ezDocumentObject* pObject = pManager->GetObject(guid);
+
+    // The document's root is a real object with a stable guid - ezUuid::MakeStableUuidFromString("DocumentRoot"),
+    // the same in every document - so it is reachable by name even though no tool ever reports it. It is
+    // an implementation detail with no parent and no type a caller can act on, and handing it out lets
+    // the object tools try to delete, move or duplicate it, which dereferences its absent parent.
+    if (pObject != nullptr && pObject == pManager->GetRootObject())
+    {
+      out_sError = "That guid is the document's internal root object, which cannot be read or modified. Omit 'object' to address the "
+                   "document's top level object, or use 'object_tree' to list the objects that can be acted on.";
+      return nullptr;
+    }
+
+    if (pObject == nullptr)
+    {
+      out_sError.SetFormat("The document has no object with guid '{}'. Object guids come from a previous 'object_tree' or "
+                           "'object_properties' call and are not stable across editor sessions.",
+        sObjectGuid);
+    }
+
+    return pObject;
+  }
+
+  const ezDocumentObject* pRoot = pManager->GetRootObject();
+
+  if (pRoot == nullptr || pRoot->GetChildren().IsEmpty())
+  {
+    out_sError = "The document has no top level object.";
+    return nullptr;
+  }
+
+  if (pRoot->GetChildren().GetCount() > 1)
+  {
+    out_sError.SetFormat("The document has {} top level objects, so there is no single one to default to. Pass 'object' with the guid "
+                         "of the one to act on - 'object_tree' lists them.",
+      pRoot->GetChildren().GetCount());
+    return nullptr;
+  }
+
+  return pRoot->GetChildren()[0];
+}
+
+ezString ezMcpDocument::GetObjectName(const ezDocumentObject* pObject)
+{
+  const ezRTTI* pType = pObject->GetType();
+
+  if (pType == nullptr || pType->FindPropertyByName("Name") == nullptr)
+    return {};
+
+  const ezVariant name = pObject->GetTypeAccessor().GetValue("Name");
+
+  if (!name.IsValid() || !name.CanConvertTo<ezString>())
+    return {};
+
+  return name.ConvertTo<ezString>();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpDocument.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpDocument.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <EditorPluginMcp/EditorPluginMcpDLL.h>
+
+#include <Foundation/Strings/StringBuilder.h>
+
+class ezDocument;
+class ezDocumentObject;
+struct ezMcpToolResult;
+
+/// \brief Resolving the 'document' and 'object' arguments that most tools take.
+///
+/// Every tool addresses a document by guid or path and holds no session state, so this lookup runs on
+/// each call. Documents are never opened implicitly: a document opened behind the agent's back stays
+/// open invisibly, and the undo stack lives on the document, so opening and closing per call would
+/// make undo meaningless.
+namespace ezMcpDocument
+{
+  /// \brief Finds an open document by guid, by absolute path, or by a trailing part of its path.
+  ///
+  /// A guid is the reliable identifier - a path can be spelled several ways and a document that was
+  /// renamed no longer answers to its old one. Returns nullptr when nothing matches, which for a path
+  /// usually means the document is not open rather than that it does not exist.
+  EZ_EDITORPLUGINMCP_DLL ezDocument* Find(ezStringView sIdentifier);
+
+  /// \brief Reports a failed Find() in a way that tells the agent what to do about it.
+  EZ_EDITORPLUGINMCP_DLL void SetNotOpenError(ezMcpToolResult& out_result, ezStringView sIdentifier);
+
+  /// \brief The object named by a guid, or the document's top level object when sObjectGuid is empty.
+  ///
+  /// The top level object is the root's single child. That is what ezSimpleAssetDocument's
+  /// GetPropertyObject() returns, reproduced here through the generic ezDocumentObject interface,
+  /// because GetPropertyObject() is declared on the template and cannot be called without knowing the
+  /// asset type. A document with several top level objects - a scene - has no single answer and fails
+  /// with a message saying so.
+  ///
+  /// Returns nullptr and fills out_sError, which is written for the agent to read.
+  EZ_EDITORPLUGINMCP_DLL const ezDocumentObject* ResolveObject(const ezDocument* pDocument, ezStringView sObjectGuid, ezStringBuilder& out_sError);
+
+  /// \brief The name a user would recognise the object by, or an empty string when it has none.
+  ///
+  /// A game object's name is an ordinary reflected property that most object types do not have, so this
+  /// checks the type before reading. Returned by value: the variant it comes out of is a temporary.
+  EZ_EDITORPLUGINMCP_DLL ezString GetObjectName(const ezDocumentObject* pObject);
+} // namespace ezMcpDocument

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ActionTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ActionTool.cpp
@@ -1,0 +1,627 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpTranslation.h>
+#include <EditorPluginMcp/McpDocument.h>
+#include <EditorPluginMcp/McpTools/ActionTool.h>
+
+#include <GuiFoundation/Action/ActionManager.h>
+#include <GuiFoundation/Action/BaseActions.h>
+#include <GuiFoundation/DocumentWindow/DocumentWindow.moc.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+#include <ToolsFoundation/Document/Document.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpActionTool, 1, ezRTTIDefaultAllocator<ezMcpActionTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  constexpr ezUInt32 uiMaxActions = 200;
+
+  ezStringView ToString(ezActionScope::Enum scope)
+  {
+    switch (scope)
+    {
+      case ezActionScope::Global:
+        return "Global";
+      case ezActionScope::Document:
+        return "Document";
+      case ezActionScope::Window:
+        return "Window";
+    }
+
+    return "Unknown";
+  }
+
+  ezStringView ToString(ezActionType::Enum type)
+  {
+    switch (type)
+    {
+      case ezActionType::Action:
+        return "Action";
+      case ezActionType::Category:
+        return "Category";
+      case ezActionType::Menu:
+        return "Menu";
+      case ezActionType::ActionAndMenu:
+        return "ActionAndMenu";
+    }
+
+    return "Unknown";
+  }
+
+  /// \brief Returns a live instance of an action, or nullptr.
+  ///
+  /// Global actions exist once per window they are mapped into, and all of those agree, so the first one
+  /// is as good as any. Document and window actions exist once per document window they are mapped into,
+  /// and each of those reports something different, so one is only picked when a document says which.
+  ///
+  /// Reading an existing instance rather than creating one matters twice over: creating an action has
+  /// side effects (it registers event handlers, and some constructors touch the editor), and a fresh
+  /// instance would not have received the updates that keep m_bEnabled current.
+  const ezAction* GetLiveInstance(const ezActionDescriptor& desc, const ezDocument* pDocument)
+  {
+    const ezArrayPtr<ezAction* const> instances = desc.GetCreatedActions();
+
+    if (desc.m_Scope == ezActionScope::Global)
+      return instances.IsEmpty() ? nullptr : instances[0];
+
+    if (pDocument == nullptr)
+      return nullptr;
+
+    for (const ezAction* pAction : instances)
+    {
+      if (pAction->GetContext().m_pDocument == pDocument)
+        return pAction;
+    }
+
+    return nullptr;
+  }
+
+  /// \brief Whether the action would let itself be triggered. True for the types that have no such flag.
+  bool IsActionEnabled(const ezAction* pAction)
+  {
+    if (const ezButtonAction* pButton = ezDynamicCast<const ezButtonAction*>(pAction))
+      return pButton->IsEnabled();
+
+    if (const ezDynamicActionAndMenuAction* pMenu = ezDynamicCast<const ezDynamicActionAndMenuAction*>(pAction))
+      return pMenu->IsEnabled();
+
+    if (const ezSliderAction* pSlider = ezDynamicCast<const ezSliderAction*>(pAction))
+      return pSlider->IsEnabled();
+
+    return true;
+  }
+
+  /// \brief Writes 'enabled', and 'checkable'/'checked' where they apply.
+  ///
+  /// Everything that cannot be determined is written as the string "unknown" rather than omitted, so
+  /// that a caller can tell 'not applicable or not known' apart from 'false'. That happens for
+  /// document actions when no document was named, for actions that are not currently mapped into any
+  /// open window, and for action types that carry no enabled flag at all (categories and plain menus).
+  void WriteActionState(ezMcpJsonWriter& ref_writer, const ezActionDescriptor& desc, const ezDocument* pDocument)
+  {
+    const ezAction* pAction = GetLiveInstance(desc, pDocument);
+
+    if (pAction == nullptr)
+    {
+      ref_writer.AddVariableString("enabled", "unknown");
+
+      if (desc.m_Scope != ezActionScope::Global && pDocument == nullptr)
+      {
+        ref_writer.AddVariableString("stateReason", "This action's state depends on a document. Pass 'document' to read it.");
+      }
+      else
+      {
+        ref_writer.AddVariableString("stateReason", "No instance of this action exists right now, so it is not mapped into any open window.");
+      }
+
+      return;
+    }
+
+    if (const ezButtonAction* pButton = ezDynamicCast<const ezButtonAction*>(pAction))
+    {
+      ref_writer.AddVariableBool("enabled", pButton->IsEnabled());
+      ref_writer.AddVariableBool("visible", pButton->IsVisible());
+
+      // only meaningful for toggles, and reporting 'checked:false' for every push button would suggest
+      // a state that does not exist
+      if (pButton->IsCheckable())
+      {
+        ref_writer.AddVariableBool("checkable", true);
+        ref_writer.AddVariableBool("checked", pButton->IsChecked());
+      }
+    }
+    else if (const ezDynamicActionAndMenuAction* pMenu = ezDynamicCast<const ezDynamicActionAndMenuAction*>(pAction))
+    {
+      ref_writer.AddVariableBool("enabled", pMenu->IsEnabled());
+      ref_writer.AddVariableBool("visible", pMenu->IsVisible());
+    }
+    else if (const ezSliderAction* pSlider = ezDynamicCast<const ezSliderAction*>(pAction))
+    {
+      ref_writer.AddVariableBool("enabled", pSlider->IsEnabled());
+      ref_writer.AddVariableBool("visible", pSlider->IsVisible());
+      ref_writer.AddVariableInt32("value", pSlider->GetValue());
+
+      ezInt32 iMin = 0, iMax = 0;
+      pSlider->GetRange(iMin, iMax);
+      ref_writer.AddVariableInt32("minValue", iMin);
+      ref_writer.AddVariableInt32("maxValue", iMax);
+    }
+    else
+    {
+      ref_writer.AddVariableString("enabled", "unknown");
+      ref_writer.AddVariableString("stateReason", "This action type has no enabled state.");
+    }
+  }
+
+  /// \brief Writes the strings a user would see for this action, skipping those that translate to nothing.
+  ///
+  /// All three lookups are keyed on the action name.
+  void WriteTranslations(ezMcpJsonWriter& ref_writer, const ezActionDescriptor& desc)
+  {
+    const ezStringView sName = desc.m_sActionName;
+
+    ezMcpTranslation::AddOptionalString(ref_writer, "displayName", ezMcpTranslation::GetDisplayName(sName));
+    ezMcpTranslation::AddOptionalString(ref_writer, "tooltip", ezMcpTranslation::GetTooltip(sName));
+    ezMcpTranslation::AddOptionalString(ref_writer, "helpUrl", ezMcpTranslation::GetHelpURL(sName));
+  }
+} // namespace
+
+void ezMcpActionTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  ezMcpToolDesc& list = out_tools.ExpandAndGetRef();
+  list.m_sName = "action_list";
+  list.m_sDescription = "Lists the editor's actions - the commands behind its menu entries and toolbar buttons - with their "
+                        "internal name, category, keyboard shortcut and the text the user sees for them. Use it to find out "
+                        "what the editor can do and what to pass to action_execute, or to explain a feature to a user in the "
+                        "wording that actually appears in their UI. Actions of scope 'Global' can be executed as they are; "
+                        "'Document' and 'Window' ones act on one document and need its guid or path passed along, so pass "
+                        "'document' here to list and inspect those.";
+  list.m_sInputSchema = R"({"type":"object","properties":{)"
+                        R"("contains":{"type":"string","description":"Only list actions whose internal name or category contains this text, case insensitive."},)"
+                        R"("matchTranslation":{"type":"boolean","description":"Also match 'contains' against the translated display name and tooltip, i.e. the words the user sees. Useful when searching for a feature by how it is described rather than by its internal name. Default false."},)"
+                        R"("document":{"type":"string","description":"Guid or path of an open document. Makes 'globalOnly' default to false, and is what the state of document and window actions is read from."},)"
+                        R"("globalOnly":{"type":"boolean","description":"Only list actions of scope 'Global'. Defaults to true, or to false when 'document' is given."},)"
+                        R"("includeMenus":{"type":"boolean","description":"Also list menus, which only group other entries and cannot be executed. Default false. Turn this on to describe the structure of the editor's menu bar to a user, not to find something to run."},)"
+                        R"("includeState":{"type":"boolean","description":"Include the current enabled/checked state of each action. Default false, because it makes the result considerably longer."}}})";
+
+  ezMcpToolDesc& state = out_tools.ExpandAndGetRef();
+  state.m_sName = "action_state";
+  state.m_sDescription = "Reports whether one action is currently enabled, and whether it is checked if it is a toggle. Read "
+                         "from the live action as the UI shows it, so it is accurate at the moment of the call - but it is "
+                         "only a hint, since anything that happens afterwards can change it. 'enabled' comes back as the "
+                         "string \"unknown\" when it cannot be determined, which is the case for actions not currently "
+                         "present in any open window, and for document actions when no 'document' was passed.";
+  state.m_sInputSchema = R"({"type":"object","properties":{)"
+                         R"("name":{"type":"string","description":"The internal action name, e.g. 'Document.Save' or 'Editor.Project.Settings'. Get it from action_list."},)"
+                         R"("category":{"type":"string","description":"The category the action is registered in. Only needed when the same name exists in several categories, which action_list reports."},)"
+                         R"("document":{"type":"string","description":"Guid or path of an open document. Required for actions of scope 'Document' or 'Window', whose state is per document."}},)"
+                         R"("required":["name"]})";
+
+  ezMcpToolDesc& exec = out_tools.ExpandAndGetRef();
+  exec.m_sName = "action_execute";
+  exec.m_sDescription = "Triggers one action, exactly as clicking its menu entry or toolbar button would. Refuses and "
+                        "reports 'wasDisabled' if the action is currently disabled, rather than invoking something that the "
+                        "UI would not let a user invoke. Actions of scope 'Document' or 'Window' act on one document and "
+                        "need 'document' passed; that document has to be open, and for window actions it also needs a "
+                        "window, i.e. it must have been opened with focus.\n"
+                        "This is how play-the-game is driven: 'Scene.GameMode.Play' starts it and 'Scene.GameMode.Stop' "
+                        "ends it, both on the scene document. The game then runs in the editor's engine process, which "
+                        "serves its own MCP port (see the editor's app_info) for screenshots, input and frames.\n"
+                        "Many actions open a dialog for the user to fill in. Those are closed unanswered here, which means the "
+                        "action did nothing - the result then lists them under 'suppressedDialogs', so check that field before "
+                        "assuming the action took effect. Some operations behind such a dialog have their own tool, e.g. "
+                        "project_export.\n"
+                        "IMPORTANT - this call runs synchronously. Every action the editor currently has was checked not to "
+                        "block, but a modal window that slips through would stop the editor for good: this call never returns, "
+                        "app_quit cannot get through either, and the only way out is killing the process. So: always call this "
+                        "with a timeout of about 30 seconds rather than waiting indefinitely, know the process id from app_info "
+                        "or app_ping beforehand, and if the timeout expires use app_ping to check - a responsive editor means "
+                        "the action is merely slow, an unresponsive one has to be killed by process id.";
+  exec.m_sInputSchema = R"({"type":"object","properties":{)"
+                        R"("name":{"type":"string","description":"The internal action name, as reported by action_list."},)"
+                        R"("category":{"type":"string","description":"The category the action is registered in. Only needed to disambiguate a name that exists in several categories."},)"
+                        R"("document":{"type":"string","description":"Guid or path of an open document to run the action on. Required for actions of scope 'Document' or 'Window', ignored for global ones."},)"
+                        R"("value":{"description":"Optional value passed to the action. Most actions ignore it; sliders and toggles use it."},)"
+                        R"("force":{"type":"boolean","description":"Execute even when the action reports itself as disabled. Default false. The action may misbehave, since it is being invoked in a state its UI would prevent."}},)"
+                        R"("required":["name"]})";
+}
+
+void ezMcpActionTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "action_list")
+  {
+    ExecuteList(arguments, out_result);
+  }
+  else if (sToolName == "action_state")
+  {
+    ExecuteState(arguments, out_result);
+  }
+  else if (sToolName == "action_execute")
+  {
+    ExecuteAction(arguments, out_result);
+  }
+}
+
+const ezActionDescriptor* ezMcpActionTool::FindAction(ezStringView sName, ezStringView sCategory, bool& out_bAmbiguous)
+{
+  out_bAmbiguous = false;
+
+  const ezActionDescriptor* pFound = nullptr;
+
+  for (auto it = ezActionManager::GetActionIterator(); it.IsValid(); ++it)
+  {
+    const ezActionDescriptor* pDesc = it.Value();
+
+    if (pDesc->m_sActionName != sName)
+      continue;
+
+    if (!sCategory.IsEmpty() && pDesc->m_sCategoryPath != sCategory)
+      continue;
+
+    if (pFound != nullptr)
+    {
+      // a name registered in several categories - reported rather than silently resolved, because the
+      // two may do entirely different things
+      out_bAmbiguous = true;
+      return nullptr;
+    }
+
+    pFound = pDesc;
+  }
+
+  return pFound;
+}
+
+void ezMcpActionTool::ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sContains = ezMcpJson::GetString(arguments, "contains");
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+  const bool bMatchTranslation = ezMcpJson::GetBool(arguments, "matchTranslation", false);
+  const bool bIncludeMenus = ezMcpJson::GetBool(arguments, "includeMenus", false);
+  const bool bIncludeState = ezMcpJson::GetBool(arguments, "includeState", false);
+
+  ezDocument* pDocument = nullptr;
+
+  if (!sDocument.IsEmpty())
+  {
+    pDocument = ezMcpDocument::Find(sDocument);
+
+    if (pDocument == nullptr)
+    {
+      ezMcpDocument::SetNotOpenError(out_result, sDocument);
+      return;
+    }
+  }
+
+  // naming a document is only ever done to get at that document's actions, so listing global ones
+  // exclusively would answer a question that was not asked
+  const bool bGlobalOnly = ezMcpJson::GetBool(arguments, "globalOnly", pDocument == nullptr);
+
+  ezUInt32 uiTotalMatches = 0;
+  ezUInt32 uiReturned = 0;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.BeginArray("actions");
+
+  for (auto it = ezActionManager::GetActionIterator(); it.IsValid(); ++it)
+  {
+    const ezActionDescriptor* pDesc = it.Value();
+
+    if (bGlobalOnly && pDesc->m_Scope != ezActionScope::Global)
+      continue;
+
+    // categories are pure grouping for the shortcut dialog, they are never executable and would only
+    // pad the list
+    if (pDesc->m_Type == ezActionType::Category)
+      continue;
+
+    // Menus are half of all global entries and none of them can be executed, so they are left out
+    // unless asked for. 'ActionAndMenu' is kept either way - it is a button that also has a menu, and
+    // the button part does work.
+    if (!bIncludeMenus && pDesc->m_Type == ezActionType::Menu)
+      continue;
+
+    if (!sContains.IsEmpty())
+    {
+      bool bMatches = pDesc->m_sActionName.FindSubString_NoCase(sContains) != nullptr ||
+                      pDesc->m_sCategoryPath.FindSubString_NoCase(sContains) != nullptr;
+
+      if (!bMatches && bMatchTranslation)
+      {
+        const ezStringView sName = pDesc->m_sActionName;
+        const ezStringBuilder sDisplay = ezMcpTranslation::GetDisplayName(sName);
+        const ezStringBuilder sTooltip = ezMcpTranslation::GetTooltip(sName);
+
+        bMatches = sDisplay.FindSubString_NoCase(sContains) != nullptr || sTooltip.FindSubString_NoCase(sContains) != nullptr;
+      }
+
+      if (!bMatches)
+        continue;
+    }
+
+    ++uiTotalMatches;
+
+    if (uiReturned >= uiMaxActions)
+      continue;
+
+    writer.BeginObject();
+
+    writer.AddVariableString("name", pDesc->m_sActionName);
+
+    if (!pDesc->m_sCategoryPath.IsEmpty())
+    {
+      writer.AddVariableString("category", pDesc->m_sCategoryPath);
+    }
+
+    writer.AddVariableString("scope", ToString(pDesc->m_Scope));
+
+    // 'Action' is the overwhelming majority, so only the exceptions are worth the tokens
+    if (pDesc->m_Type != ezActionType::Action)
+    {
+      writer.AddVariableString("type", ToString(pDesc->m_Type));
+    }
+
+    if (!pDesc->m_sShortcut.IsEmpty())
+    {
+      writer.AddVariableString("shortcut", pDesc->m_sShortcut);
+    }
+
+    WriteTranslations(writer, *pDesc);
+
+    if (bIncludeState)
+    {
+      WriteActionState(writer, *pDesc, pDocument);
+    }
+
+    writer.EndObject();
+
+    ++uiReturned;
+  }
+
+  writer.EndArray();
+
+  writer.AddVariableUInt32("totalMatches", uiTotalMatches);
+  writer.AddVariableUInt32("returned", uiReturned);
+  writer.AddVariableBool("truncated", uiTotalMatches > uiReturned);
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpActionTool::ExecuteState(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+  const ezStringView sCategory = ezMcpJson::GetString(arguments, "category");
+
+  if (sName.IsEmpty())
+  {
+    out_result.SetError("No action name given. Call action_list to find one.");
+    return;
+  }
+
+  bool bAmbiguous = false;
+  const ezActionDescriptor* pDesc = FindAction(sName, sCategory, bAmbiguous);
+
+  if (pDesc == nullptr)
+  {
+    ezStringBuilder sMsg;
+
+    if (bAmbiguous)
+    {
+      sMsg.SetFormat("The action '{}' exists in more than one category. Pass 'category' as well, see action_list.", sName);
+    }
+    else
+    {
+      sMsg.SetFormat("No action named '{}'. Call action_list to find the correct name.", sName);
+    }
+
+    out_result.SetError(sMsg);
+    return;
+  }
+
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = nullptr;
+
+  if (!sDocument.IsEmpty())
+  {
+    pDocument = ezMcpDocument::Find(sDocument);
+
+    if (pDocument == nullptr)
+    {
+      ezMcpDocument::SetNotOpenError(out_result, sDocument);
+      return;
+    }
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("name", pDesc->m_sActionName);
+  writer.AddVariableString("category", pDesc->m_sCategoryPath);
+  writer.AddVariableString("scope", ToString(pDesc->m_Scope));
+
+  WriteActionState(writer, *pDesc, pDocument);
+  WriteTranslations(writer, *pDesc);
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpActionTool::ExecuteAction(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+  const ezStringView sCategory = ezMcpJson::GetString(arguments, "category");
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+  const bool bForce = ezMcpJson::GetBool(arguments, "force", false);
+
+  if (sName.IsEmpty())
+  {
+    out_result.SetError("No action name given. Call action_list to find one.");
+    return;
+  }
+
+  bool bAmbiguous = false;
+  const ezActionDescriptor* pDesc = FindAction(sName, sCategory, bAmbiguous);
+
+  if (pDesc == nullptr)
+  {
+    ezStringBuilder sMsg;
+
+    if (bAmbiguous)
+    {
+      sMsg.SetFormat("The action '{}' exists in more than one category. Pass 'category' as well, see action_list.", sName);
+    }
+    else
+    {
+      sMsg.SetFormat("No action named '{}'. Call action_list to find the correct name.", sName);
+    }
+
+    out_result.SetError(sMsg);
+    return;
+  }
+
+  // categories and plain menus have an Execute() that does nothing, so calling them would report
+  // success while achieving nothing at all
+  if (pDesc->m_Type == ezActionType::Category || pDesc->m_Type == ezActionType::Menu)
+  {
+    ezStringBuilder sMsg;
+    sMsg.SetFormat("'{}' is a '{}', which only groups other actions and does nothing when triggered.", sName, ToString(pDesc->m_Type));
+
+    out_result.SetError(sMsg);
+    return;
+  }
+
+  // Document and window actions do their work on one document, and the descriptor alone does not say
+  // which. Without it the action would be constructed with a null document and dereference it right
+  // away, so this is refused rather than left to crash.
+  ezDocument* pDocument = nullptr;
+
+  if (!sDocument.IsEmpty())
+  {
+    pDocument = ezMcpDocument::Find(sDocument);
+
+    if (pDocument == nullptr)
+    {
+      ezMcpDocument::SetNotOpenError(out_result, sDocument);
+      return;
+    }
+  }
+  else if (pDesc->m_Scope != ezActionScope::Global)
+  {
+    ezStringBuilder sMsg;
+    sMsg.SetFormat("'{}' has scope '{}', so it acts on one document. Pass 'document' with the guid or path of an open document, "
+                   "see document_list.",
+      sName, ToString(pDesc->m_Scope));
+
+    out_result.SetError(sMsg);
+    return;
+  }
+
+  // Window actions read their widget out of the context, so a document that was opened without a window
+  // cannot serve them. The window is also handed to document actions, because it costs nothing and some
+  // of them use it for dialogs.
+  QWidget* pWindow = (pDocument != nullptr) ? ezQtDocumentWindow::FindWindowByDocument(pDocument) : nullptr;
+
+  if (pDesc->m_Scope == ezActionScope::Window && pWindow == nullptr)
+  {
+    ezStringBuilder sMsg;
+    sMsg.SetFormat("'{}' has scope 'Window', but '{}' has no window - it was opened without focus. Call document_open with "
+                   "focus true first.",
+      sName, sDocument);
+
+    out_result.SetError(sMsg);
+    return;
+  }
+
+  // Checked against a live instance before doing anything, because ezActionManager::ExecuteAction()
+  // does not: it creates an action and calls Execute() on it regardless of the enabled flag. Invoking a
+  // disabled action is what the UI exists to prevent, and for some actions it would assert or act on
+  // state that isn't there.
+  if (const ezAction* pExisting = GetLiveInstance(*pDesc, pDocument))
+  {
+    if (!IsActionEnabled(pExisting) && !bForce)
+    {
+      ezMcpJsonWriter writer;
+      writer.BeginObject();
+      writer.AddVariableBool("executed", false);
+      writer.AddVariableBool("wasDisabled", true);
+      writer.AddVariableString("reason",
+        "The action is currently disabled, so it was not executed. Whatever it needs is not available right now - for many "
+        "actions that means no document is open or nothing is selected. Pass force=true to run it anyway.");
+      writer.EndObject();
+
+      // an error, so that this cannot be mistaken for the action having run
+      out_result.m_sText = writer.GetResult();
+      out_result.m_bIsError = true;
+      return;
+    }
+  }
+
+  const ezVariant* pValue = nullptr;
+  arguments.TryGetValue("value", pValue);
+
+  ezActionContext context;
+  context.m_pDocument = pDocument;
+  context.m_pWindow = pWindow;
+
+  ezAction* pAction = pDesc->CreateAction(context);
+
+  if (pAction == nullptr)
+  {
+    out_result.SetError(ezStringBuilder("Failed to create the action '", sName, "'."));
+    return;
+  }
+
+  // The call runs with ezQtScopedUnattended active (see ezMcpToolRegistry::Execute), so an action that
+  // opens one of the editor's own dialogs gets it rejected instead of entering a nested event loop that
+  // nobody would ever leave. It can still hang on a modal window that goes around ezQtDialog - a
+  // QFileDialog, for instance - which is what the timeout in the tool description is for.
+  pAction->Execute(pValue != nullptr ? *pValue : ezVariant());
+
+  pDesc->DeleteAction(pAction);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableBool("executed", true);
+  writer.AddVariableString("name", pDesc->m_sActionName);
+
+  if (pDocument != nullptr)
+  {
+    writer.AddVariableString("document", pDocument->GetDocumentPath());
+  }
+
+  // Actions report nothing back - ezAction::Execute() returns void - so there is no result to pass on
+  // and 'executed' only means that it was invoked without anything going wrong on the way there. What
+  // it did has to be observed elsewhere, e.g. through log_read.
+  writer.AddVariableString("note", "Actions do not return a result. Check log_read or query the editor state to see what happened.");
+
+  // Only written when something was actually suppressed: for the majority of actions this stays empty,
+  // and an always present empty array would suggest the field is worth looking at every time.
+  const ezArrayPtr<const ezString> suppressed = ezQtUiServices::GetSuppressedDialogs();
+
+  if (!suppressed.IsEmpty())
+  {
+    writer.BeginArray("suppressedDialogs");
+    for (const ezString& s : suppressed)
+    {
+      writer.WriteString(s);
+    }
+    writer.EndArray();
+
+    writer.AddVariableString("suppressedDialogsNote",
+      "This action wanted user input, which is not available here, so the listed dialogs were closed unanswered. Whatever they "
+      "would have configured did not happen, and the action most likely did nothing. Look for a dedicated tool for this "
+      "operation, or ask the user to perform it in the editor.");
+  }
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ActionTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ActionTool.cpp
@@ -1,10 +1,10 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
+#include <EditorPluginMcp/McpDocument.h>
+#include <EditorPluginMcp/McpTools/ActionTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
 #include <Mcp/McpTranslation.h>
-#include <EditorPluginMcp/McpDocument.h>
-#include <EditorPluginMcp/McpTools/ActionTool.h>
 
 #include <GuiFoundation/Action/ActionManager.h>
 #include <GuiFoundation/Action/BaseActions.h>

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ActionTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ActionTool.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+struct ezActionDescriptor;
+
+/// \brief Tools for listing and triggering editor actions - the things behind menu entries and toolbar buttons.
+///
+/// Actions of ezActionScope::Global need nothing but their name. Document and window actions act on one
+/// document, which the caller names by guid or path in the 'document' argument; that document has to be
+/// open, and a window action additionally needs it to have a window. This is how play-the-game is
+/// started and stopped from outside the editor.
+class ezMcpActionTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpActionTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteState(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteAction(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Resolves an action by name, optionally restricted to a category.
+  ///
+  /// Without a category the name has to be unique across all of them, which is not guaranteed: the same
+  /// name may be registered in several categories. out_bAmbiguous reports that case separately from
+  /// 'not found', so the caller can ask for a category instead of just failing.
+  static const ezActionDescriptor* FindAction(ezStringView sName, ezStringView sCategory, bool& out_bAmbiguous);
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AppTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AppTool.cpp
@@ -1,0 +1,184 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <EditorPluginMcp/McpTools/AppTool.h>
+
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpServer.h>
+
+#include <Foundation/IO/FileSystem/FileSystem.h>
+#include <Foundation/Utilities/CommandLineUtils.h>
+
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorFramework/IPC/EngineProcessConnection.h>
+#include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+
+#include <QApplication>
+#include <QTimer>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpEditorAppTool, 1, ezRTTIDefaultAllocator<ezMcpEditorAppTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezStringView ezMcpEditorAppTool::GetBuildTimestamp() const
+{
+  return __DATE__ " " __TIME__;
+}
+
+ezStringView ezMcpEditorAppTool::GetRelaunchHint() const
+{
+  return "To start an editor again afterwards, run the ezEditor executable with "
+         "'-project <path-to-project-folder> -unattended -editor-mcpport <port>'. Pass '-unattended', or the editor may "
+         "open a dialog while opening the project - before any tool call can suppress it - and hang there. "
+         "It serves MCP at http://127.0.0.1:<port>/mcp "
+         "once the project is open, which takes a few seconds - poll the port rather than assuming a delay. "
+         "'-editor-mcpport' defaults to 7391 and is what lets several editors run at once, each on its own port. "
+         "Call app_info for this editor's own port and executable path.";
+}
+
+void ezMcpEditorAppTool::AddHostInfo(ezMcpJsonWriter& ref_writer)
+{
+  // Where the editor writes its log. Reported as an absolute path because the location is otherwise
+  // undiscoverable: it lives in the user data directory under a name derived from '-appid', and
+  // nothing in the tool list or in '-help' points at it. It matters most when the editor dies - a
+  // crash takes the MCP server with it, so the file is all that is left to read afterwards.
+  const ezInt32 iApplicationID = ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-appid", 0);
+
+  ezStringBuilder sLogFile;
+  sLogFile.SetFormat(":appdata/Logs/LogEditor_{}.htm", iApplicationID);
+
+  ezStringBuilder sAbsLogFile;
+  if (ezFileSystem::ResolvePath(sLogFile, &sAbsLogFile, nullptr).Succeeded())
+  {
+    ref_writer.AddVariableString("logFile", sAbsLogFile);
+
+    // The engine runs as a separate process and logs separately, which is why log_read cannot see
+    // it. Naming the pattern is the only way an agent can find those files at all.
+    ezStringBuilder sEngineLogPattern = sAbsLogFile;
+    sEngineLogPattern.PathParentDirectory();
+    sEngineLogPattern.AppendFormat("LogEditor_{}_Engine_<pid>.htm", iApplicationID);
+    sEngineLogPattern.MakeCleanPath();
+    ref_writer.AddVariableString("engineLogFilePattern", sEngineLogPattern);
+  }
+
+  // The engine process serves its own MCP endpoint, and that is where anything about the running game
+  // is answered - screenshots, input, frames. An agent should not be expected to know the '+1' rule, so
+  // the port is reported rather than implied.
+  {
+    const ezEditorEngineProcessConnection* pCon = ezEditorEngineProcessConnection::GetSingleton();
+    const bool bEngineRunning = pCon != nullptr && pCon->IsEngineSetup();
+
+    // The engine process' port cannot be queried from here - that would need an IPC message this
+    // feature does not have - so it is resolved exactly the way the engine plugin resolves it. That
+    // works because the editor forwards its whole command line, so both processes see the same options:
+    // an explicit '-mcpport' wins, otherwise the engine takes our port + 1.
+    const ezInt32 iExplicitPort = ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-mcpport", 0);
+
+    const ezMcpServer* pServer = ezMcpServer::GetInstance();
+    const ezUInt16 uiOwnPort = pServer != nullptr ? pServer->GetPort() : 0;
+
+    ezUInt16 uiEnginePort = 0;
+
+    if (iExplicitPort > 0 && iExplicitPort <= 0xFFFF)
+    {
+      uiEnginePort = static_cast<ezUInt16>(iExplicitPort);
+    }
+    else if (uiOwnPort > 0 && uiOwnPort < 0xFFFF)
+    {
+      uiEnginePort = uiOwnPort + 1;
+    }
+
+    if (uiEnginePort > 0 && bEngineRunning)
+    {
+      ref_writer.AddVariableUInt32("engineMcpPort", uiEnginePort);
+
+      ezStringBuilder sEngineUrl;
+      sEngineUrl.SetFormat("http://127.0.0.1:{}/mcp", uiEnginePort);
+      ref_writer.AddVariableString("engineMcpUrl", sEngineUrl);
+    }
+    else
+    {
+      // Reported as unknown with the reason, rather than omitted: a missing field is indistinguishable
+      // from a build that never had one.
+      ref_writer.AddVariableString("engineMcpPort", "unknown");
+      ref_writer.AddVariableString("engineMcpPortReason",
+        bEngineRunning
+          ? "This editor has no MCP port of its own, so the engine process had nothing to derive one from. "
+            "Restart the editor with '-editor-mcpport <port>'."
+          : "The engine process is not running yet. It starts with the first opened scene document.");
+    }
+
+    ref_writer.AddVariableString("engineMcpHint",
+      "The engine process renders and runs the game, and answers for itself on its own port: screenshots, input, "
+      "frame stepping and its own log_read are all there, not here. It only serves MCP if the build includes the "
+      "engine side plugin - call app_info against that port to find out.");
+  }
+
+  ref_writer.AddVariableString("launchHint",
+    "Run 'executable' with '-project <project-folder> -editor-mcpport <port>' to start another editor. Poll the port until it "
+    "accepts connections - startup takes a few seconds. Use a port other than 'mcpPort' to run one alongside this editor. "
+    "'logFile' is written as HTML and is the only record left if the editor crashes, since that also kills this server; "
+    "note that a crash may lose the last messages, as the log is not flushed on the way down.");
+}
+
+void ezMcpEditorAppTool::CollectModifiedDocuments(ezDynamicArray<ezString>& out_documents)
+{
+  for (const ezDocumentManager* pMan : ezDocumentManager::GetAllDocumentManagers())
+  {
+    for (const ezDocument* pDoc : pMan->GetAllOpenDocuments())
+    {
+      if (pDoc->IsModified())
+      {
+        out_documents.PushBack(pDoc->GetDocumentPath());
+      }
+    }
+  }
+}
+
+ezResult ezMcpEditorAppTool::CanQuit(bool bDiscardChanges)
+{
+  // Checked here rather than through ezToolsProject::CanCloseProject(), which asks the *user* about
+  // unsaved documents through a modal dialog. With no one at the keyboard - which is the entire point
+  // of this tool - that dialog never returns and the editor hangs, holding its port, unreachable and
+  // unkillable through MCP. So the decision is made without any dialog at all.
+  m_ModifiedDocuments.Clear();
+  CollectModifiedDocuments(m_ModifiedDocuments);
+
+  if (!m_ModifiedDocuments.IsEmpty() && !bDiscardChanges)
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+void ezMcpEditorAppTool::AddQuitRefusalInfo(ezMcpJsonWriter& ref_writer)
+{
+  ref_writer.AddVariableString("reason", "Documents have unsaved changes. Save them, or call again with discardChanges=true to lose them.");
+
+  ref_writer.BeginArray("modifiedDocuments");
+  for (const ezString& sDoc : m_ModifiedDocuments)
+  {
+    ref_writer.WriteString(sDoc);
+  }
+  ref_writer.EndArray();
+}
+
+void ezMcpEditorAppTool::AddQuitInfo(ezMcpJsonWriter& ref_writer)
+{
+  ref_writer.AddVariableUInt32("discardedDocuments", m_ModifiedDocuments.GetCount());
+}
+
+void ezMcpEditorAppTool::RequestQuit(bool bDiscardChanges)
+{
+  // Deferred to the next event loop iteration, because this runs inside the request handler: the
+  // response has not been written to the socket yet, and quitting here would drop it, leaving the
+  // caller waiting on a connection that closes with no answer.
+  QTimer::singleShot(0, qApp, []()
+    {
+      // Closes the documents first, discarding unsaved changes without asking. Otherwise the shutdown
+      // path finds modified documents and raises the modal save dialog that this tool exists to avoid.
+      // Reaching this point means that was either unnecessary or explicitly requested.
+      ezDocumentManager::CloseAllDocuments();
+
+      QApplication::closeAllWindows(); });
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AppTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AppTool.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <Mcp/Tools/McpAppTool.h>
+
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Strings/String.h>
+
+/// \brief The editor's half of the shared app tools.
+///
+/// Everything generic - the process id, the executable, the command line, the bound port - is in
+/// ezMcpAppTool. What is left here is what only the editor has: documents that can be unsaved, a log
+/// file whose name is derived from '-appid', and a separate engine process to point at.
+class ezMcpEditorAppTool : public ezMcpAppTool
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpEditorAppTool, ezMcpAppTool);
+
+protected:
+  virtual ezStringView GetHostNoun() const override { return "editor"; }
+  virtual ezStringView GetRelaunchHint() const override;
+
+  /// Overridden so that the timestamp is this plugin's, not the Mcp library's: the editor tools live
+  /// here and change far more often, so this is the binary whose age explains a missing tool.
+  virtual ezStringView GetBuildTimestamp() const override;
+
+  virtual void AddHostInfo(ezMcpJsonWriter& ref_writer) override;
+
+  virtual ezResult CanQuit(bool bDiscardChanges) override;
+  virtual void AddQuitRefusalInfo(ezMcpJsonWriter& ref_writer) override;
+  virtual void AddQuitInfo(ezMcpJsonWriter& ref_writer) override;
+  virtual void RequestQuit(bool bDiscardChanges) override;
+
+private:
+  /// \brief Appends the names of all open documents with unsaved changes.
+  static void CollectModifiedDocuments(ezDynamicArray<ezString>& out_documents);
+
+  /// Filled by CanQuit() so that the refusal can name them without walking the documents twice, and so
+  /// that a quit which goes ahead can report how many changes it discarded.
+  ezDynamicArray<ezString> m_ModifiedDocuments;
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.cpp
@@ -1,9 +1,9 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
+#include <EditorPluginMcp/McpTools/AssetTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
 #include <Mcp/McpTranslation.h>
-#include <EditorPluginMcp/McpTools/AssetTool.h>
 
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocumentGenerator.h>
@@ -50,14 +50,22 @@ namespace
   {
     switch (type)
     {
-      case ezLogMsgType::ErrorMsg: return "error";
-      case ezLogMsgType::SeriousWarningMsg: return "serious-warning";
-      case ezLogMsgType::WarningMsg: return "warning";
-      case ezLogMsgType::SuccessMsg: return "success";
-      case ezLogMsgType::InfoMsg: return "info";
-      case ezLogMsgType::DevMsg: return "dev";
-      case ezLogMsgType::DebugMsg: return "debug";
-      default: return "other";
+      case ezLogMsgType::ErrorMsg:
+        return "error";
+      case ezLogMsgType::SeriousWarningMsg:
+        return "serious-warning";
+      case ezLogMsgType::WarningMsg:
+        return "warning";
+      case ezLogMsgType::SuccessMsg:
+        return "success";
+      case ezLogMsgType::InfoMsg:
+        return "info";
+      case ezLogMsgType::DevMsg:
+        return "dev";
+      case ezLogMsgType::DebugMsg:
+        return "debug";
+      default:
+        return "other";
     }
   }
 
@@ -1503,10 +1511,18 @@ void ezMcpAssetTool::ExecuteListImporters(const ezVariantDictionary& arguments, 
       // What the import dialog would preselect. An agent with no opinion should use the highest.
       switch (mode.m_Priority)
       {
-        case ezAssetDocGeneratorPriority::HighPriority: writer.AddVariableString("priority", "high"); break;
-        case ezAssetDocGeneratorPriority::DefaultPriority: writer.AddVariableString("priority", "default"); break;
-        case ezAssetDocGeneratorPriority::LowPriority: writer.AddVariableString("priority", "low"); break;
-        default: writer.AddVariableString("priority", "undecided"); break;
+        case ezAssetDocGeneratorPriority::HighPriority:
+          writer.AddVariableString("priority", "high");
+          break;
+        case ezAssetDocGeneratorPriority::DefaultPriority:
+          writer.AddVariableString("priority", "default");
+          break;
+        case ezAssetDocGeneratorPriority::LowPriority:
+          writer.AddVariableString("priority", "low");
+          break;
+        default:
+          writer.AddVariableString("priority", "undecided");
+          break;
       }
 
       ezMcpTranslation::AddOptionalString(writer, "displayName", ezMcpTranslation::GetDisplayName(mode.m_sName));

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.cpp
@@ -1,0 +1,1732 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpTranslation.h>
+#include <EditorPluginMcp/McpTools/AssetTool.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocumentGenerator.h>
+#include <EditorFramework/Assets/AssetProcessor.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+#include <ToolsFoundation/Utilities/SearchPatternFilter.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpAssetTool, 1, ezRTTIDefaultAllocator<ezMcpAssetTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// The largest number of assets asset_find returns. A real project has thousands, and an unfiltered
+  /// listing would fill the client's context with paths it did not ask for. The total is reported
+  /// alongside, so the agent can tell 'that is all of them' from 'narrow your filter'.
+  constexpr ezUInt32 s_uiMaxAssetResults = 200;
+
+  /// The names of ezAssetInfo::TransformState, in enum order.
+  ///
+  /// These are the strings the tools report and accept as a filter, so they are part of the interface
+  /// an agent sees, not just a debug aid.
+  constexpr const char* s_szTransformStateNames[ezAssetInfo::TransformState::COUNT] = {
+    "Unknown",
+    "UpToDate",
+    "NeedsImport",
+    "NeedsTransform",
+    "NeedsThumbnail",
+    "TransformError",
+    "MissingTransformDependency",
+    "MissingThumbnailDependency",
+    "MissingPackageDependency",
+    "CircularDependency",
+  };
+
+  /// Deliberately the same severity names that log_read reports, so an agent reading a transform log
+  /// and the editor log does not have to learn two vocabularies. Kept as a separate copy rather than
+  /// shared with LogTool, because exporting it would couple two otherwise unrelated tool providers
+  /// through a header for seven strings. If a third tool needs these, move them into a common place.
+  ezStringView AssetLogSeverityToString(ezLogMsgType::Enum type)
+  {
+    switch (type)
+    {
+      case ezLogMsgType::ErrorMsg: return "error";
+      case ezLogMsgType::SeriousWarningMsg: return "serious-warning";
+      case ezLogMsgType::WarningMsg: return "warning";
+      case ezLogMsgType::SuccessMsg: return "success";
+      case ezLogMsgType::InfoMsg: return "info";
+      case ezLogMsgType::DevMsg: return "dev";
+      case ezLogMsgType::DebugMsg: return "debug";
+      default: return "other";
+    }
+  }
+
+  ezStringView TransformStateToString(ezAssetInfo::TransformState state)
+  {
+    if (state < 0 || state >= ezAssetInfo::TransformState::COUNT)
+      return "Unknown";
+
+    return s_szTransformStateNames[state];
+  }
+
+  /// Returns COUNT if the name matches no state, which the caller has to report as a bad argument
+  /// rather than silently filtering on something else.
+  ezAssetInfo::TransformState TransformStateFromString(ezStringView sName)
+  {
+    for (ezUInt32 i = 0; i < ezAssetInfo::TransformState::COUNT; ++i)
+    {
+      if (sName.IsEqual_NoCase(s_szTransformStateNames[i]))
+        return static_cast<ezAssetInfo::TransformState>(i);
+    }
+
+    return ezAssetInfo::TransformState::COUNT;
+  }
+
+  /// Wraps a semicolon separated list in semicolons, which is the form the filters compare against.
+  ///
+  /// The type filter of ezAssetBrowserAttribute is already stored this way (";Texture 2D;Texture 3D;"),
+  /// so an agent forwarding what rtti_type_properties reported would pass the delimiters along. Both
+  /// forms have to work, because requiring the agent to strip delimiters it did not add is a trap.
+  void NormalizeDelimitedList(ezStringBuilder& ref_sList)
+  {
+    ref_sList.Trim(" ");
+
+    if (ref_sList.IsEmpty())
+      return;
+
+    if (!ref_sList.StartsWith(";"))
+      ref_sList.Prepend(";");
+
+    if (!ref_sList.EndsWith(";"))
+      ref_sList.Append(";");
+  }
+
+  /// Extracts the guid of a 'ref:<guid>' / 'ref-all:<guid>' prefix out of a search text.
+  ///
+  /// This is the syntax the asset browser's search box uses for a reverse lookup. It is supported here
+  /// so a search a user typed into the browser can be pasted through unchanged, but the documented way
+  /// is the 'usedBy' argument - a schema an agent can read beats a prefix it has to be told about.
+  ///
+  /// Returns false if the text carries no such prefix, in which case the outputs are untouched.
+  bool ExtractUsesSearch(ezStringView sText, ezUuid& out_guid, bool& out_bTransitive)
+  {
+    ezStringBuilder sTemp = sText;
+
+    const char* szRefAll = ezStringUtils::FindSubString_NoCase(sTemp, "ref-all:");
+    const char* szRef = ezStringUtils::FindSubString_NoCase(sTemp, "ref:");
+
+    if (szRefAll == nullptr && szRef == nullptr)
+      return false;
+
+    const bool bTransitive = szRefAll != nullptr;
+    const char* szGuid = bTransitive ? szRefAll + ezStringUtils::GetStringElementCount("ref-all:") : szRef + ezStringUtils::GetStringElementCount("ref:");
+
+    if (!ezConversionUtils::IsStringUuid(szGuid))
+      return false;
+
+    out_guid = ezConversionUtils::ConvertStringToUuid(szGuid);
+    out_bTransitive = bTransitive;
+    return true;
+  }
+
+  /// Resolves a guid or a path to an asset.
+  ///
+  /// FindSubAsset()'s fast path handles guids and absolute paths, but *not* the data dir parent
+  /// relative path ("Testing Chambers/Prefabs/Barrel.ezMeshAsset") - which is exactly the form
+  /// asset_find reports as 'path'. Without the exhaustive fallback the tools do not compose: feeding
+  /// asset_find's own output back into asset_info fails. The fallback is a linear scan over all known
+  /// assets, but it only runs once the cheap lookup has already missed, and it is the same order of
+  /// work asset_find does anyway.
+  ezAssetCurator::ezLockedSubAsset ResolveAsset(ezStringView sPathOrGuid)
+  {
+    ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+    auto asset = pCurator->FindSubAsset(sPathOrGuid, false);
+
+    if (asset.isValid())
+      return asset;
+
+    return pCurator->FindSubAsset(sPathOrGuid, true);
+  }
+
+  /// Collects the assets that the given asset references.
+  ///
+  /// The transitive case is exactly the dependency hull. The direct case has no curator call that
+  /// returns guids, so it is the hull filtered down to the entries that appear in the asset's own
+  /// dependency sets. Those sets hold "a data dir relative path or a GUID" (see ezAssetDocumentInfo),
+  /// so each candidate is looked for under its guid and under both of its relative path spellings.
+  void CollectReferencedAssets(const ezSubAsset& subAsset, bool bTransitive, ezSet<ezUuid>& out_deps)
+  {
+    ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+    pCurator->GenerateTransitiveAssetHull(subAsset.m_Data.m_Guid, out_deps,
+      ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail | ezDependencyFlags::Package);
+
+    // the hull includes the asset itself, which is never an answer to 'what does this use'
+    out_deps.Remove(subAsset.m_Data.m_Guid);
+
+    if (bTransitive)
+      return;
+
+    const ezAssetDocumentInfo* pInfo = subAsset.m_pAssetInfo != nullptr ? subAsset.m_pAssetInfo->m_Info.Borrow() : nullptr;
+
+    if (pInfo == nullptr)
+    {
+      // without the asset's own lists there is nothing to filter against, and reporting the whole
+      // transitive hull as if it were direct would be a wrong answer rather than a partial one
+      out_deps.Clear();
+      return;
+    }
+
+    ezSet<ezUuid> direct;
+    ezStringBuilder sGuid;
+
+    auto IsListed = [pInfo](ezStringView sKey) -> bool
+    {
+      return pInfo->m_TransformDependencies.Contains(sKey) || pInfo->m_ThumbnailDependencies.Contains(sKey) ||
+             pInfo->m_PackageDependencies.Contains(sKey);
+    };
+
+    for (const ezUuid& guid : out_deps)
+    {
+      // Deliberately no check that the curator knows this guid: a reference to a missing asset is
+      // precisely what a caller asking about references wants to see.
+      ezConversionUtils::ToString(guid, sGuid);
+
+      if (IsListed(sGuid))
+      {
+        direct.Insert(guid);
+        continue;
+      }
+
+      // The same reference may be stored as a path instead, in either relative spelling. Both are
+      // asked for, because which one a document wrote depends on how the reference was authored, and a
+      // path-stored reference that is not recognised here is reported as indirect - which is wrong,
+      // not merely incomplete.
+      const ezAssetCurator::ezLockedSubAsset dep = pCurator->GetSubAsset(guid);
+
+      if (dep.isValid() && dep->m_pAssetInfo != nullptr && dep->m_pAssetInfo->m_Path.IsValid())
+      {
+        const ezDataDirPath& path = dep->m_pAssetInfo->m_Path;
+
+        if (IsListed(path.GetDataDirRelativePath()) || IsListed(path.GetDataDirParentRelativePath()))
+        {
+          direct.Insert(guid);
+        }
+      }
+    }
+
+    out_deps.Swap(direct);
+  }
+
+  /// Writes the state of the background asset processor as a nested object.
+  ///
+  /// 'Stopped' and 'paused' are different things: the first means the processor was switched off, the
+  /// second that it is on but temporarily held back (asset import does this). Both stop progress, and a
+  /// caller watching the transform state counts has to be able to tell why nothing is moving.
+  void WriteProcessorStatus(ezMcpJsonWriter& ref_writer, ezStringView sName)
+  {
+    ezAssetProcessor* pProcessor = ezAssetProcessor::GetSingleton();
+
+    if (pProcessor == nullptr)
+      return;
+
+    ref_writer.BeginObject(sName);
+
+    switch (pProcessor->GetProcessorState())
+    {
+      case ezAssetProcessor::ProcessorState::Stopped:
+        ref_writer.AddVariableString("state", "Stopped");
+        break;
+      case ezAssetProcessor::ProcessorState::Running:
+        ref_writer.AddVariableString("state", "Running");
+        break;
+      case ezAssetProcessor::ProcessorState::Stopping:
+        ref_writer.AddVariableString("state", "Stopping");
+        break;
+    }
+
+    const ezUInt32 uiProcessCount = pProcessor->GetProcessCount();
+
+    ezUInt32 uiBusy = 0;
+    ezUInt32 uiCrashed = 0;
+
+    for (ezUInt32 i = 0; i < uiProcessCount; ++i)
+    {
+      const ezEditorProcessorState state = pProcessor->GetProcessState(i);
+
+      if (state.m_bCrashed)
+        ++uiCrashed;
+      else if (state.m_bRunning)
+        ++uiBusy;
+    }
+
+    ref_writer.AddVariableUInt32("processes", uiProcessCount);
+    ref_writer.AddVariableUInt32("transformingNow", uiBusy);
+
+    // Refcounted and set by whatever is currently importing, so it can be non-zero even while the
+    // processor is Running. Nothing moves while it is set.
+    if (pProcessor->m_iPauseProcessing > 0)
+    {
+      ref_writer.AddVariableBool("paused", true);
+      ref_writer.AddVariableString("pausedReason", "Something in the editor is temporarily holding off background processing, usually an asset import. This clears on its own.");
+    }
+
+    // a crashed processor stops making progress silently, so it is always worth reporting
+    if (uiCrashed > 0)
+      ref_writer.AddVariableUInt32("crashedProcesses", uiCrashed);
+
+    ref_writer.EndObject();
+  }
+
+  /// Writes a set of strings as an array, but only if it has any content.
+  ///
+  /// Empty arrays repeated across every asset are pure token cost. This does mean a client cannot tell
+  /// 'no dependencies' from 'not reported', which is the trade Status.md settles on for optional detail.
+  void WriteStringSet(ezMcpJsonWriter& ref_writer, ezStringView sName, const ezSet<ezString>& values)
+  {
+    if (values.IsEmpty())
+      return;
+
+    ref_writer.BeginArray(sName);
+    for (const ezString& sValue : values)
+    {
+      ref_writer.WriteString(sValue);
+    }
+    ref_writer.EndArray();
+  }
+} // namespace
+
+void ezMcpAssetTool::OnActivate()
+{
+  if (m_ProgressSubscription != 0)
+    return;
+
+  // The processor is a singleton that only exists while a project is open, which is also when this
+  // provider is activated.
+  if (ezAssetProcessor* pProcessor = ezAssetProcessor::GetSingleton())
+  {
+    m_ProgressSubscription = pProcessor->m_ProgressEvents.AddEventHandler(ezMakeDelegate(&ezMcpAssetTool::ProcessorProgressEventHandler, this));
+  }
+}
+
+void ezMcpAssetTool::OnDeactivate()
+{
+  if (m_ProgressSubscription == 0)
+    return;
+
+  if (ezAssetProcessor* pProcessor = ezAssetProcessor::GetSingleton())
+  {
+    // takes the id by reference and resets it
+    pProcessor->m_ProgressEvents.RemoveEventHandler(m_ProgressSubscription);
+  }
+
+  m_ProgressSubscription = 0;
+}
+
+void ezMcpAssetTool::ProcessorProgressEventHandler(const ezAssetProcessorProgressEvent& e)
+{
+  // Only finished work is recorded. A 'started' entry would be superseded moments later and the
+  // in-flight count is already reported by asset_health.
+  if (e.m_Type != ezAssetProcessorProgressEvent::Type::ProcessingFinished)
+    return;
+
+  // The path is stored exactly as the event delivers it - GetDataDirRelativePath(), which omits the
+  // data directory and so is shorter than the path the other tools report. Resolving it through the
+  // curator would be more consistent, but this runs on a processor worker thread and GetSubAsset()
+  // takes the curator lock, which the transform path already holds in places. The existing UI handler
+  // avoids the same trap by keeping only the guid and resolving on the main thread. The guid is
+  // returned alongside and is unambiguous, so the shorter path is the cheaper trade.
+  RecordHistory(e.m_AssetGuid, e.m_sAssetPath, e.m_Result, e.m_EndTime - e.m_TransformStartTime, true);
+}
+
+void ezMcpAssetTool::RecordHistory(const ezUuid& guid, ezStringView sPath, const ezTransformStatus& status, ezTime duration, bool bBackground)
+{
+  // Called from the processor's worker threads as well as from the main thread via asset_transform.
+  EZ_LOCK(m_HistoryMutex);
+
+  if (m_History.GetCount() >= s_uiMaxHistoryEntries)
+  {
+    m_History.PopFront();
+  }
+
+  HistoryEntry& entry = m_History.ExpandAndGetRef();
+  entry.m_uiId = m_uiNextHistoryId++;
+  entry.m_Guid = guid;
+  entry.m_sPath = sPath;
+  entry.m_sMessage = status.m_sMessage;
+  entry.m_Result = status.m_Result;
+  entry.m_Duration = duration;
+  entry.m_EndTime = ezTime::Now();
+  entry.m_bBackground = bBackground;
+}
+
+void ezMcpAssetTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_types";
+    desc.m_sDescription = "Lists every document/asset type the editor knows, with its file extension, whether it can be created, "
+                          "its asset browser category, which asset slots it is compatible with, and a link to its online "
+                          "documentation where one exists. Use this to find the correct type name and extension before creating "
+                          "or looking for an asset, and the documentation link to find out what a type is actually for.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("extension":{"type":"string","description":"Only return types whose file extension contains this text, e.g. 'Mesh'."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_find";
+    desc.m_sDescription = "Searches the assets of the project and returns the GUID, path and type of each match. This is the entry "
+                          "point into the asset database: narrow down to a few GUIDs here, then use asset_info, asset_uses or "
+                          "asset_thumbnail on those. All filters combine with AND. Results are capped, but the total number of "
+                          "matches is reported. Note that this searches the editor's asset database, not the file system - it "
+                          "knows about GUIDs, types and references, which the file tools cannot answer.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"Matches against the asset name, its path and its GUID, case insensitive. Multiple words separated by spaces must all match, in any order; a word prefixed with '-' must not match. E.g. 'stone -rough'. A partial GUID works too."},)"
+                          R"("path":{"type":"string","description":"Only return assets whose data directory relative path starts with this folder, e.g. 'Textures/Nature'."},)"
+                          R"("type":{"type":"string","description":"Only return assets of these document types, separated by semicolons, e.g. 'Texture 2D;Texture 3D'. Use asset_types for the valid names. This accepts the value of an ezAssetBrowserAttribute's TypeFilter unchanged."},)"
+                          R"("tag":{"type":"string","description":"Only return assets carrying this asset document tag. Tags restrict which assets may go into a specific property - the required tag is reported by the ezAssetBrowserAttribute on that property, see rtti_type_properties."},)"
+                          R"("usedBy":{"type":"string","description":"Reverse lookup: only return assets that are directly referenced by this asset (GUID or path). Answers 'what does this asset use'."},)"
+                          R"("uses":{"type":"string","description":"Reverse lookup: only return assets that reference this asset (GUID or path). Answers 'who uses this'. Combine with 'transitive' for indirect uses."},)"
+                          R"("transitive":{"type":"boolean","description":"If true, 'uses' and 'usedBy' also follow indirect references. Default false."},)"
+                          R"("transformState":{"type":"string","description":"Only return assets in this transform state. One of: Unknown, UpToDate, NeedsImport, NeedsTransform, NeedsThumbnail, TransformError, MissingTransformDependency, MissingThumbnailDependency, MissingPackageDependency, CircularDependency."},)"
+                          R"("subAssets":{"type":"boolean","description":"If true, also return sub-assets, e.g. the individual animation clips inside an animation asset. Default false, which returns only main assets."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_info";
+    desc.m_sDescription = "Returns the details of one asset: its absolute and relative paths, type, transform state, tags, "
+                          "sub-assets, its dependencies, a link to the documentation of its type, and - if the last transform "
+                          "failed - the log messages explaining why. "
+                          "The log messages are the reason to call this on a broken asset instead of searching the editor log.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("asset":{"type":"string","description":"The asset GUID or its path, as returned by asset_find. Either form works."},)"
+                          R"("dependencies":{"type":"boolean","description":"If true, include the transform, thumbnail and package dependency lists. Default true. Set to false on assets with many references to keep the result small."})"
+                          R"(},"required":["asset"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_uses";
+    desc.m_sDescription = "Returns what an asset references and what references it. This is the question that is genuinely hard to "
+                          "answer by reading files, because references are stored as GUIDs. Use it before deleting or changing an "
+                          "asset, to find out what would break.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("asset":{"type":"string","description":"The asset GUID or its path."},)"
+                          R"("direction":{"type":"string","description":"'uses' returns what references this asset, 'usedBy' returns what this asset references, 'both' returns both. Default 'both'."},)"
+                          R"("transitive":{"type":"boolean","description":"If true, also follow indirect references. Default false. This can return a lot on a heavily shared asset such as a common material."})"
+                          R"(},"required":["asset"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_thumbnail";
+    desc.m_sDescription = "Returns the absolute path of an asset's thumbnail image (a .jpg), plus whether that file currently "
+                          "exists and whether it is up to date. The image data is not returned - read the file if you need it. "
+                          "Not every asset type has a thumbnail, and the file only exists after the asset was transformed.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("asset":{"type":"string","description":"The asset GUID or its path."})"
+                          R"(},"required":["asset"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_transform";
+    desc.m_sDescription = "Transforms one asset, i.e. compiles it into its runtime format, and returns whether that succeeded. "
+                          "On failure the returned message says why, and asset_info returns the full log. "
+                          "IMPORTANT: this blocks the editor until it finishes, which for a large asset such as a scene can take "
+                          "minutes - call it with a generous timeout. Only one asset at a time is supported on purpose; there is "
+                          "no tool to transform everything, because that would block the editor for far too long.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("asset":{"type":"string","description":"The asset GUID or its path."},)"
+                          R"("force":{"type":"boolean","description":"If true, transform even if the asset is already up to date. Default false. Use this when the output looks wrong but the editor thinks nothing changed."})"
+                          R"(},"required":["asset"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_health";
+    desc.m_sDescription = "Returns how many assets are in each transform state, plus whether the background asset processor is "
+                          "running and how many assets it is transforming right now. Cheap enough to call routinely, e.g. after "
+                          "changing assets, to check whether anything broke. Note that while the processor is Running the counts "
+                          "are moving on their own, so a large NeedsTransform count means 'not got to yet' rather than 'broken'. "
+                          "If it reports assets in a failed state, use asset_find with that transformState to get the list, then "
+                          "asset_info for the reason.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_history";
+    desc.m_sDescription = "Returns the assets that were transformed recently, newest last, with how long each took and whether it "
+                          "succeeded. Use this after changing something to see what the editor rebuilt in response, which the "
+                          "transform state counts cannot tell you. Structured, so unlike log_read it cannot be drowned out by "
+                          "unrelated editor output. Only covers this editor session, and only since a project was opened. "
+                          "The 'path' of an entry may be shorter than the path the other asset tools report (it omits the data "
+                          "directory), so use the GUID to identify an asset unambiguously.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("count":{"type":"number","description":"How many of the most recent entries to return. Default 50."},)"
+                          R"("sinceId":{"type":"number","description":"Only return entries with an id greater than this. Pass the 'lastId' of a previous call to get just what happened since - better than guessing a count."},)"
+                          R"("failedOnly":{"type":"boolean","description":"If true, only return transforms that did not succeed. Default false."},)"
+                          R"("asset":{"type":"string","description":"Only return entries for this asset, given as a GUID or a path substring."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_processor";
+    desc.m_sDescription = "Starts or stops the background asset processor, which transforms outdated assets on its own in "
+                          "separate processes. Use this when asset_health reports it as Stopped and assets are not becoming "
+                          "UpToDate, or to stop it so it does not compete for CPU with something else. Unlike asset_transform "
+                          "this returns immediately - it only flips the switch, the work happens in the background afterwards. "
+                          "Call with no arguments to just query the current state.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("action":{"type":"string","description":"'start' begins background processing, 'stop' ends it after the assets currently in flight finish, 'forceStop' kills the running processes immediately, 'query' only reports the state and changes nothing. Default 'query'."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_importers";
+    desc.m_sDescription =
+      "Lists the source file types that can be imported as assets - fbx, gltf, png and so on - and the import modes available for "
+      "each. Call this before 'asset_import': the mode name is what 'asset_import' takes, and it decides how the file is "
+      "interpreted, e.g. whether a texture is treated as colour data or as a normal map. Pass a file to see only the modes that "
+      "apply to it.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("file":{"type":"string","description":"A source file, or just an extension like 'png'. Only report importers that accept it, with the modes they offer for it."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "asset_import";
+    desc.m_sDescription =
+      "Imports a source file - a mesh, texture, animation and so on - as an asset document, the same way the asset browser's import "
+      "does. The new document is created next to the source file, with the asset extension replacing the original one, and is saved "
+      "immediately. "
+      "It is NOT opened; use 'document_open' if you want to adjust its properties afterwards, which is usually the next step - the "
+      "import only sets what it can infer from the file. "
+      "If an asset for that source file already exists this reports 'alreadyImported' and changes nothing, rather than overwriting "
+      "work. Call 'asset_importers' first to find the mode to use.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("file":{"type":"string","description":"The source file to import. Absolute, or relative to the data directory parent. Must be inside the project."},)"
+                          R"("mode":{"type":"string","description":"How to interpret the file, e.g. 'TextureImport.Diffuse'. See 'asset_importers'. If omitted the highest priority mode for the file is used, which is what the import dialog preselects."})"
+                          R"(},"required":["file"]})";
+  }
+}
+
+void ezMcpAssetTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "asset_types")
+    ExecuteListTypes(arguments, out_result);
+  else if (sToolName == "asset_find")
+    ExecuteFind(arguments, out_result);
+  else if (sToolName == "asset_info")
+    ExecuteInfo(arguments, out_result);
+  else if (sToolName == "asset_uses")
+    ExecuteUses(arguments, out_result);
+  else if (sToolName == "asset_thumbnail")
+    ExecuteThumbnail(arguments, out_result);
+  else if (sToolName == "asset_transform")
+    ExecuteTransform(arguments, out_result);
+  else if (sToolName == "asset_health")
+    ExecuteHealth(arguments, out_result);
+  else if (sToolName == "asset_processor")
+    ExecuteProcessor(arguments, out_result);
+  else if (sToolName == "asset_history")
+    ExecuteHistory(arguments, out_result);
+  else if (sToolName == "asset_importers")
+    ExecuteListImporters(arguments, out_result);
+  else if (sToolName == "asset_import")
+    ExecuteImport(arguments, out_result);
+}
+
+void ezMcpAssetTool::ExecuteHistory(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezInt64 iCount = ezMath::Clamp<ezInt64>(ezMcpJson::GetInt(arguments, "count", 50), 1, s_uiMaxHistoryEntries);
+  const ezUInt64 uiSinceId = static_cast<ezUInt64>(ezMath::Max<ezInt64>(0, ezMcpJson::GetInt(arguments, "sinceId", 0)));
+  const bool bFailedOnly = ezMcpJson::GetBool(arguments, "failedOnly", false);
+  const ezStringView sAssetFilter = ezMcpJson::GetString(arguments, "asset");
+
+  // Resolve the asset filter once, so that a guid, an exact path and a path substring all work. An
+  // unresolvable value is not an error - it is still usable as a substring match against the paths.
+  ezUuid filterGuid;
+  if (!sAssetFilter.IsEmpty())
+  {
+    auto asset = ResolveAsset(sAssetFilter);
+
+    if (asset.isValid())
+      filterGuid = asset->m_Data.m_Guid;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezUInt32 uiTotalMatches = 0;
+  ezUInt64 uiLastId = 0;
+
+  {
+    EZ_LOCK(m_HistoryMutex);
+
+    // Walk backwards to find where the newest 'count' matches begin, so the output can still be
+    // written oldest-first without collecting into a temporary array.
+    ezHybridArray<const HistoryEntry*, 64> selected;
+
+    for (ezUInt32 i = m_History.GetCount(); i > 0; --i)
+    {
+      const HistoryEntry& entry = m_History[i - 1];
+
+      if (entry.m_uiId <= uiSinceId)
+        break; // ids increase with position, so everything before this is older still
+
+      if (bFailedOnly && entry.m_Result == ezTransformResult::Success)
+        continue;
+
+      if (!sAssetFilter.IsEmpty())
+      {
+        const bool bGuidMatches = filterGuid.IsValid() && entry.m_Guid == filterGuid;
+        const bool bPathMatches = entry.m_sPath.FindSubString_NoCase(sAssetFilter) != nullptr;
+
+        if (!bGuidMatches && !bPathMatches)
+          continue;
+      }
+
+      ++uiTotalMatches;
+
+      if (selected.GetCount() < static_cast<ezUInt32>(iCount))
+        selected.PushBack(&entry);
+    }
+
+    writer.BeginArray("transforms");
+
+    // selected is newest-first, so it is written in reverse to end up chronological
+    for (ezUInt32 i = selected.GetCount(); i > 0; --i)
+    {
+      const HistoryEntry& entry = *selected[i - 1];
+
+      writer.BeginObject();
+      writer.AddVariableUInt64("id", entry.m_uiId);
+      writer.AddVariableUuid("guid", entry.m_Guid);
+      writer.AddVariableString("path", entry.m_sPath);
+
+      switch (entry.m_Result)
+      {
+        case ezTransformResult::Success:
+          writer.AddVariableString("result", "Success");
+          break;
+        case ezTransformResult::Failure:
+          writer.AddVariableString("result", "Failure");
+          break;
+        case ezTransformResult::NeedsImport:
+          writer.AddVariableString("result", "NeedsImport");
+          break;
+      }
+
+      // rounded to milliseconds - the sub-millisecond digits are noise and cost tokens
+      writer.AddVariableInt64("durationMs", static_cast<ezInt64>(entry.m_Duration.GetMilliseconds()));
+
+      // how long ago this finished, which is more useful to a model than an absolute timestamp it has
+      // no reference point for
+      writer.AddVariableInt64("secondsAgo", static_cast<ezInt64>((ezTime::Now() - entry.m_EndTime).GetSeconds()));
+
+      if (!entry.m_sMessage.IsEmpty())
+        writer.AddVariableString("message", entry.m_sMessage);
+
+      // background is the normal case; only the exception is worth the tokens
+      if (!entry.m_bBackground)
+        writer.AddVariableString("triggeredBy", "asset_transform");
+
+      writer.EndObject();
+
+      uiLastId = ezMath::Max(uiLastId, entry.m_uiId);
+    }
+
+    writer.EndArray();
+
+    writer.AddVariableUInt32("totalMatches", uiTotalMatches);
+    writer.AddVariableUInt32("returned", selected.GetCount());
+    writer.AddVariableBool("truncated", uiTotalMatches > selected.GetCount());
+  }
+
+  // What to pass as 'sinceId' next time. Zero when nothing matched, in which case the caller should
+  // keep whatever it had rather than resetting to the start of the buffer.
+  if (uiLastId > 0)
+    writer.AddVariableUInt64("lastId", uiLastId);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::WriteAssetIdentity(ezMcpJsonWriter& ref_writer, const ezSubAsset& subAsset)
+{
+  ref_writer.AddVariableUuid("guid", subAsset.m_Data.m_Guid);
+  ref_writer.AddVariableString("name", subAsset.GetName());
+
+  ezStringBuilder sIdentifier;
+  subAsset.GetSubAssetIdentifier(sIdentifier);
+  ref_writer.AddVariableString("path", sIdentifier);
+
+  ref_writer.AddVariableString("type", subAsset.m_Data.m_sSubAssetsDocumentTypeName);
+
+  if (!subAsset.m_bMainAsset)
+    ref_writer.AddVariableBool("isSubAsset", true);
+}
+
+void ezMcpAssetTool::ExecuteListTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sFilter = ezMcpJson::GetString(arguments, "extension");
+
+  ezMcpJsonWriter writer;
+  writer.BeginArray();
+
+  // this map is ordered by type name, so the output is stable
+  for (auto it : ezDocumentManager::GetAllDocumentDescriptors())
+  {
+    const ezDocumentTypeDescriptor* pDesc = it.Value();
+
+    if (!sFilter.IsEmpty() && pDesc->m_sFileExtension.FindSubString_NoCase(sFilter) == nullptr)
+      continue;
+
+    writer.BeginObject();
+
+    writer.AddVariableString("typeName", pDesc->m_sDocumentTypeName);
+
+    // What the user sees in the asset browser, which is not the type name. Without this an agent
+    // cannot connect what a user describes ('the Decal asset') to the name every other tool wants.
+    ezMcpTranslation::AddOptionalString(writer, "displayName", ezMcpTranslation::GetDisplayName(pDesc->m_sDocumentTypeName));
+
+    writer.AddVariableString("extension", pDesc->m_sFileExtension);
+    writer.AddVariableBool("canCreate", pDesc->m_bCanCreate);
+    writer.AddVariableString("category", pDesc->m_sAssetCategory);
+
+    // the RTTI name of the document class - the entry point for finding the code that handles this type
+    writer.AddVariableString("documentClass", pDesc->m_pDocumentType != nullptr ? pDesc->m_pDocumentType->GetTypeName() : ezStringView());
+
+    // The link to the online documentation for this asset type, which is prose explaining what the type
+    // is for - something no amount of reflection data conveys.
+    ezMcpTranslation::AddOptionalString(writer, "helpUrl", ezMcpTranslation::GetHelpURL(pDesc->m_sDocumentTypeName));
+
+    writer.BeginArray("compatibleTypes");
+    for (const ezString& sCompatible : pDesc->m_CompatibleTypes)
+    {
+      writer.WriteString(sCompatible);
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+  }
+
+  writer.EndArray();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteFind(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("No project is open, so there is no asset database to search.");
+    return;
+  }
+
+  const ezStringView sNameFilter = ezMcpJson::GetString(arguments, "name");
+  const ezStringView sTransformState = ezMcpJson::GetString(arguments, "transformState");
+  const bool bIncludeSubAssets = ezMcpJson::GetBool(arguments, "subAssets", false);
+  bool bTransitive = ezMcpJson::GetBool(arguments, "transitive", false);
+
+  ezStringBuilder sPathFilter = ezMcpJson::GetString(arguments, "path");
+  sPathFilter.MakeCleanPath();
+  // matching a folder prefix only makes sense with the trailing separator, otherwise 'Text' would also
+  // match the folder 'Textures'
+  if (!sPathFilter.IsEmpty() && !sPathFilter.EndsWith("/"))
+    sPathFilter.Append("/");
+
+  ezStringBuilder sTypeFilter = ezMcpJson::GetString(arguments, "type");
+  NormalizeDelimitedList(sTypeFilter);
+
+  ezStringBuilder sTagFilter = ezMcpJson::GetString(arguments, "tag");
+  sTagFilter.Trim(" ");
+
+  ezAssetInfo::TransformState stateFilter = ezAssetInfo::TransformState::COUNT;
+  if (!sTransformState.IsEmpty())
+  {
+    stateFilter = TransformStateFromString(sTransformState);
+
+    if (stateFilter == ezAssetInfo::TransformState::COUNT)
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("'{}' is not a valid transform state. Valid values are: ", sTransformState);
+      for (ezUInt32 i = 0; i < ezAssetInfo::TransformState::COUNT; ++i)
+      {
+        if (i > 0)
+          sError.Append(", ");
+        sError.Append(s_szTransformStateNames[i]);
+      }
+      out_result.SetError(sError);
+      return;
+    }
+  }
+
+  // The reverse lookups produce a set of GUIDs that the result is restricted to. An empty set is not
+  // the same as 'no restriction', so the flag has to be tracked separately - an asset that nothing
+  // references must return zero results, not everything.
+  bool bRestrictToSet = false;
+  ezSet<ezUuid> allowedGuids;
+
+  ezSearchPatternFilter searchFilter;
+  {
+    // 'ref:<guid>' inside the name filter is the asset browser's syntax for a reverse lookup. It is
+    // accepted so a search copied out of the browser works, but 'uses' is the documented argument.
+    ezUuid refGuid;
+    bool bRefTransitive = false;
+
+    if (!sNameFilter.IsEmpty() && ExtractUsesSearch(sNameFilter, refGuid, bRefTransitive))
+    {
+      bRestrictToSet = true;
+      pCurator->FindAllUses(refGuid, allowedGuids, bRefTransitive);
+    }
+    else
+    {
+      ezStringBuilder sCleanName = sNameFilter;
+      sCleanName.MakeCleanPath();
+      sCleanName.ReplaceAll("*", "");
+      searchFilter.SetSearchText(sCleanName);
+    }
+  }
+
+  // 'uses' asks who references the given asset, which is exactly FindAllUses().
+  const ezStringView sUses = ezMcpJson::GetString(arguments, "uses");
+  if (!sUses.IsEmpty())
+  {
+    auto asset = ResolveAsset(sUses);
+
+    if (!asset.isValid())
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("No asset found for 'uses' filter '{}'. Pass a GUID or a path as returned by asset_find.", sUses);
+      out_result.SetError(sError);
+      return;
+    }
+
+    bRestrictToSet = true;
+    pCurator->FindAllUses(asset->m_Data.m_Guid, allowedGuids, bTransitive);
+  }
+
+  // 'usedBy' asks the opposite - what the given asset references. There is no direct call for the
+  // transitive case that returns GUIDs, so the dependency lists are resolved by hand.
+  const ezStringView sUsedBy = ezMcpJson::GetString(arguments, "usedBy");
+  if (!sUsedBy.IsEmpty())
+  {
+    auto asset = ResolveAsset(sUsedBy);
+
+    if (!asset.isValid())
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("No asset found for 'usedBy' filter '{}'. Pass a GUID or a path as returned by asset_find.", sUsedBy);
+      out_result.SetError(sError);
+      return;
+    }
+
+    ezSet<ezUuid> deps;
+    CollectReferencedAssets(*asset, bTransitive, deps);
+
+    if (bRestrictToSet)
+    {
+      // both reverse filters were given, so only assets satisfying both remain
+      ezSet<ezUuid> intersection;
+      for (const ezUuid& guid : deps)
+      {
+        if (allowedGuids.Contains(guid))
+          intersection.Insert(guid);
+      }
+      allowedGuids.Swap(intersection);
+    }
+    else
+    {
+      bRestrictToSet = true;
+      allowedGuids.Swap(deps);
+    }
+  }
+
+  ezUInt32 uiTotalMatches = 0;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.BeginArray("assets");
+
+  {
+    auto knownSubAssets = pCurator->GetKnownSubAssets();
+
+    ezStringBuilder sIdentifier, sGuid, sTemp;
+
+    for (auto it : *knownSubAssets)
+    {
+      const ezSubAsset& subAsset = it.Value();
+
+      if (!subAsset.m_bMainAsset && !bIncludeSubAssets)
+        continue;
+
+      if (subAsset.m_pAssetInfo == nullptr)
+        continue;
+
+      if (bRestrictToSet && !allowedGuids.Contains(subAsset.m_Data.m_Guid))
+        continue;
+
+      subAsset.GetSubAssetIdentifier(sIdentifier);
+
+      // ignore everything inside the asset cache, which is generated output rather than source assets
+      if (sIdentifier.FindSubString("/AssetCache/") != nullptr)
+        continue;
+
+      if (!sPathFilter.IsEmpty() && !sIdentifier.StartsWith_NoCase(sPathFilter))
+        continue;
+
+      if (!sTypeFilter.IsEmpty())
+      {
+        sTemp.Set(";", subAsset.m_Data.m_sSubAssetsDocumentTypeName, ";");
+
+        if (sTypeFilter.FindSubString_NoCase(sTemp) == nullptr)
+          continue;
+      }
+
+      if (!sTagFilter.IsEmpty())
+      {
+        // an asset whose info failed to load carries no tags, so it cannot satisfy a tag filter
+        const ezAssetDocumentInfo* pInfo = subAsset.m_pAssetInfo->m_Info.Borrow();
+
+        if (pInfo == nullptr)
+          continue;
+
+        sTemp.Set(";", sTagFilter, ";");
+
+        if (pInfo->GetAssetsDocumentTags().FindSubString_NoCase(sTemp) == nullptr)
+          continue;
+      }
+
+      if (stateFilter != ezAssetInfo::TransformState::COUNT && subAsset.m_pAssetInfo->m_TransformState != stateFilter)
+        continue;
+
+      if (!searchFilter.IsEmpty())
+      {
+        // the same three-way match the asset browser does: path, then name, then GUID, so that a
+        // pasted GUID and a partial name both find something
+        if (!searchFilter.PassesFilters(sIdentifier) && !searchFilter.PassesFilters(subAsset.GetName()))
+        {
+          ezConversionUtils::ToString(subAsset.m_Data.m_Guid, sGuid);
+
+          if (!searchFilter.PassesFilters(sGuid))
+            continue;
+        }
+      }
+
+      ++uiTotalMatches;
+
+      if (uiTotalMatches > s_uiMaxAssetResults)
+        continue;
+
+      writer.BeginObject();
+      WriteAssetIdentity(writer, subAsset);
+      writer.AddVariableString("transformState", TransformStateToString(subAsset.m_pAssetInfo->m_TransformState));
+      writer.EndObject();
+    }
+  }
+
+  writer.EndArray();
+
+  const ezUInt32 uiReturned = ezMath::Min(uiTotalMatches, s_uiMaxAssetResults);
+  writer.AddVariableUInt32("totalMatches", uiTotalMatches);
+  writer.AddVariableUInt32("returned", uiReturned);
+  writer.AddVariableBool("truncated", uiTotalMatches > uiReturned);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("No project is open, so there is no asset database to query.");
+    return;
+  }
+
+  const ezStringView sAsset = ezMcpJson::GetString(arguments, "asset");
+
+  if (sAsset.IsEmpty())
+  {
+    out_result.SetError("The 'asset' argument is required. Pass a GUID or a path, as returned by asset_find.");
+    return;
+  }
+
+  auto asset = ResolveAsset(sAsset);
+
+  if (!asset.isValid())
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("No asset found for '{}'. Use asset_find to search for it.", sAsset);
+    out_result.SetError(sError);
+    return;
+  }
+
+  const bool bDependencies = ezMcpJson::GetBool(arguments, "dependencies", true);
+  const ezAssetInfo* pAssetInfo = asset->m_pAssetInfo;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  WriteAssetIdentity(writer, *asset);
+
+  writer.AddVariableString("absolutePath", pAssetInfo->m_Path.GetAbsolutePath());
+  writer.AddVariableString("dataDirectory", pAssetInfo->m_Path.GetDataDir());
+  writer.AddVariableString("transformState", TransformStateToString(pAssetInfo->m_TransformState));
+
+  if (pAssetInfo->m_pDocumentTypeDescriptor != nullptr)
+  {
+    writer.AddVariableString("outputExtension", pAssetInfo->m_pDocumentTypeDescriptor->m_sResourceFileExtension);
+
+    // the documentation for this asset's type, so an agent looking at one asset does not need a
+    // separate asset_types call to find out what the type is for
+    const ezString& sTypeName = pAssetInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName;
+    ezMcpTranslation::AddOptionalString(writer, "typeHelpUrl", ezMcpTranslation::GetHelpURL(sTypeName));
+  }
+
+  const ezAssetDocumentInfo* pInfo = pAssetInfo->m_Info.Borrow();
+
+  if (pInfo != nullptr)
+  {
+    const ezString& sTags = pInfo->GetAssetsDocumentTags();
+    if (!sTags.IsEmpty())
+      writer.AddVariableString("tags", sTags);
+
+    if (bDependencies)
+    {
+      WriteStringSet(writer, "transformDependencies", pInfo->m_TransformDependencies);
+      WriteStringSet(writer, "thumbnailDependencies", pInfo->m_ThumbnailDependencies);
+      WriteStringSet(writer, "packageDependencies", pInfo->m_PackageDependencies);
+    }
+  }
+
+  // These say why an asset is in a broken state, so they are written regardless of the dependencies
+  // flag - they are the answer the caller came for and are empty on a healthy asset anyway.
+  WriteStringSet(writer, "missingTransformDependencies", pAssetInfo->m_MissingTransformDeps);
+  WriteStringSet(writer, "missingThumbnailDependencies", pAssetInfo->m_MissingThumbnailDeps);
+  WriteStringSet(writer, "missingPackageDependencies", pAssetInfo->m_MissingPackageDeps);
+  WriteStringSet(writer, "circularDependencies", pAssetInfo->m_CircularDependencies);
+
+  if (!pAssetInfo->m_SubAssets.IsEmpty())
+  {
+    writer.BeginArray("subAssets");
+    for (const ezUuid& guid : pAssetInfo->m_SubAssets)
+    {
+      auto sub = pCurator->GetSubAsset(guid);
+
+      writer.BeginObject();
+      if (sub.isValid())
+      {
+        WriteAssetIdentity(writer, *sub);
+      }
+      else
+      {
+        // the sub-asset is listed but not in the table - report the guid rather than dropping it
+        writer.AddVariableUuid("guid", guid);
+      }
+      writer.EndObject();
+    }
+    writer.EndArray();
+  }
+
+  // The transform log is what makes a failure diagnosable. It is only non-empty when something went
+  // wrong, so healthy assets pay nothing for it.
+  if (!pAssetInfo->m_LogEntries.IsEmpty())
+  {
+    writer.BeginArray("transformLog");
+    for (const ezLogEntry& entry : pAssetInfo->m_LogEntries)
+    {
+      writer.BeginObject();
+      writer.AddVariableString("severity", AssetLogSeverityToString(entry.m_Type));
+      writer.AddVariableString("text", entry.m_sMsg);
+      writer.EndObject();
+    }
+    writer.EndArray();
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteUses(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("No project is open, so there is no asset database to query.");
+    return;
+  }
+
+  const ezStringView sAsset = ezMcpJson::GetString(arguments, "asset");
+
+  if (sAsset.IsEmpty())
+  {
+    out_result.SetError("The 'asset' argument is required. Pass a GUID or a path, as returned by asset_find.");
+    return;
+  }
+
+  auto asset = ResolveAsset(sAsset);
+
+  if (!asset.isValid())
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("No asset found for '{}'. Use asset_find to search for it.", sAsset);
+    out_result.SetError(sError);
+    return;
+  }
+
+  const ezStringView sDirection = ezMcpJson::GetString(arguments, "direction", "both");
+  const bool bTransitive = ezMcpJson::GetBool(arguments, "transitive", false);
+
+  const bool bWantUses = sDirection.IsEqual_NoCase("uses") || sDirection.IsEqual_NoCase("both");
+  const bool bWantUsedBy = sDirection.IsEqual_NoCase("usedBy") || sDirection.IsEqual_NoCase("both");
+
+  if (!bWantUses && !bWantUsedBy)
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("'{}' is not a valid direction. Use 'uses', 'usedBy' or 'both'.", sDirection);
+    out_result.SetError(sError);
+    return;
+  }
+
+  const ezUuid assetGuid = asset->m_Data.m_Guid;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  WriteAssetIdentity(writer, *asset);
+  writer.AddVariableBool("transitive", bTransitive);
+
+  auto writeGuidArray = [&](ezStringView sName, const ezSet<ezUuid>& guids)
+  {
+    writer.BeginArray(sName);
+
+    ezUInt32 uiWritten = 0;
+
+    for (const ezUuid& guid : guids)
+    {
+      if (uiWritten >= s_uiMaxAssetResults)
+        break;
+
+      auto other = pCurator->GetSubAsset(guid);
+
+      writer.BeginObject();
+      if (other.isValid())
+      {
+        WriteAssetIdentity(writer, *other);
+      }
+      else
+      {
+        // a reference to something the curator does not know - report the guid rather than hiding it,
+        // because a dangling reference is exactly what the caller is looking for
+        writer.AddVariableUuid("guid", guid);
+      }
+      writer.EndObject();
+
+      ++uiWritten;
+    }
+
+    writer.EndArray();
+
+    ezStringBuilder sTotalName(sName, "Total");
+    writer.AddVariableUInt32(sTotalName, guids.GetCount());
+
+    if (guids.GetCount() > uiWritten)
+    {
+      ezStringBuilder sTruncatedName(sName, "Truncated");
+      writer.AddVariableBool(sTruncatedName, true);
+    }
+  };
+
+  if (bWantUses)
+  {
+    // who references this asset
+    ezSet<ezUuid> uses;
+    pCurator->FindAllUses(assetGuid, uses, bTransitive);
+    uses.Remove(assetGuid);
+
+    writeGuidArray("usedBy", uses);
+  }
+
+  if (bWantUsedBy)
+  {
+    // what this asset references
+    ezSet<ezUuid> deps;
+    CollectReferencedAssets(*asset, bTransitive, deps);
+
+    writeGuidArray("uses", deps);
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteThumbnail(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("No project is open, so there is no asset database to query.");
+    return;
+  }
+
+  const ezStringView sAsset = ezMcpJson::GetString(arguments, "asset");
+
+  if (sAsset.IsEmpty())
+  {
+    out_result.SetError("The 'asset' argument is required. Pass a GUID or a path, as returned by asset_find.");
+    return;
+  }
+
+  auto asset = ResolveAsset(sAsset);
+
+  if (!asset.isValid())
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("No asset found for '{}'. Use asset_find to search for it.", sAsset);
+    out_result.SetError(sError);
+    return;
+  }
+
+  const ezAssetInfo* pAssetInfo = asset->m_pAssetInfo;
+  const ezAssetDocumentTypeDescriptor* pTypeDesc = pAssetInfo->m_pDocumentTypeDescriptor;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  WriteAssetIdentity(writer, *asset);
+
+  // Whether the type produces a thumbnail at all is a different answer from 'the file is missing',
+  // and the caller has to be able to tell them apart before going looking for the file.
+  const bool bMainAsset = asset->m_bMainAsset;
+  bool bSupportsThumbnail = false;
+
+  if (pTypeDesc != nullptr)
+  {
+    const ezBitflags<ezAssetDocumentFlags> flags = pTypeDesc->m_AssetDocumentFlags;
+
+    bSupportsThumbnail = bMainAsset
+                           ? flags.IsAnySet(ezAssetDocumentFlags::SupportsThumbnail | ezAssetDocumentFlags::AutoThumbnailOnTransform)
+                           : flags.IsAnySet(ezAssetDocumentFlags::SubAssetsSupportThumbnail | ezAssetDocumentFlags::SubAssetsAutoThumbnailOnTransform);
+  }
+
+  writer.AddVariableBool("supportsThumbnail", bSupportsThumbnail);
+
+  ezAssetDocumentManager* pManager = pAssetInfo->m_pDocumentTypeDescriptor != nullptr
+                                       ? static_cast<ezAssetDocumentManager*>(pAssetInfo->m_pDocumentTypeDescriptor->m_pManager)
+                                       : nullptr;
+
+  if (pManager == nullptr)
+  {
+    writer.AddVariableString("note", "The document manager for this asset type is unavailable, so no thumbnail path can be computed.");
+    writer.EndObject();
+    out_result.m_sText = writer.GetResult();
+    return;
+  }
+
+  const ezString sThumbPath = pManager->GenerateResourceThumbnailPath(pAssetInfo->m_Path, bMainAsset ? ezStringView() : ezStringView(asset->m_Data.m_sName));
+
+  // this is pure path arithmetic, so it returns a path whether or not anything was ever written there
+  writer.AddVariableString("thumbnailPath", sThumbPath);
+  writer.AddVariableBool("exists", ezOSFile::ExistsFile(sThumbPath));
+
+  const bool bUpToDate = pManager->IsThumbnailUpToDate(pAssetInfo->m_Path, bMainAsset ? ezStringView() : ezStringView(asset->m_Data.m_sName),
+    pAssetInfo->m_ThumbHash, pTypeDesc != nullptr && pTypeDesc->m_pDocumentType != nullptr ? pTypeDesc->m_pDocumentType->GetTypeVersion() : 0);
+
+  writer.AddVariableBool("upToDate", bUpToDate);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteTransform(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("No project is open, so there is nothing to transform.");
+    return;
+  }
+
+  const ezStringView sAsset = ezMcpJson::GetString(arguments, "asset");
+
+  if (sAsset.IsEmpty())
+  {
+    out_result.SetError("The 'asset' argument is required. Pass a GUID or a path, as returned by asset_find.");
+    return;
+  }
+
+  ezUuid assetGuid;
+  ezStringBuilder sIdentifier;
+
+  {
+    auto asset = ResolveAsset(sAsset);
+
+    if (!asset.isValid())
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("No asset found for '{}'. Use asset_find to search for it.", sAsset);
+      out_result.SetError(sError);
+      return;
+    }
+
+    assetGuid = asset->m_Data.m_Guid;
+    asset->GetSubAssetIdentifier(sIdentifier);
+  }
+  // the curator lock is released here on purpose - TransformAsset takes it itself, and holding it
+  // across a call that can run for minutes would block every other thread touching the curator
+
+  // TriggeredManually is always set, because without it assets flagged OnlyTransformManually - scenes
+  // among them - silently do nothing, which reads as an unexplained success to the caller.
+  ezBitflags<ezTransformFlags> flags = ezTransformFlags::TriggeredManually;
+
+  if (ezMcpJson::GetBool(arguments, "force", false))
+    flags |= ezTransformFlags::ForceTransform;
+
+  // This runs on the main thread and so does not go through the asset processor, meaning it produces
+  // no progress event. Recording it here keeps asset_history a complete picture of what was
+  // transformed rather than only what the background processor did.
+  const ezTime startTime = ezTime::Now();
+  const ezTransformStatus status = pCurator->TransformAsset(assetGuid, flags);
+  RecordHistory(assetGuid, sIdentifier, status, ezTime::Now() - startTime, false);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableUuid("guid", assetGuid);
+  writer.AddVariableString("path", sIdentifier);
+  writer.AddVariableBool("succeeded", status.Succeeded());
+
+  // NeedsImport is neither success nor failure - the asset has to be re-imported before it can be
+  // transformed, which is a different action for the caller to take.
+  switch (status.m_Result)
+  {
+    case ezTransformResult::Success:
+      writer.AddVariableString("result", "Success");
+      break;
+    case ezTransformResult::Failure:
+      writer.AddVariableString("result", "Failure");
+      break;
+    case ezTransformResult::NeedsImport:
+      writer.AddVariableString("result", "NeedsImport");
+      break;
+  }
+
+  if (!status.m_sMessage.IsEmpty())
+    writer.AddVariableString("message", status.m_sMessage);
+
+  // the state after the fact, which is what the caller would otherwise call asset_info for
+  {
+    auto asset = pCurator->GetSubAsset(assetGuid);
+
+    if (asset.isValid() && asset->m_pAssetInfo != nullptr)
+    {
+      writer.AddVariableString("transformState", TransformStateToString(asset->m_pAssetInfo->m_TransformState));
+    }
+  }
+
+  if (status.Failed())
+    writer.AddVariableString("hint", "Call asset_info on this asset for the full transform log.");
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteProcessor(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetProcessor* pProcessor = ezAssetProcessor::GetSingleton();
+
+  if (pProcessor == nullptr)
+  {
+    out_result.SetError("No project is open, so there is no asset processor.");
+    return;
+  }
+
+  const ezStringView sAction = ezMcpJson::GetString(arguments, "action", "query");
+
+  const bool bStart = sAction.IsEqual_NoCase("start");
+  const bool bStop = sAction.IsEqual_NoCase("stop");
+  const bool bForceStop = sAction.IsEqual_NoCase("forceStop");
+  const bool bQuery = sAction.IsEqual_NoCase("query");
+
+  if (!bStart && !bStop && !bForceStop && !bQuery)
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("'{}' is not a valid action. Use 'start', 'stop', 'forceStop' or 'query'.", sAction);
+    out_result.SetError(sError);
+    return;
+  }
+
+  if (bStart)
+  {
+    // The UI pairs the start with a file system check, so that assets changed while the processor was
+    // off are noticed rather than sitting untouched (see ezQtCuratorControl::BackgroundProcessClicked).
+    ezAssetCurator::GetSingleton()->CheckFileSystem();
+    pProcessor->StartProcessor();
+  }
+  else if (bStop || bForceStop)
+  {
+    // Without the force flag the running processes are allowed to finish what they are on, which is
+    // why 'stop' can leave the state at Stopping rather than Stopped.
+    pProcessor->StopProcessor(bForceStop);
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("action", sAction);
+  WriteProcessorStatus(writer, "processor");
+
+  // The state is read back straight after the call and may still be in transition - StopProcessor
+  // without force returns while processes are still finishing.
+  if (bStop && pProcessor->GetProcessorState() == ezAssetProcessor::ProcessorState::Stopping)
+  {
+    writer.AddVariableString("note", "The processor is finishing the assets it had already started. Call again with 'forceStop' to kill those processes instead of waiting.");
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteHealth(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("No project is open, so there is no asset database to query.");
+    return;
+  }
+
+  ezUInt32 uiNumAssets = 0;
+  ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT> counts;
+
+  pCurator->GetAssetTransformStats(uiNumAssets, counts);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableUInt32("totalAssets", uiNumAssets);
+
+  // Only the non-zero states are written. On a healthy project this reduces the whole answer to the
+  // asset count and one UpToDate entry, which is what makes this cheap enough to call routinely.
+  writer.BeginObject("states");
+  for (ezUInt32 i = 0; i < counts.GetCount() && i < ezAssetInfo::TransformState::COUNT; ++i)
+  {
+    if (counts[i] == 0)
+      continue;
+
+    writer.AddVariableUInt32(TransformStateToString(static_cast<ezAssetInfo::TransformState>(i)), counts[i]);
+  }
+  writer.EndObject();
+
+  // The background processor. The state counts above are a snapshot that moves on its own while the
+  // processor is running, so without this a caller cannot tell '485 assets are broken' from '485 have
+  // not been got to yet' - which are very different answers.
+  WriteProcessorStatus(writer, "processor");
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteListImporters(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sFile = ezMcpJson::GetString(arguments, "file");
+
+  ezTempHybridArray<ezAssetDocumentGenerator*, 16> generators;
+  ezAssetDocumentGenerator::CreateGenerators(generators);
+
+  // The generators are freshly allocated and owned by this call.
+  EZ_SCOPE_EXIT(ezAssetDocumentGenerator::DestroyGenerators(generators));
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.BeginArray("importers");
+
+  ezUInt32 uiCount = 0;
+
+  for (ezAssetDocumentGenerator* pGen : generators)
+  {
+    if (pGen == nullptr)
+      continue;
+
+    // SupportsFileType() takes either a path or a bare extension, so 'png' and 'C:/x/y.png' both work.
+    if (!sFile.IsEmpty() && !pGen->SupportsFileType(sFile))
+      continue;
+
+    ezHybridArray<ezAssetDocumentGenerator::ImportMode, 4> modes;
+
+    // An empty path asks the generator for its general purpose modes, which is what to report when no
+    // particular file was named.
+    pGen->GetImportModes(sFile, modes);
+
+    if (modes.IsEmpty())
+      continue;
+
+    ++uiCount;
+
+    writer.BeginObject();
+    writer.AddVariableString("documentExtension", pGen->GetDocumentExtension());
+
+    writer.BeginArray("modes");
+    for (const ezAssetDocumentGenerator::ImportMode& mode : modes)
+    {
+      writer.BeginObject();
+      writer.AddVariableString("name", mode.m_sName);
+
+      // What the import dialog would preselect. An agent with no opinion should use the highest.
+      switch (mode.m_Priority)
+      {
+        case ezAssetDocGeneratorPriority::HighPriority: writer.AddVariableString("priority", "high"); break;
+        case ezAssetDocGeneratorPriority::DefaultPriority: writer.AddVariableString("priority", "default"); break;
+        case ezAssetDocGeneratorPriority::LowPriority: writer.AddVariableString("priority", "low"); break;
+        default: writer.AddVariableString("priority", "undecided"); break;
+      }
+
+      ezMcpTranslation::AddOptionalString(writer, "displayName", ezMcpTranslation::GetDisplayName(mode.m_sName));
+
+      // What the mode actually does, where the name does not say it - which channel holds what in an
+      // ORM texture, for instance. This is the part an agent cannot infer.
+      ezMcpTranslation::AddOptionalString(writer, "description", ezMcpTranslation::GetTooltip(mode.m_sName));
+
+      writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+  }
+
+  writer.EndArray();
+  writer.AddVariableUInt32("count", uiCount);
+
+  // Without a file the list of every importable extension is the useful summary; with one it would
+  // just repeat what the caller already knows.
+  if (sFile.IsEmpty())
+  {
+    ezSet<ezString> extensions;
+    ezAssetDocumentGenerator::GetSupportsFileTypes(extensions);
+
+    writer.BeginArray("fileTypes");
+    for (const ezString& sExt : extensions)
+    {
+      writer.WriteString(sExt);
+    }
+    writer.EndArray();
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAssetTool::ExecuteImport(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sFile = ezMcpJson::GetString(arguments, "file");
+
+  if (sFile.IsEmpty())
+  {
+    out_result.SetError("No 'file' argument given.");
+    return;
+  }
+
+  ezStringBuilder sAbsFile = sFile;
+  sAbsFile.MakeCleanPath();
+
+  if (!ezPathUtils::IsAbsolutePath(sAbsFile))
+  {
+    ezStringBuilder sResolved = sAbsFile;
+
+    if (ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(sResolved, true))
+    {
+      sAbsFile = sResolved;
+    }
+    else
+    {
+      sResolved = sAbsFile;
+      if (ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sResolved))
+        sAbsFile = sResolved;
+    }
+  }
+
+  // Still relative means no data directory claimed it. Checked before ExistsFile(), which asserts on a
+  // relative path instead of returning false.
+  if (!ezPathUtils::IsAbsolutePath(sAbsFile) || !ezOSFile::ExistsFile(sAbsFile))
+  {
+    ezStringBuilder s;
+    s.SetFormat("There is no file at '{}'. Pass an absolute path, or one relative to the data directory parent such as "
+                "'Testing Chambers/Textures/Wood.png'.",
+      sAbsFile);
+    out_result.SetError(s);
+    return;
+  }
+
+  if (!ezToolsProject::IsProjectOpen())
+  {
+    out_result.SetError("No project is open, so nothing can be imported.");
+    return;
+  }
+
+  // The generated document lands next to the source file, so a source outside the project would
+  // create an asset outside it too, which the editor cannot then track.
+  if (!ezToolsProject::GetSingleton()->IsDocumentInAllowedRoot(sAbsFile))
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' is outside the open project. The imported asset is created next to its source file, so the source has to live "
+                "in one of the project's data directories - 'project_info' lists them. Copy the file into the project first.",
+      sAbsFile);
+    out_result.SetError(s);
+    return;
+  }
+
+  const ezStringView sRequestedMode = ezMcpJson::GetString(arguments, "mode");
+
+  ezTempHybridArray<ezAssetDocumentGenerator*, 16> generators;
+  ezAssetDocumentGenerator::CreateGenerators(generators);
+  EZ_SCOPE_EXIT(ezAssetDocumentGenerator::DestroyGenerators(generators));
+
+  ezAssetDocumentGenerator* pGenerator = nullptr;
+  ezString sMode = sRequestedMode;
+
+  if (sRequestedMode.IsEmpty())
+  {
+    // No mode named: pick the highest priority one any generator offers for this file, which is what
+    // the import dialog preselects.
+    ezAssetDocGeneratorPriority bestPriority = ezAssetDocGeneratorPriority::Undecided;
+
+    for (ezAssetDocumentGenerator* pGen : generators)
+    {
+      if (pGen == nullptr || !pGen->SupportsFileType(sAbsFile))
+        continue;
+
+      ezHybridArray<ezAssetDocumentGenerator::ImportMode, 4> modes;
+      pGen->GetImportModes(sAbsFile, modes);
+
+      for (const ezAssetDocumentGenerator::ImportMode& mode : modes)
+      {
+        if (pGenerator == nullptr || mode.m_Priority > bestPriority)
+        {
+          pGenerator = pGen;
+          bestPriority = mode.m_Priority;
+          sMode = mode.m_sName;
+        }
+      }
+    }
+
+    if (pGenerator == nullptr)
+    {
+      ezStringBuilder s;
+      s.SetFormat("No importer handles '{}'. 'asset_importers' lists the file types that can be imported.",
+        ezPathUtils::GetFileExtension(sAbsFile));
+      out_result.SetError(s);
+      return;
+    }
+  }
+  else
+  {
+    // A named mode has to belong to a generator that also accepts this file, otherwise Import() would
+    // fail with a message about file types that does not mention the mode.
+    for (ezAssetDocumentGenerator* pGen : generators)
+    {
+      if (pGen == nullptr || !pGen->SupportsFileType(sAbsFile))
+        continue;
+
+      ezHybridArray<ezAssetDocumentGenerator::ImportMode, 4> modes;
+      pGen->GetImportModes(sAbsFile, modes);
+
+      for (const ezAssetDocumentGenerator::ImportMode& mode : modes)
+      {
+        if (mode.m_sName == sRequestedMode)
+        {
+          pGenerator = pGen;
+          break;
+        }
+      }
+
+      if (pGenerator != nullptr)
+        break;
+    }
+
+    if (pGenerator == nullptr)
+    {
+      ezStringBuilder s;
+      s.SetFormat("'{}' is not an import mode available for '{}'. Call 'asset_importers' with that file to see which modes apply.",
+        sRequestedMode, ezPathUtils::GetFileExtension(sAbsFile));
+      out_result.SetError(s);
+      return;
+    }
+  }
+
+  // bOpenDocument false: opening is the caller's decision, and OpenDocumentQueued() would defer a
+  // window creation past the end of this call where its failure could not be reported.
+  ezAssetDocumentGenerator::ImportResult importResult = ezAssetDocumentGenerator::ImportResult::Imported;
+  ezStringBuilder sTargetDoc;
+
+  const ezStatus res = pGenerator->Import(sAbsFile, sMode, false, &importResult, &sTargetDoc);
+
+  if (res.Failed())
+  {
+    ezStringBuilder s;
+    s.SetFormat("Importing '{}' failed: {}", sAbsFile, res.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableString("sourceFile", sAbsFile);
+  writer.AddVariableString("mode", sMode);
+  writer.AddVariableString("document", sTargetDoc);
+
+  // The generators skip silently when the target exists, so without this the caller would read a
+  // success and believe it had just imported something. Import() reports which it was.
+  if (importResult == ezAssetDocumentGenerator::ImportResult::AlreadyExists)
+  {
+    writer.AddVariableBool("alreadyImported", true);
+    writer.AddVariableString("note", "An asset for this source file already existed, so nothing was imported and the existing "
+                                     "document is unchanged. Delete it first to re-import.");
+  }
+  else if (!ezOSFile::ExistsFile(sTargetDoc))
+  {
+    // Reported as created, but not where the target path says. A generator that produces several
+    // documents can do this legitimately, so it is a note rather than a failure.
+    writer.AddVariableBool("created", true);
+    writer.AddVariableString("note", "The import succeeded but no document is at the expected path - the importer may have created "
+                                     "several documents or named them differently. Use 'asset_find' to locate them.");
+  }
+  else
+  {
+    writer.AddVariableBool("created", true);
+    writer.AddVariableString("note", "The document was created and saved but is not open. Use 'document_open' to adjust its "
+                                     "properties, and 'asset_transform' to produce its runtime data.");
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+#include <EditorFramework/Assets/Declarations.h>
+#include <Foundation/Containers/Deque.h>
+#include <Foundation/Threading/Mutex.h>
+#include <Foundation/Time/Time.h>
+#include <Foundation/Types/Uuid.h>
+
+struct ezSubAsset;
+struct ezAssetProcessorProgressEvent;
+class ezMcpJsonWriter;
+
+/// \brief Queries the asset database: which asset types exist, which assets exist, and how they relate.
+///
+/// The tools split along the cost of answering. 'asset_types' and 'asset_health' are type-level and
+/// aggregate views that stay cheap on any project. 'asset_find' is the listing half - it narrows
+/// thousands of assets down to a handful of GUIDs - and 'asset_info', 'asset_uses' and
+/// 'asset_thumbnail' are the detail halves that an agent calls on those few.
+///
+/// 'asset_transform' is the only one here that changes anything, and the only one slow enough that a
+/// caller has to think about the timeout (see Status.md, 'Tool calls block the editor').
+class ezMcpAssetTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpAssetTool, ezMcpToolProvider);
+
+public:
+  virtual void OnActivate() override;
+  virtual void OnDeactivate() override;
+
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  /// One finished asset transform, as recorded by asset_history.
+  struct HistoryEntry
+  {
+    ezUInt64 m_uiId = 0;
+    ezUuid m_Guid;
+    ezString m_sPath;
+    ezString m_sMessage;
+    ezTime m_Duration;
+    ezTime m_EndTime;
+    ezEnum<ezTransformResult> m_Result;
+    bool m_bBackground = true; ///< false for a transform this plugin triggered through asset_transform
+  };
+
+  void ProcessorProgressEventHandler(const ezAssetProcessorProgressEvent& e);
+  void RecordHistory(const ezUuid& guid, ezStringView sPath, const ezTransformStatus& status, ezTime duration, bool bBackground);
+
+  void ExecuteListTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteFind(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteUses(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteThumbnail(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteTransform(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteHealth(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteProcessor(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteHistory(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteListImporters(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteImport(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// Writes the identifying fields of one asset: guid, path, type and name. This is what a listing
+  /// returns per entry and what every detail tool repeats at the top of its result, so an agent can
+  /// tell which asset it is looking at without correlating against an earlier call.
+  static void WriteAssetIdentity(ezMcpJsonWriter& ref_writer, const ezSubAsset& subAsset);
+
+  /// How many finished transforms are kept. A full transform of a large project runs into the
+  /// thousands, so this covers recent activity rather than the whole run.
+  static constexpr ezUInt32 s_uiMaxHistoryEntries = 500;
+
+  /// Progress events arrive from the processor's worker threads, everything else runs on the main
+  /// thread. Guards m_History and m_uiNextHistoryId.
+  mutable ezMutex m_HistoryMutex;
+  ezDeque<HistoryEntry> m_History;
+  ezEventSubscriptionID m_ProgressSubscription = 0;
+
+  /// Assigned in order and never reused, so a 'sinceId' from an earlier call stays meaningful even
+  /// once that entry has fallen out of the buffer. Same contract as log_read.
+  ezUInt64 m_uiNextHistoryId = 1;
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/CppTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/CppTool.cpp
@@ -1,8 +1,8 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
+#include <EditorPluginMcp/McpTools/CppTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
-#include <EditorPluginMcp/McpTools/CppTool.h>
 
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Logging/Log.h>

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/CppTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/CppTool.cpp
@@ -1,0 +1,365 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <EditorPluginMcp/McpTools/CppTool.h>
+
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Logging/Log.h>
+
+#include <EditorFramework/CodeGen/CppProject.h>
+#include <EditorFramework/CodeGen/CppSettings.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <ToolsFoundation/Project/ToolsProject.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpCppTool, 1, ezRTTIDefaultAllocator<ezMcpCppTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezMcpCppTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  ezMcpToolDesc& status = out_tools.ExpandAndGetRef();
+  status.m_sName = "cpp_status";
+  status.m_sDescription = "Returns the state of the project's C++ plugin: whether the project has C++ code at all, the plugin "
+                          "name, where its sources, its build directory, its solution and its compiled library are, whether a "
+                          "build is needed, and whether the configured compiler can be used. Call this before cpp_generate or "
+                          "cpp_build - it is the only cheap call of the three and it says which of them is the one to make. A "
+                          "project without C++ code reports 'hasCppProject' false; cpp_generate creates it.";
+  status.m_sInputSchema = R"({"type":"object","properties":{}})";
+
+  ezMcpToolDesc& generate = out_tools.ExpandAndGetRef();
+  generate.m_sName = "cpp_generate";
+  generate.m_sDescription = "Creates or regenerates the C++ plugin of the open project: writes the default sources into the "
+                            "project directory if they are not there yet, updates the generated files that belong to the SDK, "
+                            "runs CMake and (unless turned off) compiles the result. This is what the editor's 'C++ Project' "
+                            "dialog does, which cannot be used through action_execute.\n"
+                            "Existing source files are never overwritten - only files that are missing are written, plus "
+                            "SDK-owned files such as CMakeLists.txt when the SDK has a newer version of them. So calling this "
+                            "on a project that already has C++ code is safe and is the way to regenerate a broken solution.\n"
+                            "The plugin name can only be chosen when the project has no C++ settings yet; renaming later is "
+                            "refused, because the existing sources and CMake files carry the old name and are not touched.\n"
+                            "This runs for minutes - CMake generation plus a full build of the plugin - during which the editor "
+                            "answers nothing else. Use a generous timeout and see app_ping for telling a slow build apart from "
+                            "a hung editor. The full log is returned; on failure it is the only place the compiler errors are.";
+  generate.m_sInputSchema = R"({"type":"object","properties":{)"
+                            R"("pluginName":{"type":"string","description":"Name of the plugin to create, without the 'Plugin' suffix, which is added automatically. Only used when the project has no C++ settings yet, otherwise it has to match the existing name. Defaults to the project name."},)"
+                            R"("compile":{"type":"boolean","description":"Compile the plugin after generating the solution. Default true. With this off the solution exists but no library is produced, so the editor still cannot load the plugin."},)"
+                            R"("cleanBuildDirectory":{"type":"boolean","description":"Delete the build directory before running CMake. Default false. Turns an incremental build into a full one - use it when CMake or the build fails in ways that look stale. Fails harmlessly if the solution is open in an IDE."},)"
+                            R"("useSdkCompiler":{"type":"boolean","description":"Switch the editor's compiler preference to the one this SDK was built with before generating. Default false. Set it when cpp_status reports a compiler mismatch, which otherwise makes CMake refuse to run - a plugin built with a different compiler cannot be loaded."}})"
+                            R"(})";
+
+  ezMcpToolDesc& build = out_tools.ExpandAndGetRef();
+  build.m_sName = "cpp_build";
+  build.m_sDescription = "Compiles the C++ plugin of the open project and restarts the engine process so the editor picks up the "
+                         "new library. Call this after editing the project's C++ sources. Requires that the C++ project already "
+                         "exists - see cpp_status, and cpp_generate to create it.\n"
+                         "By default this compiles whenever anything might have changed, which for unchanged sources is a cheap "
+                         "no-op inside the build system; 'force' additionally re-runs CMake first, which is what to use after "
+                         "adding, removing or renaming source files.\n"
+                         "This runs for minutes, during which the editor answers nothing else. Use a generous timeout and see "
+                         "app_ping for telling a slow build apart from a hung editor. The full log is returned; on failure it "
+                         "is the only place the compiler errors are.";
+  build.m_sInputSchema = R"({"type":"object","properties":{)"
+                         R"("force":{"type":"boolean","description":"Re-run CMake before compiling, instead of only when the build files are missing or out of date. Default false. Needed after files were added to or removed from the source directory, because CMake collects them at generation time."}})"
+                         R"(})";
+}
+
+void ezMcpCppTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "cpp_status")
+  {
+    ExecuteStatus(arguments, out_result);
+  }
+  else if (sToolName == "cpp_generate")
+  {
+    ExecuteGenerate(arguments, out_result);
+  }
+  else if (sToolName == "cpp_build")
+  {
+    ExecuteBuild(arguments, out_result);
+  }
+}
+
+bool ezMcpCppTool::PrepareSettings(ezCppSettings& out_settings, ezMcpToolResult& out_result)
+{
+  if (!ezToolsProject::IsProjectOpen())
+  {
+    out_result.SetError("No project is open, so there is no C++ plugin to work with.");
+    return false;
+  }
+
+  // A project that never had C++ code has no CppProject.ddl, so a failed load is the normal state here
+  // and not an error: it leaves the settings at their defaults, which is what creating one starts from.
+  out_settings.Load().IgnoreResult();
+  return true;
+}
+
+ezString ezMcpCppTool::GetEffectivePluginName(const ezCppSettings& settings)
+{
+  if (!settings.m_sPluginName.IsEmpty())
+    return settings.m_sPluginName;
+
+  // Same fallback as the C++ project dialog, where the project name is the placeholder text.
+  return ezToolsProject::GetSingleton()->GetProjectName(true);
+}
+
+ezString ezMcpCppTool::GetPluginBinaryPath(const ezCppSettings& settings)
+{
+  ezStringBuilder sPath = ezOSFile::GetApplicationDirectory();
+  sPath.AppendPath(GetEffectivePluginName(settings));
+  sPath.Append("Plugin");
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+  sPath.Append(".dll");
+#else
+  sPath.Append(".so");
+#endif
+
+  sPath.MakeCleanPath();
+  return sPath;
+}
+
+void ezMcpCppTool::ExecuteStatus(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezCppSettings cfg;
+  if (!PrepareSettings(cfg, out_result))
+    return;
+
+  const bool bHasCppProject = ezCppProject::ExistsProjectCMakeListsTxt();
+  const ezStatus compilerStatus = ezCppProject::TestCompiler();
+  const ezString sPluginBinary = GetPluginBinaryPath(cfg);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  // Whether the CMakeLists.txt exists is the distinction that decides which tool to call next: without
+  // it every other operation does nothing, quietly, since ezCppProject treats "no C++ code" as success.
+  writer.AddVariableBool("hasCppProject", bHasCppProject);
+  writer.AddVariableBool("pluginNameConfigured", !cfg.m_sPluginName.IsEmpty());
+  writer.AddVariableString("pluginName", GetEffectivePluginName(cfg));
+
+  writer.AddVariableString("sourceDirectory", ezCppProject::GetTargetSourceDir());
+  writer.AddVariableString("pluginSourceDirectory", ezCppProject::GetPluginSourceDir(cfg));
+  writer.AddVariableString("buildDirectory", ezCppProject::GetBuildDir(cfg));
+  writer.AddVariableString("solutionPath", ezCppProject::GetSolutionPath(cfg));
+  writer.AddVariableBool("solutionExists", ezCppProject::ExistsSolution(cfg));
+
+  // The library the editor actually loads. Reported because a successful build and a loadable plugin
+  // are not the same thing: a mismatched name or a build into a different directory shows up here.
+  writer.AddVariableString("pluginBinary", sPluginBinary);
+  writer.AddVariableBool("pluginBinaryExists", ezOSFile::ExistsFile(sPluginBinary));
+
+  // Only tests for missing outputs and an outdated CMake cache - it does not compare source timestamps,
+  // so false does not mean the binary is up to date with the sources. Build anyway after editing code.
+  writer.AddVariableBool("buildRequired", ezCppProject::IsBuildRequired());
+
+  writer.AddVariableBool("compilerUsable", compilerStatus.Succeeded());
+  if (compilerStatus.Failed())
+  {
+    writer.AddVariableString("compilerError", compilerStatus.GetMessageString());
+  }
+
+  // A plugin has to be built with the compiler the SDK was built with, which is the first thing
+  // TestCompiler() checks - so a usable compiler is this one, and 'compilerError' names the configured
+  // one when it is not. cpp_generate's 'useSdkCompiler' switches the preference over.
+  writer.AddVariableString("sdkCompiler", ezCppProject::CompilerToString(ezCppProject::GetSdkCompiler()));
+  writer.AddVariableString("sdkCompilerVersion", ezCppProject::GetSdkCompilerMajorVersion());
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpCppTool::ExecuteGenerate(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezCppSettings cfg;
+  if (!PrepareSettings(cfg, out_result))
+    return;
+
+  const bool bCompile = ezMcpJson::GetBool(arguments, "compile", true);
+  const bool bCleanBuildDir = ezMcpJson::GetBool(arguments, "cleanBuildDirectory", false);
+  const bool bUseSdkCompiler = ezMcpJson::GetBool(arguments, "useSdkCompiler", false);
+
+  {
+    ezStringBuilder sRequestedName = ezMcpJson::GetString(arguments, "pluginName");
+    sRequestedName.Trim(" \t");
+
+    // The dialog stores the name without the suffix and appends it everywhere, so a caller that spells
+    // out 'FooPlugin' - the name of the resulting library - would otherwise create 'FooPluginPlugin'.
+    if (sRequestedName.EndsWith_NoCase("Plugin"))
+    {
+      sRequestedName.Shrink(0, 6);
+    }
+
+    if (!cfg.m_sPluginName.IsEmpty() && !sRequestedName.IsEmpty() && cfg.m_sPluginName != sRequestedName)
+    {
+      // Renaming is refused rather than performed: the sources, the CMake files and the file names on
+      // disk all contain the old name and are deliberately not touched, so the rename would produce a
+      // project that no longer builds. Deleting those files by hand is the only way through, which is
+      // not something to do behind the caller's back.
+      out_result.SetError(ezStringBuilder("This project's C++ plugin is called '", cfg.m_sPluginName, "', it cannot be renamed to '",
+        sRequestedName, "'. The existing sources and CMake files were written with the old name and are not modified, so the "
+                        "rename would leave a project that does not build. Omit 'pluginName' to keep the existing one."));
+      return;
+    }
+
+    if (cfg.m_sPluginName.IsEmpty())
+    {
+      cfg.m_sPluginName = sRequestedName.IsEmpty() ? GetEffectivePluginName(cfg) : ezString(sRequestedName);
+    }
+  }
+
+  if (cfg.Save().Failed())
+  {
+    out_result.SetError("Failed to save the C++ project settings to ':project/Editor/CppProject.ddl'.");
+    return;
+  }
+
+  ezLogSystemToBuffer logBuffer;
+  ezStatus result = ezStatus(EZ_SUCCESS);
+  bool bCompiled = false;
+
+  {
+    ezLogSystemScope logScope(&logBuffer);
+
+    if (bUseSdkCompiler && ezCppProject::ForceSdkCompatibleCompiler().Failed())
+    {
+      ezLog::Warning("No compiler compatible with this SDK was found on this machine, keeping the configured one.");
+    }
+
+    if (bCleanBuildDir && ezCppProject::CleanBuildDir(cfg).Failed())
+    {
+      // Not fatal: the usual cause is the solution being open in an IDE, and CMake can regenerate into
+      // an existing directory. Reported so a later stale-looking failure has an explanation.
+      ezLog::Warning("Could not delete the build directory '{}'. It is probably open in an IDE.", ezCppProject::GetBuildDir(cfg));
+    }
+
+    if (ezCppProject::PopulateWithDefaultSources(cfg).Failed())
+    {
+      result = ezStatus("Writing the default C++ source files into the project directory failed.");
+    }
+
+    if (result.Succeeded() && ezCppProject::RunCMake(cfg).Failed())
+    {
+      result = ezStatus("Generating the C++ solution with CMake failed.");
+    }
+
+    if (result.Succeeded() && bCompile)
+    {
+      if (ezCppProject::CompileSolution(cfg).Failed())
+      {
+        result = ezStatus("Compiling the generated C++ solution failed.");
+      }
+      else
+      {
+        bCompiled = true;
+      }
+    }
+  }
+
+  if (result.Succeeded())
+  {
+    // Writes the plugin's config header and reloads the engine process, so that the plugin that was
+    // just built is the one in use. Without this the editor keeps running the previous library.
+    ezCppProject::UpdatePluginConfig(cfg);
+    ezQtEditorApp::GetSingleton()->RestartEngineProcessIfPluginsChanged(true);
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableBool("generated", result.Succeeded());
+  writer.AddVariableString("pluginName", cfg.m_sPluginName);
+  writer.AddVariableString("sourceDirectory", ezCppProject::GetTargetSourceDir());
+  writer.AddVariableString("solutionPath", ezCppProject::GetSolutionPath(cfg));
+  writer.AddVariableBool("compiled", bCompiled);
+
+  if (bCompiled)
+  {
+    writer.AddVariableString("pluginBinary", GetPluginBinaryPath(cfg));
+  }
+
+  if (result.Failed())
+  {
+    writer.AddVariableString("error", result.GetMessageString());
+  }
+
+  writer.AddVariableString("log", logBuffer.m_sBuffer);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+  out_result.m_bIsError = result.Failed();
+}
+
+void ezMcpCppTool::ExecuteBuild(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezCppSettings cfg;
+  if (!PrepareSettings(cfg, out_result))
+    return;
+
+  if (!ezCppProject::ExistsProjectCMakeListsTxt())
+  {
+    // ezCppProject reports success for a project without C++ code, which as a tool result would read as
+    // "built" and leave a caller waiting for a plugin that is never going to appear.
+    out_result.SetError(ezStringBuilder("This project has no C++ code: there is no CMakeLists.txt in '",
+      ezCppProject::GetTargetSourceDir(), "'. Call cpp_generate to create the C++ plugin first."));
+    return;
+  }
+
+  const bool bForce = ezMcpJson::GetBool(arguments, "force", false);
+
+  ezLogSystemToBuffer logBuffer;
+  ezStatus result = ezStatus(EZ_SUCCESS);
+
+  {
+    ezLogSystemScope logScope(&logBuffer);
+
+    // Keeps the SDK-owned files in the project's source directory current - the same step the editor
+    // performs before it builds. It leaves the user's own sources alone.
+    if (ezCppProject::PopulateWithDefaultSources(cfg).Failed())
+    {
+      result = ezStatus("Updating the default C++ source files in the project directory failed.");
+    }
+
+    if (result.Succeeded() && bForce && ezCppProject::RunCMake(cfg).Failed())
+    {
+      result = ezStatus("Re-generating the C++ solution with CMake failed.");
+    }
+
+    if (result.Succeeded())
+    {
+      // BuildCodeIfNecessary() runs CMake only when the solution is missing or its cache is outdated,
+      // then compiles unconditionally - the build system decides what is actually out of date. With
+      // 'force' CMake has already run above.
+      if (ezCppProject::BuildCodeIfNecessary(cfg).Failed())
+      {
+        result = ezStatus("Compiling the C++ code failed.");
+      }
+    }
+  }
+
+  if (result.Succeeded())
+  {
+    ezQtEditorApp::GetSingleton()->RestartEngineProcessIfPluginsChanged(true);
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableBool("built", result.Succeeded());
+  writer.AddVariableString("pluginName", GetEffectivePluginName(cfg));
+  writer.AddVariableString("pluginBinary", GetPluginBinaryPath(cfg));
+
+  if (result.Failed())
+  {
+    writer.AddVariableString("error", result.GetMessageString());
+  }
+
+  writer.AddVariableString("log", logBuffer.m_sBuffer);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+  out_result.m_bIsError = result.Failed();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/CppTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/CppTool.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezCppSettings;
+
+/// \brief The project's C++ plugin: whether it exists, generating it and compiling it.
+///
+/// Covers what the 'C++ Project' dialog and the Cpp actions in the project menu do, none of which are
+/// reachable through action_execute, because they all end in a modal dialog. Everything here goes
+/// through the ezCppProject statics, which are dialog free.
+class ezMcpCppTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpCppTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteStatus(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteGenerate(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteBuild(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Common preconditions: a project has to be open and the C++ settings have to load.
+  ///
+  /// Returns false and fills out_result with the reason when a tool cannot run at all.
+  static bool PrepareSettings(ezCppSettings& out_settings, ezMcpToolResult& out_result);
+
+  /// \brief The name the plugin binary is built under, which is not stored anywhere: an empty setting
+  /// means the project name is used.
+  static ezString GetEffectivePluginName(const ezCppSettings& settings);
+
+  /// \brief Absolute path of the built plugin library, i.e. what the editor loads.
+  static ezString GetPluginBinaryPath(const ezCppSettings& settings);
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/DocumentTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/DocumentTool.cpp
@@ -1,0 +1,941 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <EditorPluginMcp/McpDocument.h>
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <EditorPluginMcp/McpTools/DocumentTool.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Strings/TranslationLookup.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Document/DocumentUtils.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+
+#include <QFile>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpDocumentTool, 1, ezRTTIDefaultAllocator<ezMcpDocumentTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// Turns whatever the caller passed into an absolute path.
+  ///
+  /// An agent has three plausible spellings of the same document: the absolute path, the data
+  /// directory parent relative path that asset_find reports ("Testing Chambers/Prefabs/Barrel.ezPrefab")
+  /// and the data directory relative path. All three are accepted, because rejecting a path the agent
+  /// read out of another tool's output is the kind of failure it cannot diagnose.
+  ///
+  /// Returns an empty string if nothing could be made of the input.
+  ezStringBuilder DocumentToolResolvePath(ezStringView sPath)
+  {
+    ezStringBuilder sResult = sPath;
+    sResult.MakeCleanPath();
+
+    if (sResult.IsEmpty() || ezPathUtils::IsAbsolutePath(sResult))
+      return sResult;
+
+    // Deliberately not passing a guid to MakeParentDataDirectoryRelativePathAbsolute(): it resolves
+    // one through ezSubAsset::m_pAssetInfo without checking it for null, which crashes the editor for
+    // an asset the curator knows but holds no file information for. Callers that want to name a
+    // document by guid go through ezMcpDocument::Find() instead.
+    if (ezConversionUtils::IsStringUuid(sResult))
+      return sResult;
+
+    // The parent relative form first: it is what the asset tools report, so it is the form an agent
+    // is most likely to be carrying around.
+    ezStringBuilder sTemp = sResult;
+    if (ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(sTemp, false))
+      return sTemp;
+
+    sTemp = sResult;
+    if (ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sTemp))
+      return sTemp;
+
+    return sResult;
+  }
+
+} // namespace
+
+void ezMcpDocumentTool::WriteDocumentIdentity(ezMcpJsonWriter& ref_writer, const ezDocument& document)
+{
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(document.GetGuid(), sGuid);
+
+  ref_writer.AddVariableString("guid", sGuid);
+  ref_writer.AddVariableString("path", document.GetDocumentPath());
+  ref_writer.AddVariableString("type", document.GetDocumentTypeName());
+  ref_writer.AddVariableBool("modified", document.IsModified());
+
+  if (document.IsReadOnly())
+    ref_writer.AddVariableBool("readOnly", true);
+
+  // A sub-document is edited through its main document, so a caller that got one here needs to know
+  // that acting on it is not the same as acting on a normal document.
+  if (document.IsSubDocument())
+    ref_writer.AddVariableBool("subDocument", true);
+}
+
+void ezMcpDocumentTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_types";
+    desc.m_sDescription =
+      "Lists the document types the editor can open and create, with the file extension each one uses. Call this before "
+      "'document_create': the type name is what 'document_create' takes, and the extension determines it when opening a path. "
+      "'canCreate' false means the type only ever results from importing or generating a file, so 'document_create' will refuse it. "
+      "This is a different list from 'asset_types' - it includes non-asset documents and is about what can be edited rather than "
+      "what the asset database tracks.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"Only list types whose name or extension contains this, case insensitive."},)"
+                          R"("canCreate":{"type":"boolean","description":"If true, only list types that 'document_create' accepts."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_list";
+    desc.m_sDescription =
+      "Lists the documents that are currently open in the editor, with guid, absolute path, type and whether they have unsaved "
+      "changes. The guid is the stable identifier every other document tool accepts. Note that a document can be open without a "
+      "visible window - the editor opens documents internally to resolve references - so this is not the same as what the user sees "
+      "in their tabs; 'hasWindow' tells the two apart.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("type":{"type":"string","description":"Only list documents of this document type, e.g. 'Scene'. See 'document_types'."},)"
+                          R"("modifiedOnly":{"type":"boolean","description":"If true, only list documents with unsaved changes."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_open";
+    desc.m_sDescription =
+      "Opens an existing document and returns its guid. Does nothing but return the document if it is already open, so this is also "
+      "the way to get the guid of a document by path. The type is determined by the file extension. Opening a scene can take a while, "
+      "as it starts the engine process - see 'app_ping' if the call times out.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("path":{"type":"string","description":"Absolute path, or the path relative to the data directory parent as reported by 'asset_find'."},)"
+                          R"("focus":{"type":"boolean","description":"Open a visible window and bring it to the front. Defaults to true. Pass false to open the document only internally, without disturbing what the user is looking at."})"
+                          R"(},"required":["path"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_create";
+    desc.m_sDescription =
+      "Creates a new document on disk and opens it. The new document is saved immediately, so the file exists when this returns. "
+      "Fails if the file already exists - delete it first or pick another path. By default the editor's template for the type is "
+      "copied, which gives the document the same starting state a user would get; pass 'empty' to get a document with no content "
+      "beyond what the type requires.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("path":{"type":"string","description":"Where to create it. Absolute, or relative to the data directory parent. Must be inside the project. The file extension must match the document type - if it is omitted the extension of the type is appended."},)"
+                          R"("type":{"type":"string","description":"The document type to create, e.g. 'Prefab'. See 'document_types'. Optional if the path already carries the type's extension."},)"
+                          R"("empty":{"type":"boolean","description":"If true, do not copy the type's default template. Defaults to false, i.e. use the template, which is what the editor's own 'new document' does."},)"
+                          R"("focus":{"type":"boolean","description":"Open a visible window for it and bring it to the front. Defaults to true."})"
+                          R"(},"required":["path"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_save";
+    desc.m_sDescription =
+      "Writes an open document to disk. Does nothing if it has no unsaved changes, unless 'force' is set. Saving is what makes a "
+      "change visible to the asset system, so a document that was modified through other tools has to be saved before transforming "
+      "it or before anything referencing it is transformed.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document. Omit together with 'all'."},)"
+                          R"("all":{"type":"boolean","description":"If true, save every open document with unsaved changes instead of one named document."},)"
+                          R"("force":{"type":"boolean","description":"Write the file even if the document is not modified. Defaults to false."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_close";
+    desc.m_sDescription =
+      "Closes an open document. This DISCARDS unsaved changes without asking, so it refuses to close a modified document unless "
+      "'discardChanges' is set - save it first with 'document_save' if the changes matter. Closing a document the user was working "
+      "in makes its window disappear, so prefer leaving documents open unless there is a reason to close them.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document."},)"
+                          R"("discardChanges":{"type":"boolean","description":"Required to close a document with unsaved changes. Those changes are lost permanently. Defaults to false."})"
+                          R"(},"required":["document"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_focus";
+    desc.m_sDescription =
+      "Brings an open document's window to the front, so the user is looking at it. Use this to show the user what a change refers "
+      "to instead of describing where to find it. Has no effect on a document that was opened without a window.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document."})"
+                          R"(},"required":["document"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "document_delete";
+    desc.m_sDescription =
+      "Deletes a document file, optionally repointing everything that references it at a replacement first. Deleting a referenced "
+      "asset without a replacement leaves broken references behind, so this reports how many other assets use it and refuses to "
+      "proceed unless either 'replaceWith' or 'force' is given. With 'replaceWith', every referencing document is opened, rewritten "
+      "and saved, and the original is only deleted if all of that succeeded. The file goes to the recycle bin. Prefer this over "
+      "deleting an asset file directly, which does none of the reference fixing.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("path":{"type":"string","description":"Guid or path of the document to delete. It does not have to be open."},)"
+                          R"("replaceWith":{"type":"string","description":"Guid or path of the asset that should take its place in every document that references it. Should be of the same type."},)"
+                          R"("force":{"type":"boolean","description":"Delete even though other assets reference it and no replacement was given, leaving those references broken. Defaults to false."})"
+                          R"(},"required":["path"]})";
+  }
+}
+
+void ezMcpDocumentTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "document_types")
+    ExecuteListTypes(arguments, out_result);
+  else if (sToolName == "document_list")
+    ExecuteList(arguments, out_result);
+  else if (sToolName == "document_open")
+    ExecuteOpen(arguments, out_result);
+  else if (sToolName == "document_create")
+    ExecuteCreate(arguments, out_result);
+  else if (sToolName == "document_save")
+    ExecuteSave(arguments, out_result);
+  else if (sToolName == "document_close")
+    ExecuteClose(arguments, out_result);
+  else if (sToolName == "document_focus")
+    ExecuteFocus(arguments, out_result);
+  else if (sToolName == "document_delete")
+    ExecuteDelete(arguments, out_result);
+}
+
+void ezMcpDocumentTool::ExecuteListTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sNameFilter = ezMcpJson::GetString(arguments, "name");
+  const bool bCanCreateOnly = ezMcpJson::GetBool(arguments, "canCreate", false);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.BeginArray("types");
+
+  ezUInt32 uiCount = 0;
+
+  for (auto it : ezDocumentManager::GetAllDocumentDescriptors())
+  {
+    const ezDocumentTypeDescriptor* pDesc = it.Value();
+
+    if (pDesc == nullptr)
+      continue;
+
+    if (bCanCreateOnly && !pDesc->m_bCanCreate)
+      continue;
+
+    if (!sNameFilter.IsEmpty())
+    {
+      const bool bMatches = pDesc->m_sDocumentTypeName.FindSubString_NoCase(sNameFilter) != nullptr ||
+                            pDesc->m_sFileExtension.FindSubString_NoCase(sNameFilter) != nullptr;
+      if (!bMatches)
+        continue;
+    }
+
+    ++uiCount;
+
+    writer.BeginObject();
+    writer.AddVariableString("name", pDesc->m_sDocumentTypeName);
+    writer.AddVariableString("extension", pDesc->m_sFileExtension);
+    writer.AddVariableBool("canCreate", pDesc->m_bCanCreate);
+
+    // Same trap as in AssetTool: the lookup returns the key unchanged when there is no entry, so an
+    // untranslated type would otherwise be reported as having a display name identical to its name.
+    const ezStringView sDisplayName = ezTranslate(pDesc->m_sDocumentTypeName.GetData());
+    if (!sDisplayName.IsEmpty() && sDisplayName != pDesc->m_sDocumentTypeName)
+      writer.AddVariableString("displayName", sDisplayName);
+
+    const ezStringView sHelpUrl = ezTranslateHelpURL(pDesc->m_sDocumentTypeName.GetData());
+    if (!sHelpUrl.IsEmpty() && sHelpUrl != pDesc->m_sDocumentTypeName)
+      writer.AddVariableString("helpUrl", sHelpUrl);
+
+    writer.EndObject();
+  }
+
+  writer.EndArray();
+  writer.AddVariableUInt32("count", uiCount);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpDocumentTool::ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sTypeFilter = ezMcpJson::GetString(arguments, "type");
+  const bool bModifiedOnly = ezMcpJson::GetBool(arguments, "modifiedOnly", false);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.BeginArray("documents");
+
+  ezUInt32 uiCount = 0;
+
+  for (const ezDocumentManager* pManager : ezDocumentManager::GetAllDocumentManagers())
+  {
+    for (const ezDocument* pDoc : pManager->GetAllOpenDocuments())
+    {
+      if (pDoc == nullptr)
+        continue;
+
+      if (bModifiedOnly && !pDoc->IsModified())
+        continue;
+
+      if (!sTypeFilter.IsEmpty() && !pDoc->GetDocumentTypeName().IsEqual_NoCase(sTypeFilter))
+        continue;
+
+      ++uiCount;
+
+      writer.BeginObject();
+      WriteDocumentIdentity(writer, *pDoc);
+
+      // Distinguishes a document the user is looking at from one the editor opened behind the scenes.
+      writer.AddVariableBool("hasWindow", pDoc->HasWindowBeenRequested());
+
+      writer.EndObject();
+    }
+  }
+
+  writer.EndArray();
+  writer.AddVariableUInt32("count", uiCount);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpDocumentTool::ExecuteOpen(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sPath = ezMcpJson::GetString(arguments, "path");
+
+  if (sPath.IsEmpty())
+  {
+    out_result.SetError("No 'path' argument given.");
+    return;
+  }
+
+  const bool bFocus = ezMcpJson::GetBool(arguments, "focus", true);
+
+  const ezStringBuilder sAbsPath = DocumentToolResolvePath(sPath);
+
+  // A path that resolved against no data directory is still relative, and everything below expects an
+  // absolute one: ezOSFile::ExistsFile() asserts on a relative path rather than returning false, which
+  // takes the editor down with it.
+  if (!ezPathUtils::IsAbsolutePath(sAbsPath))
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' could not be resolved to a file in this project. Pass an absolute path, or the path as 'asset_find' reports it "
+                "(data directory name first, e.g. 'Testing Chambers/Effects/SmallExplosion.ezParticleEffectAsset').",
+      sPath);
+    out_result.SetError(s);
+    return;
+  }
+
+  const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+  if (ezDocumentManager::FindDocumentTypeFromPath(sAbsPath, false, pTypeDesc).Failed() || pTypeDesc == nullptr)
+  {
+    ezStringBuilder s;
+    s.SetFormat("The file extension of '{}' is not registered with any document type. 'document_types' lists the extensions that are.", sAbsPath);
+    out_result.SetError(s);
+    return;
+  }
+
+  ezDocument* pDocument = pTypeDesc->m_pManager->GetDocumentByPath(sAbsPath);
+  const bool bWasAlreadyOpen = pDocument != nullptr;
+
+  if (!bWasAlreadyOpen)
+  {
+    if (!ezOSFile::ExistsFile(sAbsPath))
+    {
+      ezStringBuilder s;
+      s.SetFormat("There is no file at '{}'. Use 'document_create' to create a new document, or 'asset_find' to locate an existing one.", sAbsPath);
+      out_result.SetError(s);
+      return;
+    }
+
+    // Deliberately not going through ezQtEditorApp::OpenDocument(): that reports every failure with a
+    // modal message box, which never returns when there is no human to close it.
+    ezStatus res = pTypeDesc->m_pManager->CanOpenDocument(sAbsPath);
+
+    if (res.Succeeded())
+    {
+      ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::AddToRecentFilesList;
+      if (bFocus)
+        flags |= ezDocumentFlags::RequestWindow;
+
+      res = pTypeDesc->m_pManager->OpenDocument(pTypeDesc->m_sDocumentTypeName, sAbsPath, pDocument, flags);
+    }
+
+    if (res.Failed() || pDocument == nullptr)
+    {
+      ezStringBuilder s;
+      s.SetFormat("Failed to open '{}': {}", sAbsPath, res.GetMessageString());
+      out_result.SetError(s);
+      return;
+    }
+  }
+
+  if (bFocus)
+  {
+    // Covers the already-open case too, where no window was requested the first time round.
+    pTypeDesc->m_pManager->EnsureWindowRequested(pDocument);
+    pDocument->EnsureVisible();
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  WriteDocumentIdentity(writer, *pDocument);
+  writer.AddVariableBool("wasAlreadyOpen", bWasAlreadyOpen);
+
+  // Loading errors are reported here rather than as a failure: the document did open, and an agent
+  // that asked for it should be told it is incomplete rather than that nothing happened.
+  if (pDocument->GetUnknownObjectTypeInstances() > 0)
+    writer.AddVariableUInt32("unknownObjectTypeInstances", pDocument->GetUnknownObjectTypeInstances());
+
+  if (!pDocument->GetLoadingErrors().IsEmpty())
+  {
+    writer.BeginArray("loadingErrors");
+    for (const ezString& sError : pDocument->GetLoadingErrors())
+    {
+      writer.WriteString(sError);
+    }
+    writer.EndArray();
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpDocumentTool::ExecuteCreate(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sPath = ezMcpJson::GetString(arguments, "path");
+
+  if (sPath.IsEmpty())
+  {
+    out_result.SetError("No 'path' argument given.");
+    return;
+  }
+
+  const ezStringView sType = ezMcpJson::GetString(arguments, "type");
+  const bool bEmpty = ezMcpJson::GetBool(arguments, "empty", false);
+  const bool bFocus = ezMcpJson::GetBool(arguments, "focus", true);
+
+  const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+
+  if (!sType.IsEmpty())
+  {
+    pTypeDesc = ezDocumentManager::GetDescriptorForDocumentType(sType);
+
+    if (pTypeDesc == nullptr)
+    {
+      ezStringBuilder s;
+      s.SetFormat("'{}' is not a known document type. 'document_types' lists the valid names.", sType);
+      out_result.SetError(s);
+      return;
+    }
+
+    // Checked here, while the type is still the thing the caller named. Later on the failure would
+    // come out of the path checks instead and blame the file extension, which is not the problem.
+    if (!pTypeDesc->m_bCanCreate)
+    {
+      ezStringBuilder s;
+      s.SetFormat("Documents of type '{}' cannot be created this way - they are produced by importing or generating a file. "
+                  "Call 'document_types' with 'canCreate' to see which types can be created.",
+        pTypeDesc->m_sDocumentTypeName);
+      out_result.SetError(s);
+      return;
+    }
+  }
+
+  ezStringBuilder sAbsPath = DocumentToolResolvePath(sPath);
+
+  // A named type whose extension is missing from the path is a typo waiting to happen, so append it
+  // rather than failing - the type was stated unambiguously. But only when the path carries no
+  // document extension at all: appending to a path that already names a *different* type would turn a
+  // contradiction ('Thing.ezScene' as a Prefab) into a 'Thing.ezScene.ezPrefab' nobody asked for,
+  // instead of the error below.
+  if (pTypeDesc != nullptr)
+  {
+    const ezStringView sExtension = ezPathUtils::GetFileExtension(sAbsPath);
+
+    const ezDocumentTypeDescriptor* pExtensionTypeDesc = nullptr;
+    const bool bExtensionIsKnown =
+      !sExtension.IsEmpty() && ezDocumentManager::FindDocumentTypeFromPath(sAbsPath, true, pExtensionTypeDesc).Succeeded();
+
+    if (!bExtensionIsKnown && !sExtension.IsEqual_NoCase(pTypeDesc->m_sFileExtension))
+    {
+      sAbsPath.Append(".", pTypeDesc->m_sFileExtension);
+    }
+  }
+
+  if (!ezPathUtils::IsAbsolutePath(sAbsPath))
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' could not be resolved to a location inside the project. Pass an absolute path, or one relative to the data "
+                "directory parent such as 'Testing Chambers/Prefabs/Thing.ezPrefab'. 'project_info' reports the data directories.",
+      sPath);
+    out_result.SetError(s);
+    return;
+  }
+
+  if (ezOSFile::ExistsFile(sAbsPath))
+  {
+    ezStringBuilder s;
+    s.SetFormat("A file already exists at '{}'. Creating would overwrite it, which this tool does not do. Pick another path, or use "
+                "'document_open' if this is the document you meant.",
+      sAbsPath);
+    out_result.SetError(s);
+    return;
+  }
+
+  {
+    // Checks the extension is registered and that no open document already claims the path.
+    const ezDocumentTypeDescriptor* pPathTypeDesc = nullptr;
+    const ezStatus res = ezDocumentUtils::IsValidSaveLocationForDocument(sAbsPath, &pPathTypeDesc);
+
+    if (res.Failed())
+    {
+      ezStringBuilder s;
+      s.SetFormat("Cannot create '{}': {}", sAbsPath, res.GetMessageString());
+      out_result.SetError(s);
+      return;
+    }
+
+    if (pTypeDesc == nullptr)
+      pTypeDesc = pPathTypeDesc;
+    else if (pPathTypeDesc != nullptr && pPathTypeDesc != pTypeDesc)
+    {
+      // Two different answers to 'what type is this' - guessing which one the caller meant would
+      // silently create the wrong kind of document.
+      ezStringBuilder s;
+      s.SetFormat("The requested type '{}' does not match the file extension '{}', which belongs to type '{}'. Use the extension "
+                  "'{}' for a '{}' document.",
+        pTypeDesc->m_sDocumentTypeName, ezPathUtils::GetFileExtension(sAbsPath), pPathTypeDesc->m_sDocumentTypeName,
+        pTypeDesc->m_sFileExtension, pTypeDesc->m_sDocumentTypeName);
+      out_result.SetError(s);
+      return;
+    }
+  }
+
+  if (pTypeDesc == nullptr || pTypeDesc->m_pManager == nullptr)
+  {
+    out_result.SetError("Could not determine the document type to create. Pass 'type' explicitly - 'document_types' lists the valid names.");
+    return;
+  }
+
+  // ezDocumentManager::CreateDocument() asserts on a type that cannot be created, and an assert takes
+  // the whole editor down. The same check runs above for an explicitly named type; this one catches
+  // the case where the type came from the path's extension.
+  if (!pTypeDesc->m_bCanCreate)
+  {
+    ezStringBuilder s;
+    s.SetFormat("Documents of type '{}' cannot be created this way - they are produced by importing or generating a file. "
+                "Call 'document_types' with 'canCreate' to see which types can be created.",
+      pTypeDesc->m_sDocumentTypeName);
+    out_result.SetError(s);
+    return;
+  }
+
+  if (!ezToolsProject::IsProjectOpen())
+  {
+    out_result.SetError("No project is open, so no document can be created.");
+    return;
+  }
+
+  if (!ezToolsProject::GetSingleton()->IsDocumentInAllowedRoot(sAbsPath))
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' is outside the open project. Documents have to be created inside one of the project's data directories - "
+                "'project_info' lists them.",
+      sAbsPath);
+    out_result.SetError(s);
+    return;
+  }
+
+  ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::AddToRecentFilesList;
+
+  if (bFocus)
+    flags |= ezDocumentFlags::RequestWindow;
+
+  // Without this the manager clones Editor/DocumentTemplates/Default.<ext> when one exists, which is
+  // what the editor's own 'new document' does and usually the more useful starting point.
+  if (bEmpty)
+    flags |= ezDocumentFlags::EmptyDocument;
+
+  ezDocument* pDocument = nullptr;
+  const ezStatus res = pTypeDesc->m_pManager->CreateDocument(pTypeDesc->m_sDocumentTypeName, sAbsPath, pDocument, flags);
+
+  if (res.Failed() || pDocument == nullptr)
+  {
+    ezStringBuilder s;
+    s.SetFormat("Failed to create '{}': {}", sAbsPath, res.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  // Tells the asset system about the new file. Without it the document exists but the asset database
+  // does not know about it until something else triggers a file system scan.
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sAbsPath);
+
+  if (bFocus)
+    pDocument->EnsureVisible();
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  WriteDocumentIdentity(writer, *pDocument);
+  writer.AddVariableBool("fromTemplate", !bEmpty);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpDocumentTool::ExecuteSave(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sIdentifier = ezMcpJson::GetString(arguments, "document");
+  const bool bAll = ezMcpJson::GetBool(arguments, "all", false);
+  const bool bForce = ezMcpJson::GetBool(arguments, "force", false);
+
+  if (!bAll && sIdentifier.IsEmpty())
+  {
+    out_result.SetError("Pass either 'document' to save one document, or 'all' to save every modified document.");
+    return;
+  }
+
+  ezHybridArray<ezDocument*, 16> toSave;
+
+  if (bAll)
+  {
+    for (ezDocumentManager* pManager : ezDocumentManager::GetAllDocumentManagers())
+    {
+      for (ezDocument* pDoc : pManager->GetAllOpenDocuments())
+      {
+        if (pDoc != nullptr && (bForce || pDoc->IsModified()))
+          toSave.PushBack(pDoc);
+      }
+    }
+  }
+  else
+  {
+    ezDocument* pDocument = ezMcpDocument::Find(sIdentifier);
+
+    if (pDocument == nullptr)
+    {
+      ezMcpDocument::SetNotOpenError(out_result, sIdentifier);
+      return;
+    }
+
+    toSave.PushBack(pDocument);
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.BeginArray("saved");
+
+  ezUInt32 uiSaved = 0;
+  ezUInt32 uiFailed = 0;
+  ezUInt32 uiUnchanged = 0;
+
+  for (ezDocument* pDoc : toSave)
+  {
+    if (!bForce && !pDoc->IsModified())
+    {
+      ++uiUnchanged;
+      continue;
+    }
+
+    const ezStatus res = pDoc->SaveDocument(bForce);
+
+    writer.BeginObject();
+    WriteDocumentIdentity(writer, *pDoc);
+
+    if (res.Succeeded())
+    {
+      ++uiSaved;
+      writer.AddVariableBool("success", true);
+    }
+    else
+    {
+      ++uiFailed;
+      writer.AddVariableBool("success", false);
+      writer.AddVariableString("error", res.GetMessageString());
+    }
+
+    writer.EndObject();
+  }
+
+  writer.EndArray();
+  writer.AddVariableUInt32("savedCount", uiSaved);
+
+  if (uiFailed > 0)
+    writer.AddVariableUInt32("failedCount", uiFailed);
+
+  // Says 'there was nothing to do' rather than leaving the caller to infer it from an empty array.
+  if (uiUnchanged > 0)
+    writer.AddVariableUInt32("alreadyUpToDate", uiUnchanged);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+  out_result.m_bIsError = uiFailed > 0;
+}
+
+void ezMcpDocumentTool::ExecuteClose(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sIdentifier = ezMcpJson::GetString(arguments, "document");
+
+  if (sIdentifier.IsEmpty())
+  {
+    out_result.SetError("No 'document' argument given.");
+    return;
+  }
+
+  ezDocument* pDocument = ezMcpDocument::Find(sIdentifier);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sIdentifier);
+    return;
+  }
+
+  // ezDocumentManager::CloseDocument() throws unsaved changes away without a word, and the usual
+  // 'ask the user' path is a modal dialog this tool must not open. So the decision is the caller's,
+  // and the default is the safe one.
+  if (pDocument->IsModified() && !ezMcpJson::GetBool(arguments, "discardChanges", false))
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' has unsaved changes. Save it with 'document_save' first, or pass 'discardChanges' to close it and lose them.",
+      pDocument->GetDocumentPath());
+    out_result.SetError(s);
+    return;
+  }
+
+  // Everything needed for the result has to be read before the document is deleted.
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  WriteDocumentIdentity(writer, *pDocument);
+  writer.AddVariableBool("closed", true);
+  writer.EndObject();
+
+  pDocument->GetDocumentManager()->CloseDocument(pDocument);
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpDocumentTool::ExecuteFocus(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sIdentifier = ezMcpJson::GetString(arguments, "document");
+
+  if (sIdentifier.IsEmpty())
+  {
+    out_result.SetError("No 'document' argument given.");
+    return;
+  }
+
+  ezDocument* pDocument = ezMcpDocument::Find(sIdentifier);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sIdentifier);
+    return;
+  }
+
+  // A document opened with focus:false has no window yet, so asking for one first makes this work
+  // rather than silently doing nothing.
+  const bool bHadWindow = pDocument->HasWindowBeenRequested();
+
+  if (!bHadWindow)
+    pDocument->GetDocumentManager()->EnsureWindowRequested(pDocument);
+
+  pDocument->EnsureVisible();
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  WriteDocumentIdentity(writer, *pDocument);
+  writer.AddVariableBool("windowCreated", !bHadWindow);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpDocumentTool::ExecuteDelete(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sIdentifier = ezMcpJson::GetString(arguments, "path");
+
+  if (sIdentifier.IsEmpty())
+  {
+    out_result.SetError("No 'path' argument given.");
+    return;
+  }
+
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  if (pCurator == nullptr)
+  {
+    out_result.SetError("The asset curator is not available, so references cannot be checked and nothing is deleted.");
+    return;
+  }
+
+  ezUuid assetGuid;
+  ezStringBuilder sAbsPath;
+  ezString sAssetTypeName;
+
+  {
+    auto asset = pCurator->FindSubAsset(sIdentifier, false);
+
+    if (!asset.isValid())
+      asset = pCurator->FindSubAsset(sIdentifier, true);
+
+    if (!asset.isValid())
+    {
+      ezStringBuilder s;
+      s.SetFormat("No asset matches '{}'. Pass the guid or the path of an existing asset - 'asset_find' locates them.", sIdentifier);
+      out_result.SetError(s);
+      return;
+    }
+
+    if (asset->m_pAssetInfo == nullptr)
+    {
+      out_result.SetError("The asset is known but has no file information, so it cannot be deleted safely.");
+      return;
+    }
+
+    assetGuid = asset->m_Data.m_Guid;
+    sAbsPath = asset->m_pAssetInfo->m_Path.GetAbsolutePath();
+    sAssetTypeName = asset->m_Data.m_sSubAssetsDocumentTypeName.GetString();
+  }
+
+  const ezStringView sReplacement = ezMcpJson::GetString(arguments, "replaceWith");
+  const bool bForce = ezMcpJson::GetBool(arguments, "force", false);
+
+  ezSet<ezUuid> uses;
+  pCurator->FindAllUses(assetGuid, uses, true);
+
+  // Refusing here rather than deleting is the whole point of routing a delete through this tool: the
+  // caller may well not know the asset is used, and broken references surface much later as a
+  // transform failure somewhere unrelated.
+  if (!uses.IsEmpty() && sReplacement.IsEmpty() && !bForce)
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' is referenced by {} other asset(s). Pass 'replaceWith' to repoint them at a different asset of type '{}' "
+                "before deleting, or 'force' to delete anyway and leave those references broken. 'asset_uses' lists what uses it.",
+      sAbsPath, uses.GetCount(), sAssetTypeName);
+    out_result.SetError(s);
+    return;
+  }
+
+  ezUuid replacementGuid;
+
+  if (!sReplacement.IsEmpty())
+  {
+    auto replacement = pCurator->FindSubAsset(sReplacement, false);
+
+    if (!replacement.isValid())
+      replacement = pCurator->FindSubAsset(sReplacement, true);
+
+    if (!replacement.isValid())
+    {
+      ezStringBuilder s;
+      s.SetFormat("No asset matches the replacement '{}'.", sReplacement);
+      out_result.SetError(s);
+      return;
+    }
+
+    replacementGuid = replacement->m_Data.m_Guid;
+
+    if (replacementGuid == assetGuid)
+    {
+      out_result.SetError("The replacement is the same asset as the one being deleted.");
+      return;
+    }
+
+    // A replacement of a different type would be written into the referencing documents and only fail
+    // later, when something tries to load it as the type the property expects.
+    if (!replacement->m_Data.m_sSubAssetsDocumentTypeName.GetString().IsEqual_NoCase(sAssetTypeName))
+    {
+      ezStringBuilder s;
+      s.SetFormat("The replacement is of type '{}' but '{}' is of type '{}'. Replacing across types would write references that the "
+                  "using documents cannot resolve.",
+        replacement->m_Data.m_sSubAssetsDocumentTypeName, sAbsPath, sAssetTypeName);
+      out_result.SetError(s);
+      return;
+    }
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(assetGuid, sGuid);
+  writer.AddVariableString("guid", sGuid);
+  writer.AddVariableString("path", sAbsPath);
+  writer.AddVariableUInt32("referencedBy", uses.GetCount());
+
+  if (replacementGuid.IsValid())
+  {
+    ezStringBuilder sOldReference, sNewReference;
+    ezConversionUtils::ToString(assetGuid, sOldReference);
+    ezConversionUtils::ToString(replacementGuid, sNewReference);
+
+    const ezAssetCurator::ReplaceAssetResult result = pCurator->ReplaceAssetReferenceInUses(assetGuid, sOldReference, sNewReference);
+
+    writer.AddVariableString("replacedWith", sNewReference);
+    writer.AddVariableUInt32("documentsModified", result.m_uiDocumentsModified);
+    writer.AddVariableUInt32("propertiesReplaced", result.m_uiPropertiesReplaced);
+
+    if (!result.m_Errors.IsEmpty())
+    {
+      writer.BeginArray("errors");
+      for (const ezString& sError : result.m_Errors)
+      {
+        writer.WriteString(sError);
+      }
+      writer.EndArray();
+    }
+
+    // Deleting now would strand exactly the references that failed to move, so the asset stays and
+    // the caller gets to decide what to do about it.
+    if (result.m_uiDocumentsFailed > 0)
+    {
+      writer.AddVariableUInt32("documentsFailed", result.m_uiDocumentsFailed);
+      writer.AddVariableBool("deleted", false);
+      writer.EndObject();
+
+      out_result.m_sText = writer.GetResult();
+      out_result.m_bIsError = true;
+      return;
+    }
+  }
+
+  // The document has to go before the file does, otherwise the editor holds an open document whose
+  // file no longer exists and will happily save it back out again.
+  ezDocumentManager::EnsureDocumentIsClosedInAllManagers(sAbsPath);
+
+  // Qt's, because there is no ez equivalent - the asset browser deletes the same way. The recycle bin
+  // rather than an outright delete matters here: this tool can be called by mistake.
+  if (!QFile::moveToTrash(ezMakeQString(sAbsPath)))
+  {
+    writer.AddVariableBool("deleted", false);
+    writer.AddVariableString("error", "The file could not be moved to the recycle bin. It may be open in another program or write protected.");
+    writer.EndObject();
+
+    out_result.m_sText = writer.GetResult();
+    out_result.m_bIsError = true;
+    return;
+  }
+
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sAbsPath);
+
+  writer.AddVariableBool("deleted", true);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/DocumentTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/DocumentTool.cpp
@@ -1,9 +1,9 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
 #include <EditorPluginMcp/McpDocument.h>
+#include <EditorPluginMcp/McpTools/DocumentTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
-#include <EditorPluginMcp/McpTools/DocumentTool.h>
 
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <Foundation/IO/OSFile.h>

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/DocumentTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/DocumentTool.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezDocument;
+class ezMcpJsonWriter;
+struct ezDocumentTypeDescriptor;
+
+/// \brief Lists, opens, creates, saves, closes and focuses editor documents.
+///
+/// 'document_types' is the type-level view - what can be created and with which file extension - and
+/// is the call that has to come first, because every other tool here names a document type or a path
+/// whose extension decides the type.
+///
+/// The tools that change something are deliberately explicit about it: closing discards unsaved work
+/// unless told otherwise, and deleting rewrites other documents. Neither can ask, so both take the
+/// decision as an argument (see Status.md, 'A tool must never wait for a human').
+class ezMcpDocumentTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpDocumentTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteListTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteOpen(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteCreate(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteSave(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteClose(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteFocus(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteDelete(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// Writes guid, path, type and modified state of one open document. Every tool here returns this
+  /// for the document it acted on, so a caller never has to follow up with 'document_list' to learn
+  /// the guid of something it just created.
+  static void WriteDocumentIdentity(ezMcpJsonWriter& ref_writer, const ezDocument& document);
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.cpp
@@ -1,9 +1,9 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
 #include <EditorPluginMcp/McpDocument.h>
+#include <EditorPluginMcp/McpTools/ObjectTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
-#include <EditorPluginMcp/McpTools/ObjectTool.h>
 
 #include <Foundation/IO/OpenDdlWriter.h>
 #include <Foundation/Reflection/ReflectionUtils.h>
@@ -32,13 +32,20 @@ namespace
     // does not have to map one vocabulary onto another.
     switch (category)
     {
-      case ezPropertyCategory::Constant: return "constant";
-      case ezPropertyCategory::Member: return "member";
-      case ezPropertyCategory::Function: return "function";
-      case ezPropertyCategory::Array: return "array";
-      case ezPropertyCategory::Set: return "set";
-      case ezPropertyCategory::Map: return "map";
-      default: return "unknown";
+      case ezPropertyCategory::Constant:
+        return "constant";
+      case ezPropertyCategory::Member:
+        return "member";
+      case ezPropertyCategory::Function:
+        return "function";
+      case ezPropertyCategory::Array:
+        return "array";
+      case ezPropertyCategory::Set:
+        return "set";
+      case ezPropertyCategory::Map:
+        return "map";
+      default:
+        return "unknown";
     }
   }
 

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.cpp
@@ -1,0 +1,1694 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <EditorPluginMcp/McpDocument.h>
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <EditorPluginMcp/McpTools/ObjectTool.h>
+
+#include <Foundation/IO/OpenDdlWriter.h>
+#include <Foundation/Reflection/ReflectionUtils.h>
+#include <Foundation/Serialization/DdlSerializer.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Command/TreeCommands.h>
+#include <ToolsFoundation/CommandHistory/CommandHistory.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+#include <ToolsFoundation/Object/DocumentObjectManager.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+#include <ToolsFoundation/Selection/SelectionManager.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpObjectTool, 1, ezRTTIDefaultAllocator<ezMcpObjectTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// How many objects one object_tree call may report before it says it truncated.
+  constexpr ezUInt32 c_uiMaxTreeObjects = 200;
+
+  ezStringView ObjectToolCategoryToString(ezPropertyCategory::Enum category)
+  {
+    // Deliberately the same words rtti_type_properties reports, so an agent that looked a type up
+    // does not have to map one vocabulary onto another.
+    switch (category)
+    {
+      case ezPropertyCategory::Constant: return "constant";
+      case ezPropertyCategory::Member: return "member";
+      case ezPropertyCategory::Function: return "function";
+      case ezPropertyCategory::Array: return "array";
+      case ezPropertyCategory::Set: return "set";
+      case ezPropertyCategory::Map: return "map";
+      default: return "unknown";
+    }
+  }
+
+  /// Reads the components of a vector, quaternion or colour out of whatever shape the client sent.
+  ///
+  /// Accepts the object form this tool reports values in ({"x":1,"y":2,"z":3}, {"r":..,"g":..}) and a
+  /// plain array in component order. Returns false when the value is not one of those, which is not an
+  /// error - the caller then tries the ordinary conversion.
+  /// \param fDefaultAlpha Used when a colour is given without its alpha. It is the opaque value in the
+  ///        target's own units, which is 1 for ezColor but 255 for the byte based ezColorGammaUB -
+  ///        getting that wrong makes a colour written without an alpha come out invisible.
+  bool ObjectToolReadComponents(const ezVariant& input, ezUInt32 uiCount, bool bColor, double fDefaultAlpha, double* out_pComponents)
+  {
+    if (const ezVariantArray* pArray = input.IsA<ezVariantArray>() ? &input.Get<ezVariantArray>() : nullptr)
+    {
+      if (pArray->GetCount() != uiCount)
+        return false;
+
+      for (ezUInt32 i = 0; i < uiCount; ++i)
+      {
+        if (!(*pArray)[i].CanConvertTo<double>())
+          return false;
+
+        out_pComponents[i] = (*pArray)[i].ConvertTo<double>();
+      }
+
+      return true;
+    }
+
+    if (!input.IsA<ezVariantDictionary>())
+      return false;
+
+    const ezVariantDictionary& dict = input.Get<ezVariantDictionary>();
+
+    // 'a' is optional so a colour can be given without its alpha, which is how a human writes one and
+    // how most sources report one.
+    const char* szVectorNames[] = {"x", "y", "z", "w"};
+    const char* szColorNames[] = {"r", "g", "b", "a"};
+    const char* const* szNames = bColor ? szColorNames : szVectorNames;
+
+    for (ezUInt32 i = 0; i < uiCount; ++i)
+    {
+      const ezVariant* pValue = nullptr;
+
+      if (!dict.TryGetValue(szNames[i], pValue) || !pValue->CanConvertTo<double>())
+      {
+        if (bColor && i == 3)
+        {
+          out_pComponents[i] = fDefaultAlpha;
+          continue;
+        }
+
+        return false;
+      }
+
+      out_pComponents[i] = pValue->ConvertTo<double>();
+    }
+
+    return true;
+  }
+
+  /// Builds the vector, quaternion or colour a property wants, if that is what the target type is.
+  bool ObjectToolCoerceComposite(const ezVariant& input, ezVariant::Type::Enum targetType, ezVariant& out_value)
+  {
+    // Anything already of the right type went through the ordinary path before this is reached.
+    if (!input.IsA<ezVariantArray>() && !input.IsA<ezVariantDictionary>())
+      return false;
+
+    double c[4] = {0.0, 0.0, 0.0, 0.0};
+
+    switch (targetType)
+    {
+      case ezVariant::Type::Vector2:
+        if (!ObjectToolReadComponents(input, 2, false, 0.0, c))
+          return false;
+        out_value = ezVec2(static_cast<float>(c[0]), static_cast<float>(c[1]));
+        return true;
+
+      case ezVariant::Type::Vector3:
+        if (!ObjectToolReadComponents(input, 3, false, 0.0, c))
+          return false;
+        out_value = ezVec3(static_cast<float>(c[0]), static_cast<float>(c[1]), static_cast<float>(c[2]));
+        return true;
+
+      case ezVariant::Type::Vector4:
+        if (!ObjectToolReadComponents(input, 4, false, 0.0, c))
+          return false;
+        out_value = ezVec4(static_cast<float>(c[0]), static_cast<float>(c[1]), static_cast<float>(c[2]), static_cast<float>(c[3]));
+        return true;
+
+      case ezVariant::Type::Vector2I:
+        if (!ObjectToolReadComponents(input, 2, false, 0.0, c))
+          return false;
+        out_value = ezVec2I32(static_cast<ezInt32>(c[0]), static_cast<ezInt32>(c[1]));
+        return true;
+
+      case ezVariant::Type::Vector3I:
+        if (!ObjectToolReadComponents(input, 3, false, 0.0, c))
+          return false;
+        out_value = ezVec3I32(static_cast<ezInt32>(c[0]), static_cast<ezInt32>(c[1]), static_cast<ezInt32>(c[2]));
+        return true;
+
+      case ezVariant::Type::Vector4I:
+        if (!ObjectToolReadComponents(input, 4, false, 0.0, c))
+          return false;
+        out_value = ezVec4I32(static_cast<ezInt32>(c[0]), static_cast<ezInt32>(c[1]), static_cast<ezInt32>(c[2]), static_cast<ezInt32>(c[3]));
+        return true;
+
+      case ezVariant::Type::Vector2U:
+        if (!ObjectToolReadComponents(input, 2, false, 0.0, c))
+          return false;
+        out_value = ezVec2U32(static_cast<ezUInt32>(c[0]), static_cast<ezUInt32>(c[1]));
+        return true;
+
+      case ezVariant::Type::Vector3U:
+        if (!ObjectToolReadComponents(input, 3, false, 0.0, c))
+          return false;
+        out_value = ezVec3U32(static_cast<ezUInt32>(c[0]), static_cast<ezUInt32>(c[1]), static_cast<ezUInt32>(c[2]));
+        return true;
+
+      case ezVariant::Type::Vector4U:
+        if (!ObjectToolReadComponents(input, 4, false, 0.0, c))
+          return false;
+        out_value = ezVec4U32(static_cast<ezUInt32>(c[0]), static_cast<ezUInt32>(c[1]), static_cast<ezUInt32>(c[2]), static_cast<ezUInt32>(c[3]));
+        return true;
+
+      case ezVariant::Type::Quaternion:
+      {
+        if (!ObjectToolReadComponents(input, 4, false, 0.0, c))
+          return false;
+
+        ezQuat q;
+        q.x = static_cast<float>(c[0]);
+        q.y = static_cast<float>(c[1]);
+        q.z = static_cast<float>(c[2]);
+        q.w = static_cast<float>(c[3]);
+
+        // A rotation assembled from four numbers the caller may have rounded is not necessarily a unit
+        // quaternion, and an unnormalized one scales everything below the object.
+        q.Normalize();
+
+        out_value = q;
+        return true;
+      }
+
+      case ezVariant::Type::Color:
+        if (!ObjectToolReadComponents(input, 4, true, 1.0, c))
+          return false;
+        out_value = ezColor(static_cast<float>(c[0]), static_cast<float>(c[1]), static_cast<float>(c[2]), static_cast<float>(c[3]));
+        return true;
+
+      case ezVariant::Type::ColorGamma:
+      {
+        if (!ObjectToolReadComponents(input, 4, true, 255.0, c))
+          return false;
+
+        // Reported as the 0-255 bytes it is stored as, so that is what comes back in.
+        out_value = ezColorGammaUB(static_cast<ezUInt8>(c[0]), static_cast<ezUInt8>(c[1]), static_cast<ezUInt8>(c[2]), static_cast<ezUInt8>(c[3]));
+        return true;
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  /// Turns a value from the tool arguments into a variant the accessor will accept for this property.
+  ///
+  /// The JSON parser gives every number as a double and an AI client sends numbers as strings often
+  /// enough that a straight type check would reject correct intent. Enums and bitflags additionally
+  /// arrive as their names, which is the only form an agent can read out of rtti_type_properties.
+  ezResult ObjectToolCoerceValue(const ezVariant& input, const ezAbstractProperty* pProp, ezVariant& out_value, ezStringBuilder& out_sError)
+  {
+    const ezRTTI* pPropType = pProp->GetSpecificType();
+    const ezBitflags<ezPropertyFlags> flags = pProp->GetFlags();
+
+    if (flags.IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags) && pPropType != nullptr)
+    {
+      // A name, possibly fully qualified. Numbers are still accepted, because a round trip through
+      // this tool reports the name but other sources report the value.
+      if (input.IsA<ezString>() || input.IsA<ezStringView>())
+      {
+        const ezString sValue = input.ConvertTo<ezString>();
+
+        ezInt64 iValue = 0;
+        if (ezReflectionUtils::StringToEnumeration(pPropType, sValue, iValue))
+        {
+          out_value = iValue;
+          return EZ_SUCCESS;
+        }
+
+        out_sError.SetFormat("'{}' is not a valid value for '{}'. 'rtti_type_properties' lists the valid names under 'enumValues'.",
+          sValue, pProp->GetPropertyName());
+        return EZ_FAILURE;
+      }
+
+      if (input.CanConvertTo<ezInt64>())
+      {
+        out_value = input.ConvertTo<ezInt64>();
+        return EZ_SUCCESS;
+      }
+
+      out_sError.SetFormat("'{}' expects an enum name or a number.", pProp->GetPropertyName());
+      return EZ_FAILURE;
+    }
+
+    // For a plain member the property's own type says what is wanted. Converting rather than
+    // requiring an exact match is what lets 42 arrive as a double and still set an ezInt32.
+    if (pPropType != nullptr && flags.IsSet(ezPropertyFlags::StandardType))
+    {
+      const ezVariant::Type::Enum targetType = pPropType->GetVariantType();
+
+      // A vector or colour arrives as the object it was reported as ({"x":1,"y":2,"z":3}) or as an
+      // array, and ezVariant converts neither. Without this, reading a position and writing it back -
+      // the most ordinary thing to do with a transform - fails on the value this tool itself produced.
+      if (ObjectToolCoerceComposite(input, targetType, out_value))
+        return EZ_SUCCESS;
+
+      // An ezStringView property must still be written as an ezString: a variant that goes into the
+      // command history has to own its value, and ezSetObjectPropertyCommand asserts on one that does
+      // not. Asset reference properties are declared this way - ezPrefabReferenceComponent::Prefab
+      // among them - so this is the ordinary case, not an exotic one.
+      if (targetType == ezVariant::Type::StringView)
+      {
+        if (!input.CanConvertTo<ezString>())
+        {
+          out_sError.SetFormat("The value given for '{}' cannot be converted to a string.", pProp->GetPropertyName());
+          return EZ_FAILURE;
+        }
+
+        out_value = input.ConvertTo<ezString>();
+        return EZ_SUCCESS;
+      }
+
+      if (targetType != ezVariant::Type::Invalid && input.GetType() != targetType)
+      {
+        if (!input.CanConvertTo(targetType))
+        {
+          out_sError.SetFormat("The value given for '{}' cannot be converted to {}.", pProp->GetPropertyName(), pPropType->GetTypeName());
+          return EZ_FAILURE;
+        }
+
+        ezResult conversion = EZ_FAILURE;
+        out_value = input.ConvertTo(targetType, &conversion);
+
+        if (conversion.Failed())
+        {
+          out_sError.SetFormat("The value given for '{}' could not be converted to {}.", pProp->GetPropertyName(), pPropType->GetTypeName());
+          return EZ_FAILURE;
+        }
+
+        return EZ_SUCCESS;
+      }
+    }
+
+    out_value = input;
+    return EZ_SUCCESS;
+  }
+
+  /// Reads the 'value' argument, which unlike the others may legitimately be of any type.
+  const ezVariant* ObjectToolGetRawValue(const ezVariantDictionary& arguments, ezStringView sKey)
+  {
+    const ezVariant* pValue = nullptr;
+    if (arguments.TryGetValue(sKey, pValue))
+      return pValue;
+
+    return nullptr;
+  }
+
+  /// Checks that an index actually addresses an existing element.
+  ///
+  /// The accessors hand the index straight to reflection without validating it, where an out of range
+  /// array index asserts - which kills the editor rather than failing the call. So every index that
+  /// reaches a container has to be checked here first. 'bAllowEnd' is for insertion, where appending
+  /// one past the last element is the normal case.
+  ezResult ObjectToolValidateIndex(ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp,
+    const ezVariant& index, bool bAllowEnd, ezStringBuilder& out_sError)
+  {
+    const ezPropertyCategory::Enum category = pProp->GetCategory();
+
+    if (category == ezPropertyCategory::Map)
+    {
+      // A map key that does not exist is a lookup miss rather than an out of bounds access, but the
+      // same reasoning applies: report it here instead of finding out deeper down.
+      if (bAllowEnd)
+        return EZ_SUCCESS;
+
+      ezDynamicArray<ezVariant> keys;
+      if (pAccessor->GetKeysByName(pObject, pProp->GetPropertyName(), keys).Failed())
+      {
+        out_sError.SetFormat("Could not read the keys of '{}', so a key cannot be used with it safely.", pProp->GetPropertyName());
+        return EZ_FAILURE;
+      }
+
+      const ezString sKey = index.ConvertTo<ezString>();
+
+      for (const ezVariant& key : keys)
+      {
+        if (key.ConvertTo<ezString>() == sKey)
+          return EZ_SUCCESS;
+      }
+
+      out_sError.SetFormat("'{}' has no key '{}'. 'object_properties' lists the keys it has.", pProp->GetPropertyName(), sKey);
+      return EZ_FAILURE;
+    }
+
+    if (category != ezPropertyCategory::Array && category != ezPropertyCategory::Set)
+      return EZ_SUCCESS;
+
+    ezInt32 iCount = 0;
+    if (pAccessor->GetCountByName(pObject, pProp->GetPropertyName(), iCount).Failed())
+    {
+      // Refusing rather than passing the index through: the reflection layer asserts on an out of
+      // range index, and an assert is a dead editor. Without a count there is no way to know the
+      // index is safe, so the only correct answer is not to try.
+      out_sError.SetFormat("Could not determine how many elements '{}' has, so an index cannot be used with it safely.",
+        pProp->GetPropertyName());
+      return EZ_FAILURE;
+    }
+
+    const ezInt64 iIndex = index.ConvertTo<ezInt64>();
+    const ezInt64 iLimit = bAllowEnd ? iCount : iCount - 1;
+
+    if (iIndex < 0 || iIndex > iLimit)
+    {
+      if (iCount == 0)
+      {
+        out_sError.SetFormat("'{}' is empty, so there is no element {}.", pProp->GetPropertyName(), iIndex);
+      }
+      else
+      {
+        out_sError.SetFormat("Index {} is out of range for '{}', which has {} element(s), so the valid range is 0 to {}.",
+          iIndex, pProp->GetPropertyName(), iCount, iLimit);
+      }
+
+      return EZ_FAILURE;
+    }
+
+    return EZ_SUCCESS;
+  }
+
+  /// Turns the 'index' argument into what the accessor expects: an ezUInt32 for arrays and sets, a
+  /// string key for maps. Returns an invalid variant when no index was given.
+  ezVariant ObjectToolGetIndex(const ezVariantDictionary& arguments, ezPropertyCategory::Enum category)
+  {
+    const ezVariant* pIndex = ObjectToolGetRawValue(arguments, "index");
+
+    if (pIndex == nullptr || !pIndex->IsValid())
+      return ezVariant();
+
+    if (category == ezPropertyCategory::Map)
+      return ezVariant(pIndex->ConvertTo<ezString>());
+
+    if (pIndex->CanConvertTo<ezUInt32>())
+      return ezVariant(pIndex->ConvertTo<ezUInt32>());
+
+    return ezVariant();
+  }
+} // namespace
+
+void ezMcpObjectTool::WritePropertyValue(ezMcpJsonWriter& ref_writer, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject,
+  const ezAbstractProperty* pProp, bool bIncludeValues)
+{
+  ref_writer.BeginObject();
+  ref_writer.AddVariableString("name", pProp->GetPropertyName());
+
+  const ezRTTI* pPropType = pProp->GetSpecificType();
+  ref_writer.AddVariableString("type", pPropType != nullptr ? pPropType->GetTypeName() : ezStringView());
+
+  const ezPropertyCategory::Enum category = pProp->GetCategory();
+  ref_writer.AddVariableString("category", ObjectToolCategoryToString(category));
+
+  const ezBitflags<ezPropertyFlags> flags = pProp->GetFlags();
+
+  // Only the flags that change what a caller may do with the property. The full set is available from
+  // rtti_type_properties and would be repeated noise on every value.
+  if (flags.IsSet(ezPropertyFlags::ReadOnly))
+    ref_writer.AddVariableBool("readOnly", true);
+
+  if (flags.IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags))
+    ref_writer.AddVariableBool("isEnum", true);
+
+  if (!bIncludeValues)
+  {
+    ref_writer.EndObject();
+    return;
+  }
+
+  switch (category)
+  {
+    case ezPropertyCategory::Member:
+    {
+      // A member whose value is an embedded object reports that object's guid, not its contents: the
+      // tree is walked with follow up calls, so one response stays bounded regardless of nesting.
+      if (flags.IsAnySet(ezPropertyFlags::Class | ezPropertyFlags::Pointer) && !flags.IsSet(ezPropertyFlags::StandardType))
+      {
+        const ezDocumentObject* pChild = pAccessor->GetChildObjectByName(pObject, pProp->GetPropertyName(), ezVariant());
+
+        if (pChild != nullptr)
+        {
+          ezStringBuilder sChildGuid;
+          ezConversionUtils::ToString(pChild->GetGuid(), sChildGuid);
+          ref_writer.AddVariableString("objectGuid", sChildGuid);
+          ref_writer.AddVariableString("objectType", pChild->GetType() != nullptr ? pChild->GetType()->GetTypeName() : ezStringView());
+        }
+        else
+        {
+          // Distinguishes 'the pointer is null' from 'this property has no value', which for an
+          // optional sub object is the interesting difference.
+          ref_writer.AddVariableBool("null", true);
+        }
+
+        break;
+      }
+
+      ezVariant value;
+      const ezStatus res = pAccessor->GetValueByName(pObject, pProp->GetPropertyName(), value);
+
+      if (res.Failed())
+      {
+        ref_writer.AddVariableString("error", res.GetMessageString());
+        break;
+      }
+
+      // An enum's number means nothing to a reader, and the name is what has to be passed back in.
+      if (flags.IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags) && pPropType != nullptr && value.CanConvertTo<ezInt64>())
+      {
+        ezStringBuilder sName;
+        if (ezReflectionUtils::EnumerationToString(pPropType, value.ConvertTo<ezInt64>(), sName, ezReflectionUtils::EnumConversionMode::ValueNameOnly))
+        {
+          ref_writer.AddVariableString("value", sName);
+          break;
+        }
+      }
+
+      ref_writer.BeginVariable("value");
+      ref_writer.WriteVariant(value);
+      ref_writer.EndVariable();
+      break;
+    }
+
+    case ezPropertyCategory::Array:
+    case ezPropertyCategory::Set:
+    {
+      ezInt32 iCount = 0;
+      if (pAccessor->GetCountByName(pObject, pProp->GetPropertyName(), iCount).Succeeded())
+        ref_writer.AddVariableInt32("count", iCount);
+
+      break;
+    }
+
+    case ezPropertyCategory::Map:
+    {
+      ezDynamicArray<ezVariant> keys;
+      if (pAccessor->GetKeysByName(pObject, pProp->GetPropertyName(), keys).Succeeded())
+      {
+        ref_writer.AddVariableInt32("count", keys.GetCount());
+
+        // Keys, unlike elements, are what a caller needs in order to ask for anything at all.
+        ref_writer.BeginArray("keys");
+        for (const ezVariant& key : keys)
+        {
+          ref_writer.WriteString(key.ConvertTo<ezString>());
+        }
+        ref_writer.EndArray();
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  ref_writer.EndObject();
+}
+
+void ezMcpObjectTool::WriteTreeNode(ezMcpJsonWriter& ref_writer, const ezDocumentObject* pObject, ezUInt32 uiRemainingDepth, ezUInt32& ref_uiBudget)
+{
+  ref_writer.BeginObject();
+
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(pObject->GetGuid(), sGuid);
+  ref_writer.AddVariableString("guid", sGuid);
+
+  const ezString sName = ezMcpDocument::GetObjectName(pObject);
+  if (!sName.IsEmpty())
+    ref_writer.AddVariableString("name", sName);
+
+  const ezRTTI* pType = pObject->GetType();
+  ref_writer.AddVariableString("type", pType != nullptr ? pType->GetTypeName() : ezStringView());
+
+  // Which property of the parent this object sits in. A game object's children and its components are
+  // both children in this hierarchy and are told apart by nothing else. Written only when it is not
+  // 'Children', which is the overwhelming majority and would otherwise repeat on every single node.
+  const ezStringView sParentProperty = pObject->GetParentProperty();
+  if (!sParentProperty.IsEmpty() && sParentProperty != "Children")
+    ref_writer.AddVariableString("parentProperty", sParentProperty);
+
+  const ezHybridArray<ezDocumentObject*, 8>& children = pObject->GetChildren();
+  ref_writer.AddVariableUInt32("numChildren", children.GetCount());
+
+  if (uiRemainingDepth > 0 && !children.IsEmpty())
+  {
+    ref_writer.BeginArray("children");
+
+    for (const ezDocumentObject* pChild : children)
+    {
+      if (ref_uiBudget == 0)
+        break;
+
+      --ref_uiBudget;
+      WriteTreeNode(ref_writer, pChild, uiRemainingDepth - 1, ref_uiBudget);
+    }
+
+    ref_writer.EndArray();
+  }
+
+  ref_writer.EndObject();
+}
+
+void ezMcpObjectTool::ExecuteTree(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return;
+  }
+
+  const ezDocumentObjectManager* pManager = pDocument->GetObjectManager();
+  const ezStringView sObject = ezMcpJson::GetString(arguments, "object");
+
+  // Unlike the other tools here, an empty 'object' does not mean the single top level object: a scene
+  // has many, and listing them is the reason this tool exists. The root is not reported itself - it is
+  // an implementation detail with no type a caller could do anything with.
+  const ezDocumentObject* pRoot = pManager->GetRootObject();
+
+  if (!sObject.IsEmpty())
+  {
+    ezStringBuilder sError;
+    pRoot = ezMcpDocument::ResolveObject(pDocument, sObject, sError);
+
+    if (pRoot == nullptr)
+    {
+      out_result.SetError(sError);
+      return;
+    }
+  }
+
+  if (pRoot == nullptr)
+  {
+    out_result.SetError("The document has no object hierarchy.");
+    return;
+  }
+
+  // Clamped rather than rejected: a depth of 500 is a clumsy way of saying 'all of it', and the object
+  // cap bounds the response either way.
+  const ezInt64 iDepth = ezMcpJson::GetInt(arguments, "depth", 2);
+  const ezUInt32 uiDepth = static_cast<ezUInt32>(ezMath::Clamp<ezInt64>(iDepth, 0, 20));
+
+  ezUInt32 uiBudget = c_uiMaxTreeObjects;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("document", pDocument->GetDocumentPath());
+  writer.AddVariableUInt32("depth", uiDepth);
+
+  if (sObject.IsEmpty())
+  {
+    // Walking the root's children rather than the root itself, so the same shape comes back whether the
+    // document has one top level object or a hundred.
+    writer.BeginArray("objects");
+
+    for (const ezDocumentObject* pChild : pRoot->GetChildren())
+    {
+      if (uiBudget == 0)
+        break;
+
+      --uiBudget;
+      WriteTreeNode(writer, pChild, uiDepth, uiBudget);
+    }
+
+    writer.EndArray();
+  }
+  else
+  {
+    writer.BeginArray("objects");
+    --uiBudget;
+    WriteTreeNode(writer, pRoot, uiDepth, uiBudget);
+    writer.EndArray();
+  }
+
+  writer.AddVariableUInt32("returned", c_uiMaxTreeObjects - uiBudget);
+
+  // A hierarchy cut off by the cap and one cut off by 'depth' look the same from the outside, so both
+  // are reported: 'numChildren' on a node without 'children' says where to continue either way.
+  writer.AddVariableBool("truncated", uiBudget == 0);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpObjectTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "object_tree";
+    desc.m_sDescription =
+      "Lists the objects inside an open document as a hierarchy: guid, name, type and child count per object. This is where the "
+      "object guids that 'object_properties' and 'object_modify' take come from, and the only way to find anything in a scene, "
+      "whose objects have no other identifier. Returns the document's top level objects with no 'object' argument, or the subtree "
+      "below the given one. "
+      "Components appear as children of their game object, marked by 'parentProperty':'Components'. That field is omitted for an "
+      "ordinary child object, so its absence means a child in the scene hierarchy. The response is capped at 200 objects; an "
+      "object whose children were not included still reports how many it has, so descend with another call using its guid rather "
+      "than asking for a large 'depth' at once. "
+      "The document has to be open - use 'document_open' with 'focus' false to open it without a window.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document. 'document_list' reports both."},)"
+                          R"("object":{"type":"string","description":"Guid of the object to start at. Omit to list the document's top level objects."},)"
+                          R"("depth":{"type":"number","description":"How many levels of children to include. 0 lists only the objects themselves with their child counts. Defaults to 2."})"
+                          R"(},"required":["document"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "object_properties";
+    desc.m_sDescription =
+      "Reads the properties of one object inside an open document, with their current values. With no 'object' argument this is the "
+      "document's top level object, which for most asset types is the single object holding all of the asset's settings - so reading "
+      "an asset's configuration is one call with just 'document'. "
+      "Only direct properties are returned: a property whose value is another object reports that object's guid under 'objectGuid', "
+      "and arrays, sets and maps report a count (and, for maps, their keys) rather than their elements. Pass 'property' with an "
+      "'index' to read one element. The document has to be open - use 'document_open' with 'focus' false to open it invisibly.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document. 'document_list' reports both."},)"
+                          R"("object":{"type":"string","description":"Guid of the object to read, as reported by a previous call. Omit for the document's top level object."},)"
+                          R"("property":{"type":"string","description":"Only read this one property. Combine with 'index' to read a single container element."},)"
+                          R"("index":{"description":"Element to read from an array or set (a number) or from a map (the key). Only valid together with 'property'."},)"
+                          R"("includeValues":{"type":"boolean","description":"If false, only report the property names and types, not their values. Defaults to true."})"
+                          R"(},"required":["document"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "object_modify";
+    desc.m_sDescription =
+      "Changes a property of an object inside an open document. Each call is one undoable step, exactly as if a user had made the "
+      "change in the editor, and shows up in the undo menu labelled as coming from MCP. "
+      "The document is NOT saved - call 'document_save' when the change is meant to be permanent, which is also what makes it "
+      "visible to the asset system. Undo it with 'object_undo'. "
+      "Operations: 'set' writes a value (for an array or map element, pass 'index'); 'insert' adds a value to a container; 'remove' "
+      "deletes a container element; 'move' reorders one; 'addObject' creates an object of a given type inside a property and "
+      "'removeObject' deletes one by index. Enum properties take the value name, as reported by 'rtti_type_properties'. "
+      "Three operations act on the object named by 'object' rather than on a property, which is what to use with a guid from "
+      "'object_tree': 'deleteObject' deletes it and everything below it, 'moveObject' moves it under 'newParent', and "
+      "'duplicateObject' copies it, with its children and components, into 'newParent' (its own parent by default). "
+      "This is also how a scene is built: 'addObject' on a game object with property 'Children' and type 'ezGameObject' creates a "
+      "child object, and with property 'Components' and a component type name ('rtti_derived_types' of 'ezComponent' lists them) "
+      "adds a component to it. New guids come back as 'addedObject'/'addedObjects'; set their properties with further calls. "
+      "Vectors and colours are written the way they are reported ({\"x\":1,\"y\":2,\"z\":3} or [1,2,3]).";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document."},)"
+                          R"("object":{"type":"string","description":"Guid of the object to modify. Omit for the document's top level object."},)"
+                          R"("property":{"type":"string","description":"Name of the property to change. See 'object_properties'."},)"
+                          R"("operation":{"type":"string","enum":["set","insert","remove","move","addObject","removeObject","deleteObject","moveObject","duplicateObject"],"description":"What to do. Defaults to 'set'. 'deleteObject', 'moveObject' and 'duplicateObject' act on 'object' itself and need no 'property'."},)"
+                          R"("newParent":{"type":"string","description":"Guid of the object to move or duplicate into, for 'moveObject' and 'duplicateObject'. Defaults to the object's current parent, which for 'moveObject' means reordering it among its siblings."},)"
+                          R"("value":{"description":"The new value, for 'set' and 'insert'. Enums take the value name as a string."},)"
+                          R"("index":{"description":"Which element: a number for arrays and sets, the key for maps. Required for 'remove' and for 'set' on a container."},)"
+                          R"("newIndex":{"description":"Where to move the element to, for 'move'."},)"
+                          R"("type":{"type":"string","description":"The type to instantiate, for 'addObject'. Must be compatible with the property."})"
+                          R"(},"required":["document"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "object_undo";
+    desc.m_sDescription =
+      "Undoes or redoes changes in an open document, and reports what is on its undo stack. This is the same stack the user's undo "
+      "menu shows, so it also undoes changes the user made. The stack lives on the open document and is lost when the document is "
+      "closed. Call with no 'action' to only look.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document."},)"
+                          R"("action":{"type":"string","enum":["undo","redo"],"description":"Omit to only report the current stack."},)"
+                          R"("count":{"type":"number","description":"How many steps to undo or redo. Defaults to 1."})"
+                          R"(},"required":["document"]})";
+  }
+}
+
+void ezMcpObjectTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "object_tree")
+    ExecuteTree(arguments, out_result);
+  else if (sToolName == "object_properties")
+    ExecuteReadProperties(arguments, out_result);
+  else if (sToolName == "object_modify")
+    ExecuteModify(arguments, out_result);
+  else if (sToolName == "object_undo")
+    ExecuteUndo(arguments, out_result);
+}
+
+void ezMcpObjectTool::ExecuteReadProperties(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return;
+  }
+
+  ezStringBuilder sError;
+  const ezDocumentObject* pObject = ezMcpDocument::ResolveObject(pDocument, ezMcpJson::GetString(arguments, "object"), sError);
+
+  if (pObject == nullptr)
+  {
+    out_result.SetError(sError);
+    return;
+  }
+
+  ezObjectAccessorBase* pAccessor = pDocument->GetObjectAccessor();
+
+  if (pAccessor == nullptr)
+  {
+    out_result.SetError("The document has no object accessor, so its properties cannot be read.");
+    return;
+  }
+
+  const ezRTTI* pType = pObject->GetType();
+
+  if (pType == nullptr)
+  {
+    out_result.SetError("The object has no type information, so its properties cannot be read.");
+    return;
+  }
+
+  const bool bIncludeValues = ezMcpJson::GetBool(arguments, "includeValues", true);
+  const ezStringView sSingleProperty = ezMcpJson::GetString(arguments, "property");
+
+  // Everything that can fail is resolved before the writer exists. ~ezStandardJSONWriter asserts if
+  // the stream was not closed properly, so returning early from between BeginObject() and EndObject()
+  // kills the editor rather than failing the call - see Status.md.
+  const ezAbstractProperty* pSingleProp = nullptr;
+  ezVariant singleIndex;
+
+  if (!sSingleProperty.IsEmpty())
+  {
+    pSingleProp = pAccessor->FindPropertyByName(pObject, sSingleProperty);
+
+    if (pSingleProp == nullptr)
+    {
+      ezStringBuilder s;
+      s.SetFormat("'{}' has no property '{}'. Call without 'property' to list the ones it has.", pType->GetTypeName(), sSingleProperty);
+      out_result.SetError(s);
+      return;
+    }
+
+    singleIndex = ObjectToolGetIndex(arguments, pSingleProp->GetCategory());
+
+    if (singleIndex.IsValid())
+    {
+      // An out of range index asserts inside the reflection layer, which would also take the editor
+      // down, so it is rejected before anything reads through it.
+      ezStringBuilder sIndexError;
+      if (ObjectToolValidateIndex(pAccessor, pObject, pSingleProp, singleIndex, false, sIndexError).Failed())
+      {
+        out_result.SetError(sIndexError);
+        return;
+      }
+    }
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezStringBuilder sObjectGuid;
+  ezConversionUtils::ToString(pObject->GetGuid(), sObjectGuid);
+  writer.AddVariableString("object", sObjectGuid);
+  writer.AddVariableString("objectType", pType->GetTypeName());
+
+  if (pSingleProp != nullptr)
+  {
+    const ezAbstractProperty* pProp = pSingleProp;
+    const ezVariant index = singleIndex;
+
+    if (index.IsValid())
+    {
+      // One container element, which is the follow up call the container listing invites.
+      ezVariant value;
+      const ezStatus res = pAccessor->GetValueByName(pObject, sSingleProperty, value, index);
+
+      if (res.Failed())
+      {
+        // Reported as a field rather than through SetError(), because the writer is already open.
+        // EndAll() closes whatever is still open so the partial result is still valid JSON.
+        writer.AddVariableString("property", sSingleProperty);
+        writer.AddVariableString("error", res.GetMessageString());
+        writer.EndAll();
+
+        out_result.m_sText = writer.GetResult();
+        out_result.m_bIsError = true;
+        return;
+      }
+
+      writer.AddVariableString("property", sSingleProperty);
+      writer.BeginVariable("index");
+      writer.WriteVariant(index);
+      writer.EndVariable();
+
+      // An element that is an object reports its guid, matching how member properties are reported.
+      if (value.IsA<ezUuid>())
+      {
+        const ezDocumentObject* pChild = pDocument->GetObjectManager()->GetObject(value.Get<ezUuid>());
+
+        ezStringBuilder sChildGuid;
+        ezConversionUtils::ToString(value.Get<ezUuid>(), sChildGuid);
+        writer.AddVariableString("objectGuid", sChildGuid);
+
+        if (pChild != nullptr && pChild->GetType() != nullptr)
+          writer.AddVariableString("objectType", pChild->GetType()->GetTypeName());
+      }
+      else
+      {
+        writer.BeginVariable("value");
+        writer.WriteVariant(value);
+        writer.EndVariable();
+      }
+
+      writer.EndObject();
+      out_result.m_sText = writer.GetResult();
+      return;
+    }
+
+    writer.BeginArray("properties");
+    WritePropertyValue(writer, pAccessor, pObject, pProp, bIncludeValues);
+    writer.EndArray();
+    writer.EndObject();
+
+    out_result.m_sText = writer.GetResult();
+    return;
+  }
+
+  writer.BeginArray("properties");
+
+  ezUInt32 uiCount = 0;
+
+  // GetAllProperties() includes inherited ones, which is right here even though this tool only reads
+  // *direct* properties: 'direct' means 'not recursing into sub objects', not 'declared on this exact
+  // type'. An asset's settings routinely come partly from a base class, and a caller asking what it
+  // can change on this object does not care which class declared what.
+  ezDynamicArray<const ezAbstractProperty*> allProperties;
+  pType->GetAllProperties(allProperties);
+
+  for (const ezAbstractProperty* pProp : allProperties)
+  {
+    if (pProp == nullptr)
+      continue;
+
+    // Functions are not values and constants belong to the type rather than the object.
+    if (pProp->GetCategory() == ezPropertyCategory::Function || pProp->GetCategory() == ezPropertyCategory::Constant)
+      continue;
+
+    ++uiCount;
+    WritePropertyValue(writer, pAccessor, pObject, pProp, bIncludeValues);
+  }
+
+  writer.EndArray();
+  writer.AddVariableUInt32("count", uiCount);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpObjectTool::ExecuteModify(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return;
+  }
+
+  if (pDocument->IsReadOnly())
+  {
+    out_result.SetError("The document is read only and cannot be modified.");
+    return;
+  }
+
+  ezStringBuilder sError;
+  const ezDocumentObject* pObject = ezMcpDocument::ResolveObject(pDocument, ezMcpJson::GetString(arguments, "object"), sError);
+
+  if (pObject == nullptr)
+  {
+    out_result.SetError(sError);
+    return;
+  }
+
+  ezObjectAccessorBase* pAccessor = pDocument->GetObjectAccessor();
+
+  if (pAccessor == nullptr)
+  {
+    out_result.SetError("The document has no object accessor, so it cannot be modified.");
+    return;
+  }
+
+  const ezStringView sProperty = ezMcpJson::GetString(arguments, "property");
+
+  // These address the object itself rather than one of its properties, because that is the form an
+  // agent has: object_tree reports guids, not the index a child happens to sit at inside its parent's
+  // 'Children' or 'Components'. Handled before the property lookup below, which for 'moveObject' would
+  // look the property up on the wrong object - it belongs to the new parent.
+  const ezStringView sEarlyOperation = ezMcpJson::GetString(arguments, "operation");
+
+  if (sEarlyOperation == "deleteObject")
+  {
+    ExecuteDeleteObject(pDocument, pObject, pAccessor, out_result);
+    return;
+  }
+
+  if (sEarlyOperation == "moveObject")
+  {
+    ExecuteMoveObject(arguments, pDocument, pObject, pAccessor, out_result);
+    return;
+  }
+
+  if (sEarlyOperation == "duplicateObject")
+  {
+    ExecuteDuplicateObject(arguments, pDocument, pObject, out_result);
+    return;
+  }
+
+  if (sProperty.IsEmpty())
+  {
+    out_result.SetError("No 'property' argument given. 'object_properties' lists the properties of an object.");
+    return;
+  }
+
+  const ezAbstractProperty* pProp = pAccessor->FindPropertyByName(pObject, sProperty);
+
+  if (pProp == nullptr)
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' has no property '{}'. 'object_properties' lists the ones it has.",
+      pObject->GetType() != nullptr ? pObject->GetType()->GetTypeName() : ezStringView("<unknown>"), sProperty);
+    out_result.SetError(s);
+    return;
+  }
+
+  if (pProp->GetFlags().IsSet(ezPropertyFlags::ReadOnly))
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' is read only.", sProperty);
+    out_result.SetError(s);
+    return;
+  }
+
+  const ezStringView sOperation = ezMcpJson::GetString(arguments, "operation", "set");
+  const ezPropertyCategory::Enum category = pProp->GetCategory();
+  const ezVariant index = ObjectToolGetIndex(arguments, category);
+
+  // The label the user sees in the undo menu. Naming MCP makes it obvious which changes were an
+  // agent's rather than their own.
+  ezStringBuilder sTransactionName;
+  sTransactionName.SetFormat("MCP: {} '{}'", sOperation, sProperty);
+
+  ezStatus res(EZ_SUCCESS);
+  ezStringBuilder sAddedObjectGuid;
+
+  pAccessor->StartTransaction(sTransactionName);
+
+  if (sOperation == "set" || sOperation == "insert")
+  {
+    const ezVariant* pRawValue = ObjectToolGetRawValue(arguments, "value");
+
+    if (pRawValue == nullptr || !pRawValue->IsValid())
+    {
+      pAccessor->CancelTransaction();
+      ezStringBuilder s;
+      s.SetFormat("'{}' needs a 'value' argument.", sOperation);
+      out_result.SetError(s);
+      return;
+    }
+
+    ezVariant value;
+    ezStringBuilder sCoerceError;
+
+    if (ObjectToolCoerceValue(*pRawValue, pProp, value, sCoerceError).Failed())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError(sCoerceError);
+      return;
+    }
+
+    if (sOperation == "set")
+    {
+      // A container without an index would silently do nothing useful, so say what is missing.
+      if (category != ezPropertyCategory::Member && !index.IsValid())
+      {
+        pAccessor->CancelTransaction();
+        ezStringBuilder s;
+        s.SetFormat("'{}' is a {}, so 'set' needs an 'index' saying which element to write. Use 'insert' to add a new one.",
+          sProperty, ObjectToolCategoryToString(category));
+        out_result.SetError(s);
+        return;
+      }
+
+      ezStringBuilder sIndexError;
+      if (index.IsValid() && ObjectToolValidateIndex(pAccessor, pObject, pProp, index, false, sIndexError).Failed())
+      {
+        pAccessor->CancelTransaction();
+        out_result.SetError(sIndexError);
+        return;
+      }
+
+      res = pAccessor->SetValueByName(pObject, sProperty, value, index);
+    }
+    else
+    {
+      if (category == ezPropertyCategory::Member)
+      {
+        pAccessor->CancelTransaction();
+        ezStringBuilder s;
+        s.SetFormat("'{}' is a single value, not a container, so it cannot be inserted into. Use 'set'.", sProperty);
+        out_result.SetError(s);
+        return;
+      }
+
+      ezVariant insertIndex = index;
+
+      if (!insertIndex.IsValid())
+      {
+        if (category == ezPropertyCategory::Map)
+        {
+          pAccessor->CancelTransaction();
+          ezStringBuilder s;
+          s.SetFormat("'{}' is a map, so 'insert' needs an 'index' giving the key to store the value under.", sProperty);
+          out_result.SetError(s);
+          return;
+        }
+
+        // Appending is what 'insert without an index' means for a caller, but the accessor takes an
+        // invalid index to mean 'no position' and fails with a message about a key called '<Invalid>'.
+        // Turning it into 'one past the last element' is what the caller intended.
+        ezInt32 iCount = 0;
+        pAccessor->GetCountByName(pObject, sProperty, iCount).IgnoreResult();
+        insertIndex = static_cast<ezUInt32>(ezMath::Max(iCount, 0));
+      }
+      else
+      {
+        ezStringBuilder sIndexError;
+        if (ObjectToolValidateIndex(pAccessor, pObject, pProp, insertIndex, true, sIndexError).Failed())
+        {
+          pAccessor->CancelTransaction();
+          out_result.SetError(sIndexError);
+          return;
+        }
+      }
+
+      res = pAccessor->InsertValueByName(pObject, sProperty, value, insertIndex);
+    }
+  }
+  else if (sOperation == "remove")
+  {
+    if (!index.IsValid())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError("'remove' needs an 'index' saying which element to remove.");
+      return;
+    }
+
+    ezStringBuilder sIndexError;
+    if (ObjectToolValidateIndex(pAccessor, pObject, pProp, index, false, sIndexError).Failed())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError(sIndexError);
+      return;
+    }
+
+    res = pAccessor->RemoveValueByName(pObject, sProperty, index);
+  }
+  else if (sOperation == "move")
+  {
+    const ezVariant newIndex = [&]()
+    {
+      const ezVariant* pNewIndex = ObjectToolGetRawValue(arguments, "newIndex");
+
+      if (pNewIndex == nullptr || !pNewIndex->IsValid())
+        return ezVariant();
+
+      if (category == ezPropertyCategory::Map)
+        return ezVariant(pNewIndex->ConvertTo<ezString>());
+
+      return pNewIndex->CanConvertTo<ezUInt32>() ? ezVariant(pNewIndex->ConvertTo<ezUInt32>()) : ezVariant();
+    }();
+
+    if (!index.IsValid() || !newIndex.IsValid())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError("'move' needs both 'index' and 'newIndex'.");
+      return;
+    }
+
+    ezStringBuilder sIndexError;
+
+    // The destination may be one past the end, which is how an element is moved to the back.
+    if (ObjectToolValidateIndex(pAccessor, pObject, pProp, index, false, sIndexError).Failed() ||
+        ObjectToolValidateIndex(pAccessor, pObject, pProp, newIndex, true, sIndexError).Failed())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError(sIndexError);
+      return;
+    }
+
+    res = pAccessor->MoveValueByName(pObject, sProperty, index, newIndex);
+  }
+  else if (sOperation == "addObject")
+  {
+    const ezStringView sType = ezMcpJson::GetString(arguments, "type");
+
+    if (sType.IsEmpty())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError("'addObject' needs a 'type' argument naming the type to create.");
+      return;
+    }
+
+    const ezRTTI* pType = ezRTTI::FindTypeByName(sType);
+
+    if (pType == nullptr)
+    {
+      pAccessor->CancelTransaction();
+      ezStringBuilder s;
+      s.SetFormat("'{}' is not a known type. 'rtti_derived_types' lists the types that derive from a given base.", sType);
+      out_result.SetError(s);
+      return;
+    }
+
+    // Instantiating a type the property cannot hold would either fail deep inside the accessor or
+    // produce an object that cannot be serialised, so it is checked here.
+    if (pProp->GetSpecificType() != nullptr && !pType->IsDerivedFrom(pProp->GetSpecificType()))
+    {
+      pAccessor->CancelTransaction();
+      ezStringBuilder s;
+      s.SetFormat("'{}' does not derive from '{}', which is what '{}' holds.", sType, pProp->GetSpecificType()->GetTypeName(), sProperty);
+      out_result.SetError(s);
+      return;
+    }
+
+    ezVariant addIndex = index;
+
+    // Adding into a container without saying where means appending, same as 'insert'.
+    if (!addIndex.IsValid() && (category == ezPropertyCategory::Array || category == ezPropertyCategory::Set))
+    {
+      ezInt32 iCount = 0;
+      pAccessor->GetCountByName(pObject, sProperty, iCount).IgnoreResult();
+      addIndex = static_cast<ezUInt32>(ezMath::Max(iCount, 0));
+    }
+    else if (addIndex.IsValid())
+    {
+      ezStringBuilder sIndexError;
+      if (ObjectToolValidateIndex(pAccessor, pObject, pProp, addIndex, true, sIndexError).Failed())
+      {
+        pAccessor->CancelTransaction();
+        out_result.SetError(sIndexError);
+        return;
+      }
+    }
+
+    // The object manager knows the rules that reflection does not: a scene refuses a component type
+    // that may only exist once on an object, or one that does not belong on this kind of object at all.
+    // Asking first turns a failed transaction into a message that says which rule was broken.
+    const ezStatus canAdd = pDocument->GetObjectManager()->CanAdd(pType, pObject, sProperty, addIndex);
+
+    if (canAdd.Failed())
+    {
+      pAccessor->CancelTransaction();
+      ezStringBuilder s;
+      s.SetFormat("'{}' cannot be added to '{}': {}", sType, sProperty, canAdd.GetMessageString());
+      out_result.SetError(s);
+      return;
+    }
+
+    ezUuid newObjectGuid;
+    res = pAccessor->AddObjectByName(pObject, sProperty, addIndex, pType, newObjectGuid);
+
+    if (res.Succeeded())
+      ezConversionUtils::ToString(newObjectGuid, sAddedObjectGuid);
+  }
+  else if (sOperation == "removeObject")
+  {
+    // GetChildObjectByName() reads through GetValueByName(), so an unchecked index asserts here too.
+    ezStringBuilder sIndexError;
+    if (index.IsValid() && ObjectToolValidateIndex(pAccessor, pObject, pProp, index, false, sIndexError).Failed())
+    {
+      pAccessor->CancelTransaction();
+      out_result.SetError(sIndexError);
+      return;
+    }
+
+    const ezDocumentObject* pChild = pAccessor->GetChildObjectByName(pObject, sProperty, index);
+
+    if (pChild == nullptr)
+    {
+      pAccessor->CancelTransaction();
+      ezStringBuilder s;
+      s.SetFormat("'{}' holds no object{} to remove.", sProperty, index.IsValid() ? " at that index" : "");
+      out_result.SetError(s);
+      return;
+    }
+
+    res = pAccessor->RemoveObject(pChild);
+  }
+  else
+  {
+    pAccessor->CancelTransaction();
+    ezStringBuilder s;
+    s.SetFormat("'{}' is not a valid operation. Use one of: set, insert, remove, move, addObject, removeObject.", sOperation);
+    out_result.SetError(s);
+    return;
+  }
+
+  if (res.Failed())
+  {
+    // Cancelling rather than finishing leaves no half applied step on the undo stack.
+    pAccessor->CancelTransaction();
+
+    ezStringBuilder s;
+    s.SetFormat("Could not {} '{}': {}", sOperation, sProperty, res.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  pAccessor->FinishTransaction();
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableString("property", sProperty);
+  writer.AddVariableString("operation", sOperation);
+
+  if (!sAddedObjectGuid.IsEmpty())
+    writer.AddVariableString("addedObject", sAddedObjectGuid);
+
+  writer.AddVariableBool("modified", pDocument->IsModified());
+
+  // Saying this on every successful change is repetitive, but an unsaved change is invisible to the
+  // asset system, and an agent that assumes otherwise transforms stale data.
+  writer.AddVariableString("note", "The document is not saved yet. Call 'document_save' to write it to disk.");
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpObjectTool::ExecuteDeleteObject(ezDocument* pDocument, const ezDocumentObject* pObject, ezObjectAccessorBase* pAccessor, ezMcpToolResult& out_result)
+{
+  const ezDocumentObjectManager* pManager = pDocument->GetObjectManager();
+
+  // No guard against deleting the root here: ezMcpDocument::ResolveObject() refuses to hand it out, which
+  // is where that case is caught for every tool at once.
+  //
+  // Asked before the transaction is opened: the manager refuses things the accessor would otherwise
+  // fail on deep inside, and its message says why - a component the scene requires, for instance.
+  const ezStatus canRemove = pManager->CanRemove(pObject);
+
+  if (canRemove.Failed())
+  {
+    ezStringBuilder s;
+    s.SetFormat("This object cannot be deleted: {}", canRemove.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  // Recorded before the object is gone, so the result can say what was deleted rather than only that
+  // something was.
+  const ezStringBuilder sName = ezMcpDocument::GetObjectName(pObject);
+  const ezStringView sType = pObject->GetType() != nullptr ? pObject->GetType()->GetTypeName() : ezStringView();
+  const ezUInt32 uiChildren = pObject->GetChildren().GetCount();
+
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(pObject->GetGuid(), sGuid);
+
+  pAccessor->StartTransaction("MCP: delete object");
+
+  const ezStatus res = pAccessor->RemoveObject(pObject);
+
+  if (res.Failed())
+  {
+    pAccessor->CancelTransaction();
+
+    ezStringBuilder s;
+    s.SetFormat("Could not delete the object: {}", res.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  pAccessor->FinishTransaction();
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("deletedObject", sGuid);
+
+  if (!sName.IsEmpty())
+    writer.AddVariableString("name", sName);
+
+  writer.AddVariableString("type", sType);
+
+  // A game object takes its children and components with it, which is the part that is easy to
+  // underestimate from a guid alone.
+  if (uiChildren > 0)
+    writer.AddVariableUInt32("deletedChildren", uiChildren);
+
+  writer.AddVariableBool("modified", pDocument->IsModified());
+  writer.AddVariableString("note", "The document is not saved yet. Call 'document_save' to write it to disk, or 'object_undo' to take "
+                                   "this back.");
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpObjectTool::ExecuteMoveObject(const ezVariantDictionary& arguments, ezDocument* pDocument, const ezDocumentObject* pObject,
+  ezObjectAccessorBase* pAccessor, ezMcpToolResult& out_result)
+{
+  const ezDocumentObjectManager* pManager = pDocument->GetObjectManager();
+  const ezStringView sNewParent = ezMcpJson::GetString(arguments, "newParent");
+
+  // No 'newParent' means reordering within the current one, which is the other thing a move is for.
+  const ezDocumentObject* pNewParent = pObject->GetParent();
+
+  if (!sNewParent.IsEmpty())
+  {
+    ezStringBuilder sParentError;
+    pNewParent = ezMcpDocument::ResolveObject(pDocument, sNewParent, sParentError);
+
+    if (pNewParent == nullptr)
+    {
+      out_result.SetError(sParentError);
+      return;
+    }
+  }
+
+  if (pNewParent == nullptr)
+  {
+    out_result.SetError("The object has no parent to move it within, and no 'newParent' was given.");
+    return;
+  }
+
+  // Keeping the object's own parent property is what makes moving a game object between parents a
+  // single argument: a child stays under 'Children', a component under 'Components'.
+  ezStringView sProperty = ezMcpJson::GetString(arguments, "property");
+
+  if (sProperty.IsEmpty())
+    sProperty = pObject->GetParentProperty();
+
+  if (sProperty.IsEmpty())
+  {
+    out_result.SetError("Could not tell which property of the new parent to move the object into. Pass 'property', e.g. 'Children'.");
+    return;
+  }
+
+  ezVariant index = ObjectToolGetIndex(arguments, ezPropertyCategory::Array);
+
+  if (!index.IsValid())
+  {
+    // Append. The count is read from the new parent, so moving to the end of a different parent works
+    // without the caller knowing how many children it has.
+    ezInt32 iCount = 0;
+    pAccessor->GetCountByName(pNewParent, sProperty, iCount).IgnoreResult();
+    index = static_cast<ezUInt32>(ezMath::Max(iCount, 0));
+  }
+
+  // CanMove() is what rejects moving an object onto itself or into its own child, which would otherwise
+  // detach that whole branch from the document. It also covers what CanAdd() and CanRemove() check.
+  const ezStatus canMove = pManager->CanMove(pObject, pNewParent, sProperty, index);
+
+  if (canMove.Failed())
+  {
+    ezStringBuilder s;
+    s.SetFormat("This object cannot be moved there: {}", canMove.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  pAccessor->StartTransaction("MCP: move object");
+
+  const ezStatus res = pAccessor->MoveObjectByName(pObject, pNewParent, sProperty, index);
+
+  if (res.Failed())
+  {
+    pAccessor->CancelTransaction();
+
+    ezStringBuilder s;
+    s.SetFormat("Could not move the object: {}", res.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  pAccessor->FinishTransaction();
+
+  ezStringBuilder sGuid, sParentGuid;
+  ezConversionUtils::ToString(pObject->GetGuid(), sGuid);
+  ezConversionUtils::ToString(pNewParent->GetGuid(), sParentGuid);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("movedObject", sGuid);
+  writer.AddVariableString("newParent", sParentGuid);
+  writer.AddVariableString("property", sProperty);
+  writer.AddVariableVariant("index", index);
+
+  // A game object keeps its local transform, so it lands wherever the new parent's transform puts it -
+  // not where it appeared to be before. Worth saying, because the agent cannot see the viewport.
+  writer.AddVariableString("note", "The object keeps its local position and rotation, so its position in the world follows the new "
+                                   "parent's transform. The document is not saved yet.");
+
+  writer.AddVariableBool("modified", pDocument->IsModified());
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpObjectTool::ExecuteDuplicateObject(const ezVariantDictionary& arguments, ezDocument* pDocument, const ezDocumentObject* pObject,
+  ezMcpToolResult& out_result)
+{
+  const ezStringView sNewParent = ezMcpJson::GetString(arguments, "newParent");
+
+  const ezDocumentObject* pParent = pObject->GetParent();
+
+  if (!sNewParent.IsEmpty())
+  {
+    ezStringBuilder sParentError;
+    pParent = ezMcpDocument::ResolveObject(pDocument, sNewParent, sParentError);
+
+    if (pParent == nullptr)
+    {
+      out_result.SetError(sParentError);
+      return;
+    }
+  }
+
+  if (pParent == nullptr)
+  {
+    // Only reachable for an object that sits in no parent at all. Checked because everything below reads
+    // through it, and a null dereference here would take the editor down instead of failing the call.
+    out_result.SetError("The object has no parent to duplicate it into, and no 'newParent' was given.");
+    return;
+  }
+
+  ezSelectionManager* pSelection = pDocument->GetSelectionManager();
+
+  if (pSelection == nullptr)
+  {
+    out_result.SetError("This document type has no selection, so nothing can be copied out of it.");
+    return;
+  }
+
+  // CopySelectedObjects() works off the selection - that is the only entry point the documents
+  // implement, there is no 'copy this object' call. Restored right after, so a failed copy does not
+  // leave the selection moved. Note the paste below selects what it created, exactly as the editor's
+  // own paste does, so the selection does not survive a successful duplicate - that is reported rather
+  // than undone, because seeing the new object selected is useful to the user watching.
+  const ezDeque<const ezDocumentObject*> previousSelection = pSelection->GetSelection();
+
+  ezAbstractObjectGraph graph;
+  ezStringBuilder sMimeType;
+
+  pSelection->SetSelection(pObject);
+  const bool bCopied = pDocument->CopySelectedObjects(graph, sMimeType);
+  pSelection->SetSelection(previousSelection);
+
+  if (!bCopied)
+  {
+    out_result.SetError("This document type does not support copying objects, so they cannot be duplicated either. Create the object "
+                        "with 'addObject' and set its properties instead.");
+    return;
+  }
+
+  // The paste command takes the graph as text, the same way the editor's own copy and paste do.
+  ezContiguousMemoryStreamStorage streamStorage;
+  ezMemoryStreamWriter memoryWriter(&streamStorage);
+  ezAbstractGraphDdlSerializer::Write(memoryWriter, &graph, nullptr, false);
+  memoryWriter.WriteBytes("\0", 1).IgnoreResult();
+
+  // Which children the parent had before, so the new object can be identified afterwards: the paste
+  // command keeps the objects it created to itself.
+  ezHybridArray<ezUuid, 16> before;
+  for (const ezDocumentObject* pChild : pParent->GetChildren())
+  {
+    before.PushBack(pChild->GetGuid());
+  }
+
+  ezPasteObjectsCommand cmd;
+  cmd.m_Parent = pParent->GetGuid();
+  cmd.m_sMimeType = sMimeType;
+  cmd.m_sGraphTextFormat = reinterpret_cast<const char*>(streamStorage.GetData());
+
+  // The picked position is where the user's mouse last pointed in a viewport, which is meaningless for
+  // a tool call and would drop the copy somewhere unrelated.
+  cmd.m_bAllowPickedPosition = false;
+
+  ezCommandHistory* pHistory = pDocument->GetCommandHistory();
+
+  pHistory->StartTransaction("MCP: duplicate object");
+
+  const ezStatus res = pHistory->AddCommand(cmd);
+
+  if (res.Failed())
+  {
+    pHistory->CancelTransaction();
+
+    ezStringBuilder s;
+    s.SetFormat("Could not duplicate the object: {}", res.GetMessageString());
+    out_result.SetError(s);
+    return;
+  }
+
+  pHistory->FinishTransaction();
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(pObject->GetGuid(), sGuid);
+  writer.AddVariableString("sourceObject", sGuid);
+
+  ezConversionUtils::ToString(pParent->GetGuid(), sGuid);
+  writer.AddVariableString("parent", sGuid);
+
+  writer.BeginArray("addedObjects");
+  for (const ezDocumentObject* pChild : pParent->GetChildren())
+  {
+    if (before.Contains(pChild->GetGuid()))
+      continue;
+
+    ezStringBuilder sNewGuid;
+    ezConversionUtils::ToString(pChild->GetGuid(), sNewGuid);
+    writer.WriteString(sNewGuid);
+  }
+  writer.EndArray();
+
+  writer.AddVariableBool("modified", pDocument->IsModified());
+  writer.AddVariableString("note", "The copy sits at the same position as the original, so it is hidden inside it until it is moved "
+                                   "('moveObject', or set its LocalPosition). It is now the document's selection, as it would be "
+                                   "after pasting in the editor. The document is not saved yet.");
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpObjectTool::ExecuteUndo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return;
+  }
+
+  ezCommandHistory* pHistory = pDocument->GetCommandHistory();
+
+  if (pHistory == nullptr)
+  {
+    out_result.SetError("The document has no command history.");
+    return;
+  }
+
+  const ezStringView sAction = ezMcpJson::GetString(arguments, "action");
+  const ezUInt32 uiCount = static_cast<ezUInt32>(ezMath::Max<ezInt64>(ezMcpJson::GetInt(arguments, "count", 1), 1));
+
+  ezUInt32 uiDone = 0;
+  ezStringBuilder sFailure;
+
+  if (sAction == "undo")
+  {
+    for (ezUInt32 i = 0; i < uiCount && pHistory->CanUndo(); ++i)
+    {
+      if (pHistory->Undo().Failed())
+      {
+        sFailure = "Undo failed.";
+        break;
+      }
+
+      ++uiDone;
+    }
+
+    // Distinguishes 'nothing to undo' from 'undo did not work', which call for different responses.
+    if (uiDone == 0 && sFailure.IsEmpty())
+      sFailure = "There is nothing to undo in this document.";
+  }
+  else if (sAction == "redo")
+  {
+    for (ezUInt32 i = 0; i < uiCount && pHistory->CanRedo(); ++i)
+    {
+      if (pHistory->Redo().Failed())
+      {
+        sFailure = "Redo failed.";
+        break;
+      }
+
+      ++uiDone;
+    }
+
+    if (uiDone == 0 && sFailure.IsEmpty())
+      sFailure = "There is nothing to redo in this document.";
+  }
+  else if (!sAction.IsEmpty())
+  {
+    ezStringBuilder s;
+    s.SetFormat("'{}' is not a valid action. Use 'undo' or 'redo', or omit it to only report the stack.", sAction);
+    out_result.SetError(s);
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  if (!sAction.IsEmpty())
+  {
+    writer.AddVariableString("action", sAction);
+    writer.AddVariableUInt32("stepsPerformed", uiDone);
+  }
+
+  writer.AddVariableBool("canUndo", pHistory->CanUndo());
+  writer.AddVariableBool("canRedo", pHistory->CanRedo());
+  writer.AddVariableBool("modified", pDocument->IsModified());
+
+  if (!sFailure.IsEmpty())
+    writer.AddVariableString("error", sFailure);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+
+  // Asking to undo when there is nothing to undo is a failed call, not a silent no-op.
+  out_result.m_bIsError = !sFailure.IsEmpty();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezDocument;
+class ezDocumentObject;
+class ezObjectAccessorBase;
+class ezMcpJsonWriter;
+class ezAbstractProperty;
+
+/// \brief Reads and modifies the properties of the objects inside a document.
+///
+/// The unit of addressing is one object plus one property name. An object is named by its guid, or
+/// implicitly: every tool here defaults to the document's top level object, which for the asset types
+/// deriving from ezSimpleAssetDocument is the single object holding all of the asset's settings.
+///
+/// Only direct properties are read. A property whose value is another object reports that object's
+/// guid instead of its contents, so walking a tree is a sequence of calls rather than one large
+/// response - the same listing/detail split the rest of the tools use.
+///
+/// Modifications go through the document's ezObjectCommandAccessor, so each one is a single undoable
+/// transaction. Nothing here saves; that stays an explicit ezMcpDocumentTool call.
+class ezMcpObjectTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpObjectTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteTree(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteReadProperties(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteModify(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteUndo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// Deletes one object, wherever it sits in the document.
+  ///
+  /// This and the two below are split out of ExecuteModify() because they address an object rather than
+  /// a property of one: 'property' either does not apply or names a property of a *different* object,
+  /// so the lookup ExecuteModify() does before dispatching would be wrong for them.
+  void ExecuteDeleteObject(ezDocument* pDocument, const ezDocumentObject* pObject, ezObjectAccessorBase* pAccessor, ezMcpToolResult& out_result);
+
+  /// Moves one object to a different parent, or to a different place under the same one.
+  void ExecuteMoveObject(const ezVariantDictionary& arguments, ezDocument* pDocument, const ezDocumentObject* pObject,
+    ezObjectAccessorBase* pAccessor, ezMcpToolResult& out_result);
+
+  /// Copies one object, with everything below it, into a parent.
+  void ExecuteDuplicateObject(const ezVariantDictionary& arguments, ezDocument* pDocument, const ezDocumentObject* pObject,
+    ezMcpToolResult& out_result);
+
+  /// Writes one object of the hierarchy and, while there is depth and budget left, its children.
+  ///
+  /// \param uiRemainingDepth How many more levels to descend. Zero still writes the object itself, but
+  ///        reports its children as a count only.
+  /// \param ref_uiBudget Objects left before the response is truncated. Shared across the whole walk,
+  ///        so a wide hierarchy runs out at the same total size a deep one does.
+  static void WriteTreeNode(ezMcpJsonWriter& ref_writer, const ezDocumentObject* pObject, ezUInt32 uiRemainingDepth, ezUInt32& ref_uiBudget);
+
+  /// Writes one property's name, category, type and current value.
+  ///
+  /// Containers report their element count and, for maps, their keys, but not their elements - those
+  /// are a follow up call with an index. Values that are objects report a guid for the same reason.
+  static void WritePropertyValue(ezMcpJsonWriter& ref_writer, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject,
+    const ezAbstractProperty* pProp, bool bIncludeValues);
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ProjectTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ProjectTool.cpp
@@ -1,8 +1,8 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
+#include <EditorPluginMcp/McpTools/ProjectTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
-#include <EditorPluginMcp/McpTools/ProjectTool.h>
 
 #include <Foundation/Configuration/Plugin.h>
 

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ProjectTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ProjectTool.cpp
@@ -1,0 +1,212 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <EditorPluginMcp/McpTools/ProjectTool.h>
+
+#include <Foundation/Configuration/Plugin.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorFramework/Project/ProjectExport.h>
+#include <ToolsFoundation/Project/ToolsProject.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpProjectTool, 1, ezRTTIDefaultAllocator<ezMcpProjectTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezMcpProjectTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+  desc.m_sName = "project_info";
+  desc.m_sDescription = "Returns which project the editor currently has open: its name, the project directory, the configured "
+                        "data directories, the asset profiles and the loaded plugins. Call this first - paths returned by other "
+                        "tools are relative to these data directories, asset transform states depend on the active profile, and "
+                        "the loaded plugins determine which reflected types exist.";
+  desc.m_sInputSchema = R"({"type":"object","properties":{}})";
+
+  ezMcpToolDesc& exp = out_tools.ExpandAndGetRef();
+  exp.m_sName = "project_export";
+  exp.m_sDescription = "Exports the open project into a standalone, runnable directory - the same operation as the editor's "
+                       "'Export Project' dialog, which cannot be used through action_execute. Builds the project's C++ plugin, "
+                       "transforms all assets and then writes the runtime binaries, the transformed assets and launch scripts "
+                       "to the target directory. Both preparation steps can be turned off, but only do that when you know they "
+                       "have just been done - otherwise the export contains stale or missing assets.\n"
+                       "IMPORTANT - the target directory is DELETED before the export, so never point this at a directory that "
+                       "holds anything else, in particular not at the project directory itself.\n"
+                       "This runs for a long time: transforming the assets of a project that was never transformed takes many "
+                       "minutes, during which the editor answers nothing else. Use a generous timeout - 30 minutes rather than "
+                       "30 seconds - and see app_ping for telling a slow export apart from a hung editor. The export log is "
+                       "returned and also written to 'ExportLog.txt' in the target directory.";
+  exp.m_sInputSchema = R"({"type":"object","properties":{)"
+                       R"("targetDirectory":{"type":"string","description":"Absolute path of the directory to export into. It is deleted and recreated. Must not be inside the project directory."},)"
+                       R"("compileCppPlugin":{"type":"boolean","description":"Build the project's C++ plugin first, so the exported binaries match the current code. Default true. Has no effect on a project without C++ code."},)"
+                       R"("transformAssets":{"type":"boolean","description":"Transform all assets first. Default true. With this off, assets modified since the last transform are exported in their old state, and assets never transformed for the active profile are missing entirely."},)"
+                       R"("createLaunchScripts":{"type":"boolean","description":"Write .bat files for starting the exported project. Default true."}},)"
+                       R"("required":["targetDirectory"]})";
+}
+
+void ezMcpProjectTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "project_info")
+  {
+    ExecuteProjectInfo(arguments, out_result);
+  }
+  else if (sToolName == "project_export")
+  {
+    ExecuteProjectExport(arguments, out_result);
+  }
+}
+
+void ezMcpProjectTool::ExecuteProjectInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  // Reported explicitly rather than as an error, because "no project open" is a legitimate state that
+  // the agent has to be able to observe - it explains why every other tool returns nothing.
+  const bool bProjectOpen = ezToolsProject::IsProjectOpen();
+  writer.AddVariableBool("projectOpen", bProjectOpen);
+
+  if (!bProjectOpen)
+  {
+    writer.EndObject();
+    out_result.m_sText = writer.GetResult();
+    return;
+  }
+
+  const ezToolsProject* pProject = ezToolsProject::GetSingleton();
+
+  writer.AddVariableString("projectName", pProject->GetProjectName(false));
+  writer.AddVariableString("projectDirectory", pProject->GetProjectDirectory());
+  writer.AddVariableString("projectFile", pProject->GetProjectFile());
+  writer.AddVariableString("projectDataFolder", pProject->GetProjectDataFolder());
+
+  // The configured directories, not the mounted ones: these are what asset paths are expressed
+  // relative to, and the root name is the '>rootname/...' prefix that shows up in those paths.
+  writer.BeginArray("dataDirectories");
+  for (const auto& dd : ezQtEditorApp::GetSingleton()->GetFileSystemConfig().m_DataDirs)
+  {
+    writer.BeginObject();
+    writer.AddVariableString("path", dd.m_sDataDirSpecialPath);
+    writer.AddVariableString("rootName", dd.m_sRootName);
+    writer.AddVariableBool("writable", dd.m_bWritable);
+    // set for directories the project depends on, which the user cannot remove in the settings dialog
+    writer.AddVariableBool("hardCodedDependency", dd.m_bHardCodedDependency);
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  if (const ezAssetCurator* pCurator = ezAssetCurator::GetSingleton())
+  {
+    if (const ezPlatformProfile* pActive = pCurator->GetActiveAssetProfile())
+    {
+      writer.AddVariableString("activeAssetProfile", pActive->GetConfigName());
+    }
+
+    writer.BeginArray("assetProfiles");
+    for (ezUInt32 i = 0; i < pCurator->GetNumAssetProfiles(); ++i)
+    {
+      if (const ezPlatformProfile* pProfile = pCurator->GetAssetProfile(i))
+      {
+        writer.WriteString(pProfile->GetConfigName());
+      }
+    }
+    writer.EndArray();
+  }
+
+  // Which plugins are loaded determines which reflected types exist at all, so this is the companion
+  // to the 'plugin' field that rtti_type_info returns for a type.
+  ezDynamicArray<ezPlugin::PluginInfo> pluginInfos;
+  ezPlugin::GetAllPluginInfos(pluginInfos);
+
+  writer.BeginArray("loadedPlugins");
+  for (const ezPlugin::PluginInfo& info : pluginInfos)
+  {
+    writer.BeginObject();
+    writer.AddVariableString("name", info.m_sName);
+
+    writer.BeginArray("dependencies");
+    for (const ezString& sDep : info.m_sDependencies)
+    {
+      writer.WriteString(sDep);
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpProjectTool::ExecuteProjectExport(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (!ezToolsProject::IsProjectOpen())
+  {
+    out_result.SetError("No project is open, so there is nothing to export.");
+    return;
+  }
+
+  ezStringBuilder sTargetDir = ezMcpJson::GetString(arguments, "targetDirectory");
+  sTargetDir.MakeCleanPath();
+  sTargetDir.Trim("", "/");
+
+  if (sTargetDir.IsEmpty())
+  {
+    out_result.SetError("No 'targetDirectory' given.");
+    return;
+  }
+
+  if (!sTargetDir.IsAbsolutePath())
+  {
+    out_result.SetError(ezStringBuilder("'", sTargetDir, "' is not an absolute path. The export target is not resolved against "
+                                                         "the project or any data directory, so it has to be a full path."));
+    return;
+  }
+
+  // The export clears the target directory first, so an unlucky path would delete the project. Checked
+  // here rather than deeper down because this is the only caller whose argument comes from a model that
+  // has never seen the folder it is naming.
+  ezStringBuilder sProjectDir = ezToolsProject::GetSingleton()->GetProjectDirectory();
+  sProjectDir.MakeCleanPath();
+  sProjectDir.Trim("", "/");
+
+  if (ezPathUtils::IsSubPath_NoCase(sTargetDir, sProjectDir) || ezPathUtils::IsSubPath_NoCase(sProjectDir, sTargetDir))
+  {
+    out_result.SetError(ezStringBuilder("Refusing to export to '", sTargetDir, "', because it overlaps with the project directory '",
+      sProjectDir, "'. The target directory is deleted before the export, which would destroy the project. Pick a directory outside of it."));
+    return;
+  }
+
+  ezProjectExportOptions options;
+  options.m_bCompileCppPlugin = ezMcpJson::GetBool(arguments, "compileCppPlugin", true);
+  options.m_bTransformAssets = ezMcpJson::GetBool(arguments, "transformAssets", true);
+  options.m_bCreateLaunchScripts = ezMcpJson::GetBool(arguments, "createLaunchScripts", true);
+
+  ezStringBuilder sLog;
+  const ezStatus status = ezProjectExport::ExportProjectComplete(sTargetDir, options, &sLog);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableBool("exported", status.Succeeded());
+  writer.AddVariableString("targetDirectory", sTargetDir);
+
+  if (status.Failed())
+  {
+    writer.AddVariableString("error", status.GetMessageString());
+  }
+
+  // The whole log, not a summary: it is the only record of what was written and which assets failed, and
+  // an export that "succeeded" can still have skipped things that only show up here.
+  writer.AddVariableString("log", sLog);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+  out_result.m_bIsError = status.Failed();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ProjectTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ProjectTool.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+/// \brief Information about the project that the editor currently has open.
+///
+/// This is what orients an agent that has just connected: every path an other tool returns is
+/// relative to the data directories reported here, and asset states depend on the active profile.
+class ezMcpProjectTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpProjectTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteProjectInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteProjectExport(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/SelectionTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/SelectionTool.cpp
@@ -1,9 +1,9 @@
 #include <EditorPluginMcp/EditorPluginMcpPCH.h>
 
 #include <EditorPluginMcp/McpDocument.h>
+#include <EditorPluginMcp/McpTools/SelectionTool.h>
 #include <Mcp/McpJson.h>
 #include <Mcp/McpJsonWriter.h>
-#include <EditorPluginMcp/McpTools/SelectionTool.h>
 
 #include <Foundation/Utilities/ConversionUtils.h>
 #include <ToolsFoundation/Document/Document.h>

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/SelectionTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/SelectionTool.cpp
@@ -1,0 +1,208 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <EditorPluginMcp/McpDocument.h>
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <EditorPluginMcp/McpTools/SelectionTool.h>
+
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Object/DocumentObjectManager.h>
+#include <ToolsFoundation/Selection/SelectionManager.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpSelectionTool, 1, ezRTTIDefaultAllocator<ezMcpSelectionTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezMcpSelectionTool::WriteObject(ezMcpJsonWriter& ref_writer, const ezDocumentObject* pObject)
+{
+  ref_writer.BeginObject();
+
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(pObject->GetGuid(), sGuid);
+  ref_writer.AddVariableString("guid", sGuid);
+
+  const ezString sName = ezMcpDocument::GetObjectName(pObject);
+  if (!sName.IsEmpty())
+    ref_writer.AddVariableString("name", sName);
+
+  const ezRTTI* pType = pObject->GetType();
+  ref_writer.AddVariableString("type", pType != nullptr ? pType->GetTypeName() : ezStringView());
+
+  ref_writer.EndObject();
+}
+
+void ezMcpSelectionTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "selection_get";
+    desc.m_sDescription =
+      "Returns which objects are selected in an open document, with their guid, name and type. Use it to find out what a user means "
+      "by 'this object' or 'the selected one' before acting on it. "
+      "Reports the selection in the order the objects were added, and separately the top level selection, which drops objects whose "
+      "parent is also selected - that is the set an operation should usually act on, because acting on both a parent and its child "
+      "applies the change twice.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document. 'document_list' reports both."})"
+                          R"(},"required":["document"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "selection_set";
+    desc.m_sDescription =
+      "Selects objects in an open document, which is how to show a user what is being talked about instead of describing it - the "
+      "editor highlights the selection in its viewport and shows it in the property grid. Guids come from 'object_tree'. "
+      "Pass an empty list to clear the selection. Objects are selected as given; guids that the document does not know are reported "
+      "back rather than failing the call, so a partly stale list still selects what it can. The selection is not part of the "
+      "document and is not saved, so this needs no undo and does not modify anything. "
+      "A document opened without a window has a selection too, but nobody can see it.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("document":{"type":"string","description":"Guid or path of an open document."},)"
+                          R"("objects":{"type":"array","items":{"type":"string"},"description":"Guids of the objects to select, as reported by 'object_tree'. An empty array clears the selection."})"
+                          R"(},"required":["document","objects"]})";
+  }
+}
+
+void ezMcpSelectionTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "selection_get")
+    ExecuteGet(arguments, out_result);
+  else if (sToolName == "selection_set")
+    ExecuteSet(arguments, out_result);
+}
+
+void ezMcpSelectionTool::ExecuteGet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return;
+  }
+
+  const ezSelectionManager* pSelection = pDocument->GetSelectionManager();
+
+  if (pSelection == nullptr)
+  {
+    out_result.SetError("This document type has no selection.");
+    return;
+  }
+
+  ezDynamicArray<ezSelectionEntry> topLevel;
+  pSelection->GetTopLevelSelection(topLevel);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("document", pDocument->GetDocumentPath());
+  writer.AddVariableUInt32("count", pSelection->GetSelection().GetCount());
+
+  writer.BeginArray("selection");
+  for (const ezDocumentObject* pObject : pSelection->GetSelection())
+  {
+    WriteObject(writer, pObject);
+  }
+  writer.EndArray();
+
+  writer.BeginArray("topLevelSelection");
+  for (const ezSelectionEntry& entry : topLevel)
+  {
+    WriteObject(writer, entry.m_pObject);
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpSelectionTool::ExecuteSet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return;
+  }
+
+  ezSelectionManager* pSelection = pDocument->GetSelectionManager();
+
+  if (pSelection == nullptr)
+  {
+    out_result.SetError("This document type has no selection.");
+    return;
+  }
+
+  ezDynamicArray<ezString> objectGuids;
+
+  // An absent 'objects' is a mistake worth reporting; an empty one is the documented way to clear the
+  // selection, and the two are indistinguishable once the list is in hand.
+  if (!ezMcpJson::GetStringArray(arguments, "objects", objectGuids))
+  {
+    out_result.SetError("Argument 'objects' is required and has to be an array of object guids. Pass an empty array to clear the "
+                        "selection.");
+    return;
+  }
+
+  const ezDocumentObjectManager* pManager = pDocument->GetObjectManager();
+
+  ezDeque<const ezDocumentObject*> selection;
+  ezHybridArray<ezString, 4> unknown;
+
+  for (const ezString& sGuid : objectGuids)
+  {
+    // IsStringUuid() first: ConvertStringToUuid() asserts on anything that is not one, and this input
+    // comes straight from a language model.
+    if (!ezConversionUtils::IsStringUuid(sGuid))
+    {
+      unknown.PushBack(sGuid);
+      continue;
+    }
+
+    const ezDocumentObject* pObject = pManager->GetObject(ezConversionUtils::ConvertStringToUuid(sGuid));
+
+    if (pObject == nullptr)
+    {
+      unknown.PushBack(sGuid);
+      continue;
+    }
+
+    selection.PushBack(pObject);
+  }
+
+  pSelection->SetSelection(selection);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("document", pDocument->GetDocumentPath());
+  writer.AddVariableUInt32("selected", selection.GetCount());
+
+  if (!unknown.IsEmpty())
+  {
+    // Named individually: with a partial match the caller needs to know which of its guids went
+    // nowhere, and a count would send it back to object_tree for all of them.
+    writer.BeginArray("unknownObjects");
+    for (const ezString& sGuid : unknown)
+    {
+      writer.WriteString(sGuid);
+    }
+    writer.EndArray();
+
+    writer.AddVariableString("note", "These guids are not objects of this document. Object guids are per editor session and change when "
+                                     "a document is closed and reopened - list the current ones with 'object_tree'.");
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/SelectionTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/SelectionTool.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezDocumentObject;
+class ezMcpJsonWriter;
+
+/// \brief Reads and sets the selection of an open document.
+///
+/// The selection is the one piece of editor state that is visible to both sides: it is what a user
+/// means by "this object", and setting it is how an agent points at something instead of describing
+/// it. It is per document and is not saved.
+///
+/// Selecting an object does not require its window to exist, but a document that was opened without
+/// one shows nothing, so a selection meant for the user to see belongs to a document they have open.
+class ezMcpSelectionTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpSelectionTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteGet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteSet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// Writes guid, name and type - enough to recognise an object without a second call per entry.
+  static void WriteObject(ezMcpJsonWriter& ref_writer, const ezDocumentObject* pObject);
+};

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/finalize.cmake
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/finalize.cmake
@@ -1,0 +1,6 @@
+if (TARGET Editor AND TARGET EditorPluginMcp)
+
+    # Make sure this project is built when the Editor is built
+    add_dependencies(Editor EditorPluginMcp)
+
+endif()

--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -263,6 +263,17 @@ public:
 
   ezCopyOnBroadcastEvent<const ezGameApplicationExecutionEvent&> m_ExecutionEvents;
 
+  /// \brief Lets a plugin report that it has work which nothing else is going to wake the app up for.
+  ///
+  /// Only relevant to an application whose main loop *blocks* when it has nothing to do. A game that
+  /// free-runs never asks. The one that does is the editor's engine process, which normally sleeps
+  /// until the editor sends it a message - a plugin listening on a socket there would otherwise not be
+  /// serviced until the user happens to touch the editor.
+  ///
+  /// Returning true makes such an application come around again promptly instead of sleeping. Kept as a
+  /// delegate so that neither side needs to know what the other's work is.
+  ezDelegate<bool()> m_HasPendingExternalWork;
+
   ezTime GetFrameTime() const { return m_FrameTime; }
 
   /// The overridden version also quits the application when the active game state signals to quit.

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -7,6 +7,7 @@
 #include <Core/Prefabs/PrefabResource.h>
 #include <Foundation/IO/FileSystem/DataDirTypeFolder.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
+#include <Foundation/Utilities/CommandLineUtils.h>
 #include <GameEngine/Animation/PropertyAnimResource.h>
 #include <GameEngine/GameApplication/GameApplication.h>
 #include <GameEngine/StateMachine/StateMachineResource.h>
@@ -284,6 +285,18 @@ void ezGameApplication::Init_LoadRequiredPlugins()
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   ezPlugin::LoadPlugin("ezInspectorPlugin").IgnoreResult();
+
+  // The MCP server is a development-only tool, so it is not part of the project's plugin config and thus
+  // never ends up in a shipping build. Load it on demand instead, when a port was actually requested.
+  // In the editor's engine process this is not needed - there the Mcp plugin bundle pulls it in.
+  if (ezCommandLineUtils::GetGlobalInstance()->HasOption("-mcpport") ||
+      ezCommandLineUtils::GetGlobalInstance()->HasOption("-editor-mcpport"))
+  {
+    if (ezPlugin::LoadPlugin("ezMcpPlugin", ezPluginLoadFlags::PluginIsOptional).Failed())
+    {
+      ezLog::Warning("An MCP port was given on the command line, but 'ezMcpPlugin' could not be loaded.");
+    }
+  }
 
   // on sandboxed platforms, we can only load data through fileserve, so enforce use of this plugin
 #  if EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)

--- a/Code/Engine/Mcp/CMakeLists.txt
+++ b/Code/Engine/Mcp/CMakeLists.txt
@@ -1,6 +1,6 @@
 ez_cmake_init()
 
-
+ez_requires_desktop()
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)

--- a/Code/Engine/Mcp/CMakeLists.txt
+++ b/Code/Engine/Mcp/CMakeLists.txt
@@ -1,0 +1,25 @@
+ez_cmake_init()
+
+
+
+# Get the name of this folder as the project name
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
+
+ez_create_target(LIBRARY ${PROJECT_NAME})
+
+ez_enable_strict_warnings(${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  Foundation
+)
+
+# the transport is a plain TCP listener, so it needs the platform's socket library
+if (EZ_CMAKE_PLATFORM_WINDOWS)
+
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    Ws2_32.lib
+  )
+
+endif()

--- a/Code/Engine/Mcp/McpDLL.h
+++ b/Code/Engine/Mcp/McpDLL.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+
+// Configure the DLL Import/Export Define
+#if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)
+#  ifdef BUILDSYSTEM_BUILDING_MCP_LIB
+#    define EZ_MCP_DLL EZ_DECL_EXPORT
+#  else
+#    define EZ_MCP_DLL EZ_DECL_IMPORT
+#  endif
+#else
+#  define EZ_MCP_DLL
+#endif

--- a/Code/Engine/Mcp/McpJson.cpp
+++ b/Code/Engine/Mcp/McpJson.cpp
@@ -1,0 +1,109 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJson.h>
+
+#include <Foundation/Utilities/ConversionUtils.h>
+
+ezStringView ezMcpJson::GetString(const ezVariantDictionary& dict, ezStringView sKey, ezStringView sFallback)
+{
+  const ezVariant* pValue = nullptr;
+
+  if (dict.TryGetValue(sKey, pValue) && pValue->IsA<ezString>())
+  {
+    return pValue->Get<ezString>().GetView();
+  }
+
+  return sFallback;
+}
+
+ezInt64 ezMcpJson::GetInt(const ezVariantDictionary& dict, ezStringView sKey, ezInt64 iFallback)
+{
+  const ezVariant* pValue = nullptr;
+
+  if (!dict.TryGetValue(sKey, pValue) || !pValue->IsValid())
+    return iFallback;
+
+  if (pValue->IsNumber())
+    return static_cast<ezInt64>(pValue->ConvertTo<double>());
+
+  if (pValue->IsA<ezString>())
+  {
+    ezInt64 iResult = 0;
+    if (ezConversionUtils::StringToInt64(pValue->Get<ezString>(), iResult).Succeeded())
+      return iResult;
+  }
+
+  return iFallback;
+}
+
+bool ezMcpJson::GetBool(const ezVariantDictionary& dict, ezStringView sKey, bool bFallback)
+{
+  const ezVariant* pValue = nullptr;
+
+  if (!dict.TryGetValue(sKey, pValue) || !pValue->IsValid())
+    return bFallback;
+
+  if (pValue->IsA<bool>())
+    return pValue->Get<bool>();
+
+  if (pValue->IsNumber())
+    return pValue->ConvertTo<double>() != 0.0;
+
+  if (pValue->IsA<ezString>())
+  {
+    bool bResult = false;
+    if (ezConversionUtils::StringToBool(pValue->Get<ezString>(), bResult) == EZ_SUCCESS)
+      return bResult;
+  }
+
+  return bFallback;
+}
+
+bool ezMcpJson::GetStringArray(const ezVariantDictionary& dict, ezStringView sKey, ezDynamicArray<ezString>& out_values)
+{
+  const ezVariant* pValue = nullptr;
+
+  if (!dict.TryGetValue(sKey, pValue) || !pValue->IsValid())
+    return false;
+
+  if (pValue->IsA<ezString>())
+  {
+    out_values.PushBack(pValue->Get<ezString>());
+    return true;
+  }
+
+  if (!pValue->IsA<ezVariantArray>())
+    return false;
+
+  for (const ezVariant& element : pValue->Get<ezVariantArray>())
+  {
+    if (element.CanConvertTo<ezString>())
+      out_values.PushBack(element.ConvertTo<ezString>());
+  }
+
+  return true;
+}
+
+const ezVariantDictionary* ezMcpJson::GetDict(const ezVariantDictionary& dict, ezStringView sKey)
+{
+  const ezVariant* pValue = nullptr;
+
+  if (dict.TryGetValue(sKey, pValue) && pValue->IsA<ezVariantDictionary>())
+  {
+    return &pValue->Get<ezVariantDictionary>();
+  }
+
+  return nullptr;
+}
+
+const ezVariantArray* ezMcpJson::GetArray(const ezVariantDictionary& dict, ezStringView sKey)
+{
+  const ezVariant* pValue = nullptr;
+
+  if (dict.TryGetValue(sKey, pValue) && pValue->IsA<ezVariantArray>())
+  {
+    return &pValue->Get<ezVariantArray>();
+  }
+
+  return nullptr;
+}

--- a/Code/Engine/Mcp/McpJson.h
+++ b/Code/Engine/Mcp/McpJson.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <Mcp/McpDLL.h>
+
+#include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Types/Variant.h>
+
+/// \brief Reads values out of the arguments of a tool call.
+///
+/// Every accessor takes a fallback and never fails, because the caller is a language model: arguments
+/// go missing, arrive as the wrong type, or are spelled differently than the schema asked for. A tool
+/// that wants to reject bad input has to compare against the fallback and say so in its result.
+///
+/// For producing JSON see ezMcpJsonWriter.
+struct EZ_MCP_DLL ezMcpJson
+{
+  /// \brief Returns the value of a string member, or sFallback if it is missing or not a string.
+  static ezStringView GetString(const ezVariantDictionary& dict, ezStringView sKey, ezStringView sFallback = {});
+
+  /// \brief Returns the value of a number member, or iFallback if it is missing or not a number.
+  ///
+  /// The JSON parser turns every number into a double, and AI clients happily send "10" as a string,
+  /// so this accepts anything convertible.
+  static ezInt64 GetInt(const ezVariantDictionary& dict, ezStringView sKey, ezInt64 iFallback);
+
+  /// \brief Returns the value of a bool member, or bFallback if it is missing or not a bool.
+  ///
+  /// Also accepts the strings "true"/"false" and numbers, because clients send all three.
+  static bool GetBool(const ezVariantDictionary& dict, ezStringView sKey, bool bFallback);
+
+  /// \brief Returns a nested object member, or nullptr.
+  static const ezVariantDictionary* GetDict(const ezVariantDictionary& dict, ezStringView sKey);
+
+  /// \brief Returns a member that is a raw JSON array, or nullptr if it is missing or not an array.
+  ///
+  /// Unlike GetStringArray() this does not convert or filter elements - use it when the array holds
+  /// objects (e.g. a list of steps), and inspect each ezVariant yourself.
+  static const ezVariantArray* GetArray(const ezVariantDictionary& dict, ezStringView sKey);
+
+  /// \brief Collects a member that is a list of strings into out_values.
+  ///
+  /// Accepts a JSON array, and also a single string as a list of one - a client asked for one element
+  /// tends to send it bare. Non-string array elements are converted where they can be and skipped
+  /// otherwise, so one malformed entry does not discard the rest. Returns false when the member is
+  /// missing entirely, which is what distinguishes 'not given' from 'given as empty'.
+  static bool GetStringArray(const ezVariantDictionary& dict, ezStringView sKey, ezDynamicArray<ezString>& out_values);
+};

--- a/Code/Engine/Mcp/McpJsonWriter.cpp
+++ b/Code/Engine/Mcp/McpJsonWriter.cpp
@@ -1,0 +1,98 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJsonWriter.h>
+
+#include <Foundation/Reflection/Reflection.h>
+#include <Foundation/Types/Uuid.h>
+
+ezMcpJsonWriter::ezMcpJsonWriter()
+  : m_Writer(&m_Storage)
+{
+  SetOutputStream(&m_Writer);
+
+  // every character here is a token that the client pays for, and nothing reads this by eye
+  SetWhitespaceMode(ezJSONWriter::WhitespaceMode::None);
+  SetArrayMode(ezJSONWriter::ArrayMode::InOneLine);
+}
+
+ezMcpJsonWriter::~ezMcpJsonWriter() = default;
+
+ezStringView ezMcpJsonWriter::GetResult()
+{
+  const ezArrayPtr<const ezUInt8> bytes = m_Storage.GetContiguousMemoryRange(0);
+
+  m_sResult = ezStringView(reinterpret_cast<const char*>(bytes.GetPtr()), bytes.GetCount());
+
+  return m_sResult.GetView();
+}
+
+void ezMcpJsonWriter::WriteVariant(const ezVariant& value)
+{
+  switch (value.GetType())
+  {
+    case ezVariant::Type::TypedPointer:
+    {
+      // Written as a description of the target rather than as its contents: the pointer may be null,
+      // may point at a type with cycles, and the model can look the type up with the rtti tools anyway.
+      const ezTypedPointer ptr = value.Get<ezTypedPointer>();
+
+      const ezRTTI* pType = ptr.m_pType;
+
+      // The variant carries the *declared* pointer type, which for a reflected container is the base
+      // class - an array of ezPropertyAttribute* reports 'ezPropertyAttribute' for every element,
+      // losing which attribute it actually is. When the target derives from ezReflectedClass it can
+      // say so itself, and that is the name worth reporting.
+      if (ptr.m_pObject != nullptr && pType != nullptr && pType->IsDerivedFrom<ezReflectedClass>())
+      {
+        pType = static_cast<const ezReflectedClass*>(ptr.m_pObject)->GetDynamicRTTI();
+      }
+
+      BeginObject();
+      AddVariableString("$type", pType != nullptr ? pType->GetTypeName() : ezStringView());
+
+      if (ptr.m_pObject == nullptr)
+      {
+        AddVariableBool("$null", true);
+      }
+
+      EndObject();
+      return;
+    }
+
+    case ezVariant::Type::TypedObject:
+    {
+      // Only the type is written. Serialising the members would need the property system and could
+      // recurse without bound, which is not what a JSON writer should be doing.
+      const ezRTTI* pType = value.GetReflectedType();
+
+      BeginObject();
+      AddVariableString("$type", pType != nullptr ? pType->GetTypeName() : ezStringView());
+      EndObject();
+      return;
+    }
+
+    default:
+      break;
+  }
+
+  // The base class ends in EZ_REPORT_FAILURE for a type its switch does not cover, and an assert here
+  // is a dead editor in the middle of answering a tool call. Everything the enum currently defines is handled by
+  // one of the two writers, so this only catches a type added later.
+  const ezVariant::Type::Enum type = value.GetType();
+
+  const bool bBaseHandlesIt = (type > ezVariant::Type::Invalid && type < ezVariant::Type::LastStandardType) ||
+                              type == ezVariant::Type::VariantArray || type == ezVariant::Type::VariantDictionary ||
+                              type == ezVariant::Type::Invalid;
+
+  if (bBaseHandlesIt)
+  {
+    ezStandardJSONWriter::WriteVariant(value);
+    return;
+  }
+
+  BeginObject();
+  AddVariableString("$type", value.GetReflectedType() != nullptr ? value.GetReflectedType()->GetTypeName() : ezStringView());
+  AddVariableUInt32("$variantType", static_cast<ezUInt32>(type));
+  AddVariableString("$note", "This value's type has no JSON representation, so only its type is reported.");
+  EndObject();
+}

--- a/Code/Engine/Mcp/McpJsonWriter.h
+++ b/Code/Engine/Mcp/McpJsonWriter.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <Mcp/McpDLL.h>
+
+#include <Foundation/IO/JSONWriter.h>
+#include <Foundation/IO/MemoryStream.h>
+#include <Foundation/Strings/StringBuilder.h>
+
+/// \brief Writes the JSON that tool results and protocol responses are made of.
+///
+///  - The output goes into an ezStringBuilder that the writer owns, so tools never deal with streams.
+///  - No whitespace is emitted, because every character is a token the client pays for.
+///  - WriteVariant() covers what a language model reading arbitrary editor data runs into: variants
+///    holding reflected pointers or objects, which the base class refuses.
+class EZ_MCP_DLL ezMcpJsonWriter : public ezStandardJSONWriter
+{
+public:
+  ezMcpJsonWriter();
+  ~ezMcpJsonWriter();
+
+  /// \brief The JSON written so far.
+  ///
+  /// Only meaningful once every Begin* has been matched by its End*, because the closing brace is
+  /// written by the latter.
+  ezStringView GetResult();
+
+  /// Adds the variant types that the base class asserts on: pointers and embedded objects, which turn
+  /// up when reflection data is written generically. The base class' assert is fine for a caller that
+  /// knows what it writes, but a tool reading arbitrary reflection data cannot know, and an assert in
+  /// a tool call takes the whole editor down.
+  virtual void WriteVariant(const ezVariant& value) override;
+
+private:
+  /// The written bytes are collected here and only turned into a string by GetResult(), because the
+  /// writer produces a byte stream and has no notion of a terminating zero.
+  ezContiguousMemoryStreamStorage m_Storage;
+  ezMemoryStreamWriter m_Writer;
+  ezStringBuilder m_sResult;
+};

--- a/Code/Engine/Mcp/McpPCH.cpp
+++ b/Code/Engine/Mcp/McpPCH.cpp
@@ -1,0 +1,7 @@
+#include <Mcp/McpPCH.h>
+
+EZ_STATICLINK_LIBRARY(Mcp)
+{
+  if (bReturn)
+    return;
+}

--- a/Code/Engine/Mcp/McpPCH.h
+++ b/Code/Engine/Mcp/McpPCH.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Logging/Log.h>

--- a/Code/Engine/Mcp/McpServer.cpp
+++ b/Code/Engine/Mcp/McpServer.cpp
@@ -1,0 +1,245 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpServer.h>
+#include <Mcp/McpToolRegistry.h>
+
+#include <Foundation/IO/JSONReader.h>
+#include <Foundation/IO/MemoryStream.h>
+
+namespace
+{
+  /// \brief Writes the JSON-RPC 'id' back out exactly as the type it came in as.
+  ///
+  /// The spec allows numbers, strings and null, and the client is entitled to reject a response whose
+  /// id doesn't match what it sent.
+  void WriteId(ezMcpJsonWriter& ref_writer, const ezVariantDictionary& msg)
+  {
+    ref_writer.BeginVariable("id");
+
+    const ezVariant* pId = nullptr;
+
+    if (!msg.TryGetValue("id", pId) || !pId->IsValid())
+    {
+      ref_writer.WriteNULL();
+    }
+    else if (pId->IsA<ezString>())
+    {
+      ref_writer.WriteString(pId->Get<ezString>().GetView());
+    }
+    else
+    {
+      // the JSON reader represents every number as a double, but ids are conventionally integers,
+      // so write them without a fractional part
+      ref_writer.WriteInt64(static_cast<ezInt64>(pId->ConvertTo<double>()));
+    }
+
+    ref_writer.EndVariable();
+  }
+} // namespace
+
+ezMcpServer* ezMcpServer::s_pInstance = nullptr;
+
+ezMcpServer::ezMcpServer(ezStringView sServerName)
+  : m_sServerName(sServerName)
+{
+  // only ever one of these, created by the plugin - the last one wins rather than asserting, because
+  // taking the host down over a reporting detail would be worse than reporting the wrong port
+  s_pInstance = this;
+}
+
+ezMcpServer::~ezMcpServer()
+{
+  Stop();
+
+  if (s_pInstance == this)
+  {
+    s_pInstance = nullptr;
+  }
+}
+
+ezResult ezMcpServer::Start(ezUInt16 uiPort)
+{
+  Stop();
+
+  if (m_Transport.Start(uiPort, ezMakeDelegate(&ezMcpServer::HandleRequest, this)).Failed())
+    return EZ_FAILURE;
+
+  // plugins that were loaded after this one may bring their own tools along
+  ezMcpToolRegistry::UpdateProviders();
+
+  ezLog::Success("MCP server listening on http://127.0.0.1:{}/mcp, {} tools available.", m_Transport.GetPort(), ezMcpToolRegistry::GetTools().GetCount());
+  return EZ_SUCCESS;
+}
+
+void ezMcpServer::Stop()
+{
+  if (!m_Transport.IsRunning())
+    return;
+
+  m_Transport.Stop();
+
+  ezLog::Info("MCP server stopped.");
+}
+
+void ezMcpServer::HandleRequest(const ezMcpHttpRequest& request, ezMcpHttpResponse& ref_response)
+{
+  if (request.m_sPath != "/mcp")
+  {
+    ref_response.m_sStatus = "404 Not Found";
+    return;
+  }
+
+  if (request.m_sMethod != "POST")
+  {
+    // GET would be the SSE stream and DELETE would end a session - we support neither
+    ref_response.m_sStatus = "405 Method Not Allowed";
+    return;
+  }
+
+  ezRawMemoryStreamReader reader(request.m_sBody.GetData(), request.m_sBody.GetElementCount());
+
+  ezJSONReader json;
+  if (json.Parse(reader).Failed())
+  {
+    ref_response.m_sStatus = "400 Bad Request";
+    ref_response.m_sBody = "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}";
+    return;
+  }
+
+  ezStringBuilder sResponse;
+  bool bDeferred = false;
+
+  if (HandleMessage(json.GetTopLevelObject(), sResponse, bDeferred).Failed())
+  {
+    // this was a notification - it must not be answered with a JSON-RPC response
+    ref_response.m_sStatus = "202 Accepted";
+    return;
+  }
+
+  if (bDeferred)
+  {
+    // The tool is not done. Nothing goes out; the whole request is parsed and run again next time the
+    // host pumps. Re-parsing costs a JSON read of a small body per attempt, which is cheaper than
+    // teaching the transport to hold a half-finished response.
+    ref_response.m_bDeferred = true;
+    return;
+  }
+
+  ref_response.m_sStatus = "200 OK";
+  ref_response.m_sBody = sResponse;
+}
+
+ezResult ezMcpServer::HandleMessage(const ezVariantDictionary& msg, ezStringBuilder& out_sResponse, bool& out_bDeferred)
+{
+  const ezStringView sMethod = ezMcpJson::GetString(msg, "method");
+  const ezVariantDictionary* pParams = ezMcpJson::GetDict(msg, "params");
+
+  // notifications carry no 'id' and must be answered with an empty body, never with a JSON-RPC response
+  if (sMethod.StartsWith("notifications/"))
+    return EZ_FAILURE;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("jsonrpc", "2.0");
+  WriteId(writer, msg);
+
+  if (sMethod == "initialize")
+  {
+    // echo the client's protocol version back, rather than guessing at one
+    const ezStringView sVersion = pParams ? ezMcpJson::GetString(*pParams, "protocolVersion", "2025-06-18") : "2025-06-18";
+
+    writer.BeginObject("result");
+    writer.AddVariableString("protocolVersion", sVersion);
+
+    writer.BeginObject("capabilities");
+    writer.BeginObject("tools");
+    writer.EndObject();
+    writer.EndObject();
+
+    writer.BeginObject("serverInfo");
+    writer.AddVariableString("name", m_sServerName);
+    writer.AddVariableString("version", "0.1");
+    writer.EndObject();
+
+    writer.EndObject();
+  }
+  else if (sMethod == "tools/list")
+  {
+    writer.BeginObject("result");
+    writer.BeginArray("tools");
+
+    for (const ezMcpToolDesc& tool : ezMcpToolRegistry::GetTools())
+    {
+      writer.BeginObject();
+      writer.AddVariableString("name", tool.m_sName);
+      writer.AddVariableString("description", tool.m_sDescription);
+
+      // the schema is raw JSON authored by the tool, so it is spliced in rather than escaped
+      writer.AddVariableRawJson("inputSchema", tool.m_sInputSchema.IsEmpty() ? ezStringView("{\"type\":\"object\"}") : tool.m_sInputSchema.GetView());
+      writer.EndObject();
+    }
+
+    writer.EndArray();
+    writer.EndObject();
+  }
+  else if (sMethod == "tools/call")
+  {
+    const ezStringView sToolName = pParams ? ezMcpJson::GetString(*pParams, "name") : ezStringView();
+    const ezVariantDictionary* pArgs = pParams ? ezMcpJson::GetDict(*pParams, "arguments") : nullptr;
+
+    // a call without an 'arguments' object is legal for tools that take none
+    const ezVariantDictionary emptyArgs;
+
+    ezMcpToolResult result;
+
+    if (ezMcpToolRegistry::Execute(sToolName, pArgs != nullptr ? *pArgs : emptyArgs, result).Failed())
+    {
+      result.SetError(ezStringBuilder("Unknown tool: ", sToolName));
+    }
+
+    if (result.m_bNotFinished)
+    {
+      // EndAll() rather than just returning: the writer asserts on destruction if the object it opened
+      // above was never closed, and the half-written result is thrown away anyway.
+      writer.EndAll();
+      out_bDeferred = true;
+      return EZ_SUCCESS;
+    }
+
+    writer.BeginObject("result");
+
+    if (result.m_bIsError)
+    {
+      // a failed tool call is reported inside the result, not as a JSON-RPC error - that way the
+      // client hands the message to the model instead of treating it as a protocol failure
+      writer.AddVariableBool("isError", true);
+    }
+
+    writer.BeginArray("content");
+    writer.BeginObject();
+    writer.AddVariableString("type", "text");
+    writer.AddVariableString("text", result.m_sText);
+    writer.EndObject();
+    writer.EndArray();
+
+    writer.EndObject();
+  }
+  else
+  {
+    ezStringBuilder sMessage("Method not found: ", sMethod);
+
+    writer.BeginObject("error");
+    writer.AddVariableInt32("code", -32601);
+    writer.AddVariableString("message", sMessage);
+    writer.EndObject();
+  }
+
+  writer.EndObject();
+
+  out_sResponse = writer.GetResult();
+
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/Mcp/McpServer.h
+++ b/Code/Engine/Mcp/McpServer.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <Mcp/McpTransport.h>
+
+#include <Foundation/Strings/String.h>
+#include <Foundation/Types/Variant.h>
+
+/// A minimal MCP (Model Context Protocol) server, speaking the 'streamable HTTP' transport.
+///
+/// Hosts the JSON-RPC half; the sockets and the main-thread hand-off are ezMcpTransport's job, and the
+/// tools themselves come from ezMcpToolRegistry. That split is what lets the editor and a game process
+/// run the same server.
+///
+/// The protocol implemented here is a subset: `initialize`, `tools/list` and `tools/call`, no sessions,
+/// no SSE, no batching. See Status.md in EditorPluginMcp for why, and for what that costs.
+class EZ_MCP_DLL ezMcpServer
+{
+public:
+  /// \param sServerName Reported to the client as `serverInfo.name`, so that an agent talking to two
+  ///        of these at once can tell the editor from the game.
+  ezMcpServer(ezStringView sServerName);
+  ~ezMcpServer();
+
+  /// Starts listening on 127.0.0.1 at the given port.
+  ezResult Start(ezUInt16 uiPort);
+
+  /// Stops the server and drops all pending connections. Safe to call when not running.
+  void Stop();
+
+  bool IsRunning() const { return m_Transport.IsRunning(); }
+
+  /// The port that is currently being listened on, or 0 while not running.
+  ezUInt16 GetPort() const { return m_Transport.GetPort(); }
+
+  /// \brief Answers whatever request is waiting. Must be called regularly from the main thread, or
+  /// clients never get an answer.
+  void ProcessPendingRequests() { m_Transport.ProcessPendingRequests(); }
+
+  /// \brief Whether a client is currently waiting for an answer.
+  ///
+  /// A host whose main loop sleeps when there is nothing to draw has to wake up and pump when this is
+  /// true - see the editor's engine process.
+  bool HasPendingRequest() const { return m_Transport.HasPendingRequest(); }
+
+  /// The running server, or nullptr if none was started. Exists so that tools can report how to
+  /// reach this process, which is not otherwise discoverable from inside a tool call.
+  static ezMcpServer* GetInstance() { return s_pInstance; }
+
+private:
+  /// Turns one HTTP request into a response. Runs on the main thread.
+  void HandleRequest(const ezMcpHttpRequest& request, ezMcpHttpResponse& ref_response);
+
+  /// Turns one JSON-RPC message into a response body. Returns EZ_FAILURE for notifications,
+  /// which must not be answered with a body at all.
+  ///
+  /// \param out_bDeferred Set when the tool asked to be re-run later. The response body is then
+  ///        meaningless and the caller must not send anything - see ezMcpToolResult::m_bNotFinished.
+  ezResult HandleMessage(const ezVariantDictionary& msg, ezStringBuilder& out_sResponse, bool& out_bDeferred);
+
+  ezString m_sServerName;
+  ezMcpTransport m_Transport;
+
+  static ezMcpServer* s_pInstance;
+};

--- a/Code/Engine/Mcp/McpSocket.h
+++ b/Code/Engine/Mcp/McpSocket.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <Mcp/McpDLL.h>
+
+#include <Foundation/Time/Time.h>
+
+/// \brief The little bit of TCP that the MCP transport needs, with the platform differences taken out.
+///
+/// Deliberately minimal and blocking: one listening socket, one connection at a time, one request per
+/// connection. The transport runs this on its own thread, so blocking is the simple option rather than
+/// the expensive one. Everything above this - HTTP framing, JSON-RPC, dispatch - is platform free and
+/// lives in ezMcpTransport and ezMcpServer.
+///
+/// Not copyable; a socket has an owner, and closing it twice closes a handle somebody else got given.
+class EZ_MCP_DLL ezMcpSocket
+{
+public:
+  ezMcpSocket();
+  ~ezMcpSocket();
+
+  ezMcpSocket(const ezMcpSocket&) = delete;
+  ezMcpSocket& operator=(const ezMcpSocket&) = delete;
+
+  /// \brief Binds to 127.0.0.1 at the given port and starts listening.
+  ///
+  /// Loopback only, never INADDR_ANY: this server has no authentication of any kind, so it must not be
+  /// reachable from another machine.
+  ///
+  /// A port of 0 lets the OS pick one - use GetPort() to find out which. That is only useful to a
+  /// caller that can publish the result, since a client needs the number to build its URL.
+  ezResult Listen(ezUInt16 uiPort);
+
+  /// \brief The port that is actually bound, read back from the socket rather than from the argument.
+  ezUInt16 GetPort() const { return m_uiPort; }
+
+  bool IsValid() const { return m_iSocket >= 0; }
+
+  void Close();
+
+  /// \brief Waits up to \a timeout for an incoming connection.
+  ///
+  /// Returns EZ_FAILURE when nothing arrived in time, which is not an error - it is how the accept
+  /// loop gets a chance to notice that it was asked to stop. There is no portable way to interrupt a
+  /// blocking accept(), so it is polled instead.
+  ezResult Accept(ezMcpSocket& out_client, ezTime timeout);
+
+  /// \brief Reads whatever has arrived, blocking until something does.
+  ///
+  /// Returns the number of bytes read, 0 when the peer closed the connection in an orderly way, and a
+  /// negative value on error or timeout. Accepted sockets carry a receive timeout so that a client
+  /// which opens a connection and then says nothing cannot wedge the transport thread.
+  ezInt32 Receive(void* pBuffer, ezUInt32 uiSize);
+
+  /// \brief Writes the whole buffer, looping over partial writes.
+  ezResult SendAll(const void* pBuffer, ezUInt32 uiSize);
+
+private:
+  /// The platform handle. Windows' SOCKET is an unsigned pointer and POSIX' is an int, but both use an
+  /// all-ones value for 'invalid', so a signed 64 bit integer holds either and -1 means the same thing.
+  ezInt64 m_iSocket = -1;
+  ezUInt16 m_uiPort = 0;
+};

--- a/Code/Engine/Mcp/McpTool.cpp
+++ b/Code/Engine/Mcp/McpTool.cpp
@@ -1,0 +1,8 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpTool.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpToolProvider, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on

--- a/Code/Engine/Mcp/McpTool.h
+++ b/Code/Engine/Mcp/McpTool.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <Mcp/McpDLL.h>
+
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Reflection/Reflection.h>
+#include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Types/Variant.h>
+
+/// \brief Describes one callable function, as it appears in the MCP client's tool list.
+struct EZ_MCP_DLL ezMcpToolDesc
+{
+  /// The name the client calls. Must be unique across all providers. Convention is lower snake_case,
+  /// prefixed with the area, e.g. 'log_write'.
+  ezString m_sName;
+
+  /// What the tool does. This is the only thing an AI agent has to go by when deciding whether to call
+  /// it, so be specific about what it returns and what it modifies.
+  ezString m_sDescription;
+
+  /// The JSON schema of the arguments, as a raw JSON object. Empty means 'no arguments'.
+  /// E.g. R"({"type":"object","properties":{"count":{"type":"number"}}})"
+  ezString m_sInputSchema;
+};
+
+/// \brief The result of one tool call.
+struct EZ_MCP_DLL ezMcpToolResult
+{
+  /// The text handed back to the client. For structured data just write JSON in here - MCP has no
+  /// separate typed result, everything is text content.
+  ezStringBuilder m_sText;
+
+  /// If true, the client is told the call failed. The text should then say why.
+  bool m_bIsError = false;
+
+  /// \brief Set this to have the call re-run later instead of answered now.
+  ///
+  /// For a tool that has to wait for the host to make progress - most obviously 'run for N frames',
+  /// which cannot happen while the tool itself is holding the main thread. Setting this leaves the
+  /// client waiting on its connection and re-enters the tool with the same arguments the next time the
+  /// host pumps, until a call finally leaves it false.
+  ///
+  /// The tool therefore has to keep its own 'where was I' state across those calls, and has to give up
+  /// on its own after a timeout: a host that stops pumping is indistinguishable from one that is still
+  /// working, and a wait that never ends looks exactly like a hang.
+  ///
+  /// Only meaningful in a host that pumps repeatedly. m_sText is ignored while this is true.
+  bool m_bNotFinished = false;
+
+  void SetError(ezStringView sMessage)
+  {
+    m_sText = sMessage;
+    m_bIsError = true;
+  }
+};
+
+/// \brief Base class for everything that the MCP server exposes to AI agents.
+///
+/// One provider offers one or more tools, which is why they are grouped: 'log_write' and 'log_read'
+/// share a ring buffer, so they belong to the same object.
+///
+/// Providers are found through reflection, so **any plugin can add its own** simply by deriving from
+/// this class - there is no list to register with. The plugin only has to link against the Mcp library,
+/// which works on both sides: an editor plugin adds editor tools, a runtime plugin adds tools to the
+/// game process. See ezMcpLogTool for the smallest complete example.
+///
+/// Everything happens on the main thread, so implementations may touch the host directly.
+class EZ_MCP_DLL ezMcpToolProvider : public ezReflectedClass
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpToolProvider, ezReflectedClass);
+
+public:
+  /// \brief Called once, right after the provider was instantiated. Use it to hook into the editor.
+  virtual void OnActivate() {}
+
+  /// \brief Called once, before the provider is destroyed.
+  virtual void OnDeactivate() {}
+
+  /// \brief Appends the description of every tool that this provider implements.
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const = 0;
+
+  /// \brief Executes one of the tools returned by GetSupportedTools().
+  ///
+  /// \param sToolName The tool to run. A provider with a single tool may ignore this.
+  /// \param arguments The 'arguments' object of the call. Missing and mistyped values are normal -
+  ///        the client is an AI and will get this wrong. Validate and report through out_result.
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) = 0;
+};

--- a/Code/Engine/Mcp/McpToolRegistry.cpp
+++ b/Code/Engine/Mcp/McpToolRegistry.cpp
@@ -1,0 +1,90 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpToolRegistry.h>
+
+ezSet<const ezRTTI*> ezMcpToolRegistry::s_KnownTypes;
+ezDynamicArray<ezMcpToolProvider*> ezMcpToolRegistry::s_Providers;
+ezDynamicArray<ezMcpToolDesc> ezMcpToolRegistry::s_Tools;
+ezMap<ezString, ezMcpToolProvider*> ezMcpToolRegistry::s_ToolLookup;
+ezMcpExecuteWrapper ezMcpToolRegistry::s_ExecuteWrapper;
+
+void ezMcpToolRegistry::UpdateProviders()
+{
+  ezRTTI::ForEachDerivedType<ezMcpToolProvider>(
+    [](const ezRTTI* pRtti)
+    {
+      // remember the type even if it can't be allocated, so we don't look at it again
+      if (s_KnownTypes.Contains(pRtti))
+        return;
+
+      s_KnownTypes.Insert(pRtti);
+
+      // an abstract provider base declares the tools that several hosts share; only the host's concrete
+      // subclass is instantiated, so the tool names cannot collide with themselves
+      if (!pRtti->GetAllocator()->CanAllocate())
+        return;
+
+      ezMcpToolProvider* pProvider = pRtti->GetAllocator()->Allocate<ezMcpToolProvider>();
+      s_Providers.PushBack(pProvider);
+
+      pProvider->OnActivate();
+
+      ezDynamicArray<ezMcpToolDesc> tools;
+      pProvider->GetSupportedTools(tools);
+
+      for (const ezMcpToolDesc& tool : tools)
+      {
+        if (s_ToolLookup.Contains(tool.m_sName))
+        {
+          // two providers claiming the same name would make dispatch ambiguous, and the client would
+          // see a duplicate entry in its tool list
+          ezLog::Error("MCP: Tool name '{}' is already in use, the one from '{}' is ignored.", tool.m_sName, pRtti->GetTypeName());
+          continue;
+        }
+
+        s_ToolLookup[tool.m_sName] = pProvider;
+        s_Tools.PushBack(tool);
+      }
+    },
+    ezRTTI::ForEachOptions::ExcludeNotConcrete);
+}
+
+void ezMcpToolRegistry::Clear()
+{
+  for (ezMcpToolProvider* pProvider : s_Providers)
+  {
+    pProvider->OnDeactivate();
+    pProvider->GetDynamicRTTI()->GetAllocator()->Deallocate(pProvider);
+  }
+
+  s_Providers.Clear();
+  s_Tools.Clear();
+  s_ToolLookup.Clear();
+  s_KnownTypes.Clear();
+}
+
+ezResult ezMcpToolRegistry::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  auto it = s_ToolLookup.Find(sToolName);
+
+  if (!it.IsValid())
+    return EZ_FAILURE;
+
+  ezMcpToolProvider* pProvider = it.Value();
+
+  ezDelegate<void()> execute = [&]()
+  {
+    pProvider->Execute(sToolName, arguments, out_result);
+  };
+
+  if (s_ExecuteWrapper.IsValid())
+  {
+    s_ExecuteWrapper(sToolName, out_result, execute);
+  }
+  else
+  {
+    execute();
+  }
+
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/Mcp/McpToolRegistry.h
+++ b/Code/Engine/Mcp/McpToolRegistry.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+#include <Foundation/Containers/Map.h>
+#include <Foundation/Containers/Set.h>
+#include <Foundation/Types/Delegate.h>
+
+/// \brief Wraps every tool call in whatever setup and teardown the host needs.
+///
+/// The registry itself is host independent, but the editor has to put a call into unattended mode and
+/// turn a failed assert into a tool error, and a game has no equivalent of either. So the host installs
+/// this instead of the registry knowing about any of it.
+///
+/// \param execute Runs the tool. Call it exactly once - skipping it answers the client with an empty
+///        result, calling it twice runs the tool twice.
+using ezMcpExecuteWrapper = ezDelegate<void(ezStringView sToolName, ezMcpToolResult& ref_result, ezDelegate<void()> execute)>;
+
+/// \brief Owns one instance of every ezMcpToolProvider and routes calls to them.
+///
+/// The registry is filled through reflection, so a provider in another plugin needs no registration
+/// call - it only has to exist.
+class EZ_MCP_DLL ezMcpToolRegistry
+{
+public:
+  /// \brief Instantiates every provider type that isn't known yet.
+  ///
+  /// Idempotent, and called again when the server starts, because plugins may be loaded after the one
+  /// that owns the server and would otherwise never be picked up.
+  ///
+  /// Provider types that cannot be allocated are skipped, which is what makes an abstract provider base
+  /// usable: a tool that exists in several hosts declares the shared half with ezRTTINoAllocator and
+  /// each host derives the concrete type that is actually instantiated here.
+  static void UpdateProviders();
+
+  /// \brief Destroys all providers. Called when the plugin is unloaded.
+  static void Clear();
+
+  /// \brief All tools of all providers, in registration order.
+  static const ezDynamicArray<ezMcpToolDesc>& GetTools() { return s_Tools; }
+
+  /// \brief Installs the host's wrapper around every tool call. Pass an invalid delegate to remove it.
+  static void SetExecuteWrapper(ezMcpExecuteWrapper wrapper) { s_ExecuteWrapper = wrapper; }
+
+  /// \brief Runs a tool. Fails only if no tool of that name exists - a tool that ran but didn't like
+  /// its arguments reports that through out_result instead.
+  static ezResult Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+private:
+  static ezSet<const ezRTTI*> s_KnownTypes;
+  static ezDynamicArray<ezMcpToolProvider*> s_Providers;
+  static ezDynamicArray<ezMcpToolDesc> s_Tools;
+  static ezMap<ezString, ezMcpToolProvider*> s_ToolLookup;
+  static ezMcpExecuteWrapper s_ExecuteWrapper;
+};

--- a/Code/Engine/Mcp/McpTranslation.cpp
+++ b/Code/Engine/Mcp/McpTranslation.cpp
@@ -1,0 +1,118 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpTranslation.h>
+
+#include <Foundation/Reflection/Reflection.h>
+#include <Foundation/Strings/TranslationLookup.h>
+
+namespace
+{
+  /// The echo guard: an unknown key comes back unchanged, which is indistinguishable from a translation
+  /// that happens to equal its key - and treating the latter as missing loses nothing, since repeating
+  /// the key tells the caller nothing it did not send.
+  ///
+  /// Missing-translation logging is off for the duration: these tools ask about reflection data wholesale,
+  /// where most keys are expected to have no entry, and ezTranslatorLogMissing would fill the editor log
+  /// with a warning per property. The property grid disables it for the same reason.
+  ezStringView Lookup(ezStringView sKey, ezTranslationUsage usage)
+  {
+    if (sKey.IsEmpty())
+      return {};
+
+    const bool bLogMissing = ezTranslatorLogMissing::s_bActive;
+    ezTranslatorLogMissing::s_bActive = false;
+
+    const ezStringView sResult = ezTranslationLookup::Translate(sKey, ezHashingUtils::StringHash(sKey), usage);
+
+    ezTranslatorLogMissing::s_bActive = bLogMissing;
+
+    if (sResult == sKey)
+      return {};
+
+    return sResult;
+  }
+
+  /// True when the translation is what ezTranslatorMakeMoreReadable derives from the key itself: the
+  /// part behind the last '::' with spaces inserted at CamelCase boundaries. That translator is
+  /// registered in the editor, so a key with no entry anywhere still comes back as readable text - and
+  /// 'Projection Axis' for 'ProjectionAxis' is a token per property that tells the reader nothing it
+  /// could not have written down itself. Genuine overrides ('Base Color Texture' for 'BaseColor')
+  /// survive the comparison.
+  bool IsDerivableFromKey(ezStringView sTranslation, ezStringView sKey)
+  {
+    const char* szScope = sKey.FindLastSubString("::");
+
+    if (szScope != nullptr)
+    {
+      sKey.SetStartPosition(szScope + 2);
+    }
+
+    ezStringBuilder sStripped = sTranslation;
+    sStripped.ReplaceAll(" ", "");
+
+    return sStripped.IsEqual_NoCase(sKey);
+  }
+
+  /// Walks up the type hierarchy because the entry sits on the type that declares the property, which for
+  /// an inherited property is not the type the caller asked about.
+  ezStringView LookupProperty(const ezRTTI* pType, ezStringView sPropertyName, ezTranslationUsage usage)
+  {
+    if (sPropertyName.IsEmpty())
+      return {};
+
+    ezStringBuilder sKey;
+
+    for (const ezRTTI* pCurrent = pType; pCurrent != nullptr; pCurrent = pCurrent->GetParentType())
+    {
+      sKey.Set(pCurrent->GetTypeName(), "::", sPropertyName);
+
+      const ezStringView sResult = Lookup(sKey, usage);
+
+      // A readable-ified key is not an entry: it is produced for every key, so accepting it here would
+      // stop the walk on the first type and never reach the base type that declares the property.
+      if (!sResult.IsEmpty() && !IsDerivableFromKey(sResult, sKey))
+        return sResult;
+    }
+
+    return {};
+  }
+} // namespace
+
+ezStringView ezMcpTranslation::GetDisplayName(ezStringView sKey)
+{
+  const ezStringView sResult = Lookup(sKey, ezTranslationUsage::Default);
+
+  if (IsDerivableFromKey(sResult, sKey))
+    return {};
+
+  return sResult;
+}
+
+ezStringView ezMcpTranslation::GetTooltip(ezStringView sKey)
+{
+  return Lookup(sKey, ezTranslationUsage::Tooltip);
+}
+
+ezStringView ezMcpTranslation::GetHelpURL(ezStringView sKey)
+{
+  return Lookup(sKey, ezTranslationUsage::HelpURL);
+}
+
+ezStringView ezMcpTranslation::GetPropertyDisplayName(const ezRTTI* pType, ezStringView sPropertyName)
+{
+  return LookupProperty(pType, sPropertyName, ezTranslationUsage::Default);
+}
+
+ezStringView ezMcpTranslation::GetPropertyTooltip(const ezRTTI* pType, ezStringView sPropertyName)
+{
+  return LookupProperty(pType, sPropertyName, ezTranslationUsage::Tooltip);
+}
+
+void ezMcpTranslation::AddOptionalString(ezMcpJsonWriter& ref_writer, ezStringView sFieldName, ezStringView sValue)
+{
+  if (sValue.IsEmpty())
+    return;
+
+  ref_writer.AddVariableString(sFieldName, sValue);
+}

--- a/Code/Engine/Mcp/McpTranslation.h
+++ b/Code/Engine/Mcp/McpTranslation.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <Mcp/McpDLL.h>
+
+#include <Foundation/Strings/String.h>
+
+class ezMcpJsonWriter;
+class ezRTTI;
+
+/// \brief Translation lookups that report a missing entry as an empty string.
+///
+/// The ezTranslate* macros return the key unchanged when nothing is registered for it, so a tool using
+/// them directly reports every action without a tooltip as having its own name as one, and every type
+/// without documentation as having a help URL that is really just the type name. Comparing the result
+/// against the key is the only way to tell the two apart, and doing it at each call site is how that
+/// check gets forgotten.
+///
+/// These matter because the editor's UI shows translated text: the asset browser lists
+/// ezTranslate(typeName), so what a user calls 'the Decal asset' is not the name any tool wants. The
+/// help URL is prose about what a type is for, which reflection data never conveys.
+namespace ezMcpTranslation
+{
+  /// \brief The display name for sKey, or an empty view when there is no entry.
+  ///
+  /// Also empty when the result is only sKey made readable - the editor registers a translator that
+  /// splits CamelCase names for keys nobody translated, and reporting 'Projection Axis' for
+  /// 'ProjectionAxis' costs tokens without adding anything.
+  EZ_MCP_DLL ezStringView GetDisplayName(ezStringView sKey);
+
+  /// \brief The tooltip for sKey, or an empty view when there is no entry.
+  EZ_MCP_DLL ezStringView GetTooltip(ezStringView sKey);
+
+  /// \brief The documentation URL for sKey, or an empty view when there is no entry.
+  EZ_MCP_DLL ezStringView GetHelpURL(ezStringView sKey);
+
+  /// \brief The display name for a reflected property, or an empty view when there is no entry.
+  ///
+  /// Property translations are keyed '<TypeName>::<PropertyName>' and registered on the type that
+  /// declares the property, so the lookup walks up from pType until it finds an entry. That matters for
+  /// an inherited property, whose key names a base type the caller never asked about.
+  EZ_MCP_DLL ezStringView GetPropertyDisplayName(const ezRTTI* pType, ezStringView sPropertyName);
+
+  /// \brief The tooltip for a reflected property, or an empty view when there is no entry.
+  ///
+  /// This is the one place where prose about what a property *does* exists - reflection only ever gives
+  /// its name and type. Keyed as described for GetPropertyDisplayName().
+  EZ_MCP_DLL ezStringView GetPropertyTooltip(const ezRTTI* pType, ezStringView sPropertyName);
+
+  /// \brief Writes sFieldName only if sValue is not empty, so an absent translation costs no tokens.
+  ///
+  /// The field name is passed in because the same lookup appears under different names depending on
+  /// whose translation it is - an asset's own help URL versus that of its type, for instance.
+  EZ_MCP_DLL void AddOptionalString(ezMcpJsonWriter& ref_writer, ezStringView sFieldName, ezStringView sValue);
+} // namespace ezMcpTranslation

--- a/Code/Engine/Mcp/McpTransport.cpp
+++ b/Code/Engine/Mcp/McpTransport.cpp
@@ -124,7 +124,7 @@ private:
       }
 
       if (iHeaderEnd >= 0 && buffer.GetCount() >= uiBodyStart + static_cast<ezUInt32>(iContentLength))
-        break; // request is complete
+        break;  // request is complete
 
       if (buffer.GetCount() > uiMaxRequestSize)
         return; // hang up on something that is not going to become a valid request

--- a/Code/Engine/Mcp/McpTransport.cpp
+++ b/Code/Engine/Mcp/McpTransport.cpp
@@ -1,0 +1,342 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpSocket.h>
+#include <Mcp/McpTransport.h>
+
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Threading/Lock.h>
+#include <Foundation/Threading/Thread.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+
+namespace
+{
+  /// A request larger than this is not a request, it is either a mistake or an attack. The largest
+  /// legitimate body is an object_modify call carrying a value, which is kilobytes.
+  constexpr ezUInt32 uiMaxRequestSize = 16 * 1024 * 1024;
+
+  /// How long the accept loop blocks before looking at the stop flag again. Only bounds how long Stop()
+  /// takes, so it can be generous.
+  constexpr ezTime AcceptPollInterval = ezTime::MakeFromMilliseconds(100);
+
+  /// \brief Finds the value of one header in the raw header block, case insensitively.
+  ///
+  /// The result points into \a sHeaders, so it stays valid as long as the receive buffer does. Nothing
+  /// is copied into a local builder for that reason: searching the original directly also means the
+  /// offset cannot drift, which it would if a lower-cased copy of a header containing non-ASCII bytes
+  /// came out at a different byte length than the input.
+  ezStringView FindHeaderValue(ezStringView sHeaders, ezStringView sName)
+  {
+    ezStringBuilder sSearch = sName;
+    sSearch.Append(":");
+
+    const char* szFound = sHeaders.FindSubString_NoCase(sSearch);
+
+    if (szFound == nullptr)
+      return {};
+
+    const char* szStart = szFound + sSearch.GetElementCount();
+    const char* szEnd = sHeaders.GetEndPointer();
+
+    if (const char* szLineEnd = ezStringView(szStart, szEnd).FindSubString("\r\n"))
+    {
+      szEnd = szLineEnd;
+    }
+
+    while (szStart < szEnd && (*szStart == ' ' || *szStart == '\t'))
+      ++szStart;
+
+    while (szEnd > szStart && (szEnd[-1] == ' ' || szEnd[-1] == '\t'))
+      --szEnd;
+
+    return ezStringView(szStart, szEnd);
+  }
+} // namespace
+
+/// \brief Owns the listening socket and turns bytes into ezMcpHttpRequest.
+class ezMcpTransportThread : public ezThread
+{
+public:
+  ezMcpTransportThread(ezMcpTransport* pOwner)
+    : ezThread("ezMcpTransport")
+    , m_pOwner(pOwner)
+  {
+  }
+
+  ezMcpSocket m_Listener;
+  ezAtomicInteger32 m_iStopRequested;
+
+private:
+  virtual ezUInt32 Run() override
+  {
+    while (m_iStopRequested == 0)
+    {
+      ezMcpSocket client;
+
+      if (m_Listener.Accept(client, AcceptPollInterval).Failed())
+        continue; // nothing connected within the poll interval, or we are shutting down
+
+      HandleConnection(client);
+    }
+
+    return 0;
+  }
+
+  /// \brief Reads one request off the connection, has it answered, writes the response and hangs up.
+  ///
+  /// One request per connection. The server always answers `Connection: close`, so a client that wants
+  /// to make a second call opens a second connection.
+  void HandleConnection(ezMcpSocket& client)
+  {
+    ezDynamicArray<ezUInt8> buffer;
+    buffer.Reserve(4096);
+
+    ezUInt8 chunk[4096];
+    ezInt32 iHeaderEnd = -1;
+    ezInt32 iContentLength = 0;
+    ezUInt32 uiBodyStart = 0;
+
+    while (true)
+    {
+      // find the end of the headers, then keep reading until the whole body has arrived - a single TCP
+      // read is not guaranteed to contain either
+      if (iHeaderEnd < 0)
+      {
+        const ezStringView sSoFar(reinterpret_cast<const char*>(buffer.GetData()), buffer.GetCount());
+        const char* szEnd = sSoFar.FindSubString("\r\n\r\n");
+
+        if (szEnd != nullptr)
+        {
+          iHeaderEnd = static_cast<ezInt32>(szEnd - sSoFar.GetStartPointer());
+          uiBodyStart = static_cast<ezUInt32>(iHeaderEnd) + 4;
+
+          const ezStringView sHeaders(reinterpret_cast<const char*>(buffer.GetData()), static_cast<ezUInt32>(iHeaderEnd));
+          const ezStringView sLength = FindHeaderValue(sHeaders, "Content-Length");
+
+          if (!sLength.IsEmpty())
+          {
+            ezInt64 iParsed = 0;
+            if (ezConversionUtils::StringToInt64(sLength, iParsed).Succeeded() && iParsed > 0)
+            {
+              iContentLength = static_cast<ezInt32>(ezMath::Min<ezInt64>(iParsed, uiMaxRequestSize));
+            }
+          }
+        }
+      }
+
+      if (iHeaderEnd >= 0 && buffer.GetCount() >= uiBodyStart + static_cast<ezUInt32>(iContentLength))
+        break; // request is complete
+
+      if (buffer.GetCount() > uiMaxRequestSize)
+        return; // hang up on something that is not going to become a valid request
+
+      const ezInt32 iRead = client.Receive(chunk, EZ_ARRAY_SIZE(chunk));
+
+      if (iRead <= 0)
+        return; // peer hung up, timed out, or errored - either way there is nothing to answer
+
+      buffer.PushBackRange(ezArrayPtr<const ezUInt8>(chunk, static_cast<ezUInt32>(iRead)));
+    }
+
+    ezMcpHttpRequest request;
+    ParseRequestLine(ezStringView(reinterpret_cast<const char*>(buffer.GetData()), static_cast<ezUInt32>(iHeaderEnd)), request);
+    request.m_sBody = ezStringView(reinterpret_cast<const char*>(buffer.GetData()) + uiBodyStart, static_cast<ezUInt32>(iContentLength));
+
+    ezMcpHttpResponse response;
+
+    if (m_pOwner->DispatchAndWait(request, response).Failed())
+      return; // the transport was stopped before the main thread got to this - drop the connection
+
+    SendResponse(client, response);
+  }
+
+  /// \brief Splits "POST /mcp HTTP/1.1" into the two parts we care about.
+  ///
+  /// Done by hand rather than with ezStringBuilder::Split(), whose result views would point into a
+  /// builder that goes out of scope here.
+  static void ParseRequestLine(ezStringView sHeaders, ezMcpHttpRequest& ref_request)
+  {
+    const char* szStart = sHeaders.GetStartPointer();
+    const char* szEnd = sHeaders.GetEndPointer();
+
+    if (const char* szLineEnd = sHeaders.FindSubString("\r\n"))
+    {
+      szEnd = szLineEnd;
+    }
+
+    const char* szFirstSpace = szStart;
+    while (szFirstSpace < szEnd && *szFirstSpace != ' ')
+      ++szFirstSpace;
+
+    ref_request.m_sMethod = ezStringView(szStart, szFirstSpace);
+
+    if (szFirstSpace >= szEnd)
+      return;
+
+    const char* szPathStart = szFirstSpace + 1;
+    const char* szSecondSpace = szPathStart;
+    while (szSecondSpace < szEnd && *szSecondSpace != ' ')
+      ++szSecondSpace;
+
+    ref_request.m_sPath = ezStringView(szPathStart, szSecondSpace);
+  }
+
+  static void SendResponse(ezMcpSocket& client, const ezMcpHttpResponse& response)
+  {
+    ezStringBuilder sHeader;
+    sHeader.SetFormat("HTTP/1.1 {}\r\n"
+                      "Content-Type: application/json\r\n"
+                      "Content-Length: {}\r\n"
+                      "Connection: close\r\n"
+                      "\r\n",
+      response.m_sStatus, response.m_sBody.GetElementCount());
+
+    if (client.SendAll(sHeader.GetData(), sHeader.GetElementCount()).Failed())
+      return;
+
+    if (!response.m_sBody.IsEmpty())
+    {
+      client.SendAll(response.m_sBody.GetData(), response.m_sBody.GetElementCount()).IgnoreResult();
+    }
+  }
+
+  ezMcpTransport* m_pOwner = nullptr;
+};
+
+ezMcpTransport::ezMcpTransport() = default;
+
+ezMcpTransport::~ezMcpTransport()
+{
+  Stop();
+}
+
+ezResult ezMcpTransport::Start(ezUInt16 uiPort, RequestHandler handler)
+{
+  Stop();
+
+  ezUniquePtr<ezMcpTransportThread> pThread = EZ_DEFAULT_NEW(ezMcpTransportThread, this);
+
+  if (pThread->m_Listener.Listen(uiPort).Failed())
+    return EZ_FAILURE;
+
+  m_uiPort = pThread->m_Listener.GetPort();
+  m_Handler = handler;
+  m_bShutdown = false;
+
+  m_pThread = std::move(pThread);
+  m_pThread->Start();
+
+  return EZ_SUCCESS;
+}
+
+void ezMcpTransport::Stop()
+{
+  if (m_pThread == nullptr)
+    return;
+
+  {
+    EZ_LOCK(m_Mutex);
+    m_bShutdown = true;
+  }
+
+  // release a transport thread that is waiting for a response the main thread is never going to give it
+  m_ResponseSignal.RaiseSignal();
+
+  m_pThread->m_iStopRequested.Increment();
+  m_pThread->Join();
+  m_pThread->m_Listener.Close();
+  m_pThread = nullptr;
+
+  m_uiPort = 0;
+  m_Handler = {};
+
+  {
+    EZ_LOCK(m_Mutex);
+    m_pPendingRequest = nullptr;
+    m_pPendingResponse = nullptr;
+    m_bShutdown = false;
+  }
+}
+
+bool ezMcpTransport::HasPendingRequest() const
+{
+  EZ_LOCK(m_Mutex);
+  return m_pPendingRequest != nullptr && !m_bRequestAnswered;
+}
+
+ezResult ezMcpTransport::DispatchAndWait(const ezMcpHttpRequest& request, ezMcpHttpResponse& out_response)
+{
+  {
+    EZ_LOCK(m_Mutex);
+
+    if (m_bShutdown)
+      return EZ_FAILURE;
+
+    m_pPendingRequest = &request;
+    m_pPendingResponse = &out_response;
+    m_bRequestAnswered = false;
+  }
+
+  // The main thread may take arbitrarily long over this - a project export or a C++ build runs for
+  // minutes - so there is deliberately no timeout here. A client that gives up simply closes its end.
+  while (true)
+  {
+    m_ResponseSignal.WaitForSignal();
+
+    EZ_LOCK(m_Mutex);
+
+    if (m_bShutdown)
+    {
+      m_pPendingRequest = nullptr;
+      m_pPendingResponse = nullptr;
+      return EZ_FAILURE;
+    }
+
+    if (m_bRequestAnswered)
+    {
+      m_pPendingRequest = nullptr;
+      m_pPendingResponse = nullptr;
+      return EZ_SUCCESS;
+    }
+  }
+}
+
+void ezMcpTransport::ProcessPendingRequests()
+{
+  const ezMcpHttpRequest* pRequest = nullptr;
+  ezMcpHttpResponse* pResponse = nullptr;
+
+  {
+    EZ_LOCK(m_Mutex);
+
+    if (m_pPendingRequest == nullptr || m_bRequestAnswered)
+      return;
+
+    pRequest = m_pPendingRequest;
+    pResponse = m_pPendingResponse;
+  }
+
+  // Outside the lock: this runs the tool, which may take minutes, and holding the mutex for that would
+  // block the transport thread out of Stop() as well.
+  if (m_Handler.IsValid())
+  {
+    pResponse->m_bDeferred = false;
+    m_Handler(*pRequest, *pResponse);
+
+    // The handler wants to be asked again rather than answered. Leaving the request pending is all that
+    // takes: the transport thread is already blocked on the signal, and the client on its socket.
+    if (pResponse->m_bDeferred)
+      return;
+  }
+  else
+  {
+    pResponse->m_sStatus = "503 Service Unavailable";
+    pResponse->m_sBody.Clear();
+  }
+
+  {
+    EZ_LOCK(m_Mutex);
+    m_bRequestAnswered = true;
+  }
+
+  m_ResponseSignal.RaiseSignal();
+}

--- a/Code/Engine/Mcp/McpTransport.h
+++ b/Code/Engine/Mcp/McpTransport.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <Mcp/McpDLL.h>
+
+#include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Threading/Mutex.h>
+#include <Foundation/Threading/ThreadSignal.h>
+#include <Foundation/Types/Delegate.h>
+#include <Foundation/Types/UniquePtr.h>
+
+class ezMcpTransportThread;
+
+/// \brief One HTTP request, as far as the transport understands it.
+struct ezMcpHttpRequest
+{
+  ezString m_sMethod;
+  ezString m_sPath;
+  ezStringBuilder m_sBody;
+};
+
+/// \brief The answer to one request.
+struct ezMcpHttpResponse
+{
+  /// E.g. "200 OK". The transport turns this into a status line and adds the headers.
+  ezStringBuilder m_sStatus = "200 OK";
+
+  /// May be empty, e.g. for the 202 that a JSON-RPC notification is answered with.
+  ezStringBuilder m_sBody;
+
+  /// \brief Set by the handler to mean "not yet - ask me again next time you pump".
+  ///
+  /// The request stays pending and the client keeps waiting, which is what a tool that has to let the
+  /// host run for a while needs. The transport resets it before each attempt, so a handler only has to
+  /// set it, never clear it. See ezMcpToolResult::m_bNotFinished.
+  bool m_bDeferred = false;
+};
+
+/// \brief Accepts HTTP requests on a socket and hands them to the main thread to be answered.
+///
+/// Deliberately not an event loop. A tool call may touch anything in the host - the world, the editor's
+/// documents, the renderer - none of which is thread safe, so the answer has to be produced on the main
+/// thread. The socket work is what happens on the transport's own thread:
+///
+///   transport thread                      main thread
+///   ----------------                      -----------
+///   accept, read the request
+///   publish it, then wait  --------->     ProcessPendingRequests() picks it up
+///                                         the handler runs the tool
+///                          <---------     publishes the response and wakes the transport
+///   write the response, close
+///
+/// Only one request is in flight at a time. That mirrors what the server does anyway - one request per
+/// connection, `Connection: close` - and it means a tool never has to reason about a second call
+/// arriving while it runs.
+///
+/// The consequence to be aware of: while the main thread does not call ProcessPendingRequests(), a
+/// client just waits. That is the same behaviour a blocking tool call has always had, but it now also
+/// applies to a host whose main loop is idle.
+class EZ_MCP_DLL ezMcpTransport
+{
+public:
+  /// \brief Produces the response to one request. Always called on the main thread.
+  using RequestHandler = ezDelegate<void(const ezMcpHttpRequest& request, ezMcpHttpResponse& ref_response)>;
+
+  ezMcpTransport();
+  ~ezMcpTransport();
+
+  /// \brief Binds to 127.0.0.1 at the given port and starts the transport thread.
+  ezResult Start(ezUInt16 uiPort, RequestHandler handler);
+
+  /// \brief Stops the thread and closes the socket. Safe to call when not running.
+  ///
+  /// A request that is waiting for an answer at that moment is abandoned rather than answered - the
+  /// client sees the connection close, which is the honest report of a server that went away.
+  void Stop();
+
+  bool IsRunning() const { return m_pThread != nullptr; }
+
+  /// \brief The port that is actually bound, or 0 while not running.
+  ezUInt16 GetPort() const { return m_uiPort; }
+
+  /// \brief Answers a request if one is waiting. Call this once per frame from the main thread.
+  ///
+  /// Does nothing when no request is pending, so it is cheap enough to call unconditionally.
+  void ProcessPendingRequests();
+
+  /// \brief Whether a request is waiting to be answered.
+  ///
+  /// For a host whose main loop sleeps when idle: it has to wake up and pump when this turns true, or
+  /// the client waits forever.
+  bool HasPendingRequest() const;
+
+private:
+  friend class ezMcpTransportThread;
+
+  /// Called by the transport thread. Publishes the request, waits for the main thread to answer it, and
+  /// returns EZ_FAILURE if the transport was stopped before that happened.
+  ezResult DispatchAndWait(const ezMcpHttpRequest& request, ezMcpHttpResponse& out_response);
+
+  RequestHandler m_Handler;
+  ezUniquePtr<ezMcpTransportThread> m_pThread;
+  ezUInt16 m_uiPort = 0;
+
+  mutable ezMutex m_Mutex;
+  const ezMcpHttpRequest* m_pPendingRequest = nullptr;
+  ezMcpHttpResponse* m_pPendingResponse = nullptr;
+  bool m_bRequestAnswered = false;
+  bool m_bShutdown = false;
+
+  /// Raised by the main thread once it has filled in the response, and by Stop() to release a transport
+  /// thread that would otherwise wait for an answer that is never coming.
+  ezThreadSignal m_ResponseSignal;
+};

--- a/Code/Engine/Mcp/Platform/Posix/McpSocket_Posix.cpp
+++ b/Code/Engine/Mcp/Platform/Posix/McpSocket_Posix.cpp
@@ -1,0 +1,160 @@
+#include <Mcp/McpPCH.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_LINUX) || EZ_ENABLED(EZ_PLATFORM_OSX) || EZ_ENABLED(EZ_PLATFORM_ANDROID)
+
+#  include <Mcp/McpSocket.h>
+
+#  include <arpa/inet.h>
+#  include <errno.h>
+#  include <netinet/in.h>
+#  include <sys/select.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+
+// macOS has no MSG_NOSIGNAL; it spells the same thing SO_NOSIGPIPE, as a socket option
+#  ifndef MSG_NOSIGNAL
+#    define MSG_NOSIGNAL 0
+#  endif
+
+ezMcpSocket::ezMcpSocket() = default;
+
+ezMcpSocket::~ezMcpSocket()
+{
+  Close();
+}
+
+ezResult ezMcpSocket::Listen(ezUInt16 uiPort)
+{
+  Close();
+
+  const int iSocket = socket(AF_INET, SOCK_STREAM, 0);
+
+  if (iSocket < 0)
+  {
+    ezLog::Error("MCP: Could not create a socket: {}", errno);
+    return EZ_FAILURE;
+  }
+
+  // Without this a port stays unusable for a couple of minutes after the process that held it exited,
+  // which turns 'restart the editor' into 'restart the editor and wait'.
+  const int iReuse = 1;
+  setsockopt(iSocket, SOL_SOCKET, SO_REUSEADDR, &iReuse, sizeof(iReuse));
+
+  sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(uiPort);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+  if (bind(iSocket, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) < 0)
+  {
+    ezLog::Warning("MCP: Could not bind to port {}: {}", uiPort, errno);
+    close(iSocket);
+    return EZ_FAILURE;
+  }
+
+  if (listen(iSocket, SOMAXCONN) < 0)
+  {
+    ezLog::Error("MCP: Could not listen on port {}: {}", uiPort, errno);
+    close(iSocket);
+    return EZ_FAILURE;
+  }
+
+  // read the port back off the socket, so that a caller which passed 0 learns what it actually got
+  sockaddr_in bound = {};
+  socklen_t boundSize = sizeof(bound);
+
+  if (getsockname(iSocket, reinterpret_cast<sockaddr*>(&bound), &boundSize) == 0)
+  {
+    m_uiPort = ntohs(bound.sin_port);
+  }
+  else
+  {
+    m_uiPort = uiPort;
+  }
+
+  m_iSocket = iSocket;
+  return EZ_SUCCESS;
+}
+
+void ezMcpSocket::Close()
+{
+  if (m_iSocket < 0)
+    return;
+
+  close(static_cast<int>(m_iSocket));
+
+  m_iSocket = -1;
+  m_uiPort = 0;
+}
+
+ezResult ezMcpSocket::Accept(ezMcpSocket& out_client, ezTime timeout)
+{
+  if (m_iSocket < 0)
+    return EZ_FAILURE;
+
+  const int iListener = static_cast<int>(m_iSocket);
+
+  fd_set readable;
+  FD_ZERO(&readable);
+  FD_SET(iListener, &readable);
+
+  timeval tv = {};
+  tv.tv_sec = static_cast<time_t>(timeout.GetSeconds());
+  tv.tv_usec = static_cast<suseconds_t>((timeout - ezTime::MakeFromSeconds(static_cast<double>(tv.tv_sec))).GetMicroseconds());
+
+  if (select(iListener + 1, &readable, nullptr, nullptr, &tv) != 1)
+    return EZ_FAILURE;
+
+  const int iClient = accept(iListener, nullptr, nullptr);
+
+  if (iClient < 0)
+    return EZ_FAILURE;
+
+  // A client that connects and then never sends anything would otherwise hold the transport thread
+  // forever, and with it every later request.
+  timeval recvTimeout = {};
+  recvTimeout.tv_sec = 10;
+  setsockopt(iClient, SOL_SOCKET, SO_RCVTIMEO, &recvTimeout, sizeof(recvTimeout));
+
+#  ifdef SO_NOSIGPIPE
+  // the macOS spelling of MSG_NOSIGNAL: a client hanging up mid-response must not raise SIGPIPE
+  const int iNoSigPipe = 1;
+  setsockopt(iClient, SOL_SOCKET, SO_NOSIGPIPE, &iNoSigPipe, sizeof(iNoSigPipe));
+#  endif
+
+  out_client.Close();
+  out_client.m_iSocket = iClient;
+  return EZ_SUCCESS;
+}
+
+ezInt32 ezMcpSocket::Receive(void* pBuffer, ezUInt32 uiSize)
+{
+  if (m_iSocket < 0)
+    return -1;
+
+  return static_cast<ezInt32>(recv(static_cast<int>(m_iSocket), pBuffer, uiSize, 0));
+}
+
+ezResult ezMcpSocket::SendAll(const void* pBuffer, ezUInt32 uiSize)
+{
+  if (m_iSocket < 0)
+    return EZ_FAILURE;
+
+  const char* pBytes = static_cast<const char*>(pBuffer);
+  ezUInt32 uiSent = 0;
+
+  while (uiSent < uiSize)
+  {
+    // MSG_NOSIGNAL: a client that hangs up mid-response must not take the process down with SIGPIPE
+    const ssize_t iResult = send(static_cast<int>(m_iSocket), pBytes + uiSent, uiSize - uiSent, MSG_NOSIGNAL);
+
+    if (iResult <= 0)
+      return EZ_FAILURE;
+
+    uiSent += static_cast<ezUInt32>(iResult);
+  }
+
+  return EZ_SUCCESS;
+}
+
+#endif

--- a/Code/Engine/Mcp/Platform/Win/McpSocket_Win.cpp
+++ b/Code/Engine/Mcp/Platform/Win/McpSocket_Win.cpp
@@ -1,0 +1,186 @@
+#include <Mcp/McpPCH.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+
+#  include <Mcp/McpSocket.h>
+
+#  include <Foundation/Threading/AtomicUtils.h>
+
+#  include <WS2tcpip.h>
+#  include <WinSock2.h>
+
+namespace
+{
+  ezAtomicInteger32 g_iWinsockRefCount;
+
+  /// Winsock has to be initialised per process, but the MCP library has no startup of its own and may
+  /// be used by a plugin that is loaded and unloaded repeatedly. Ref counting it around the sockets
+  /// that need it keeps that self contained.
+  void AddWinsockRef()
+  {
+    if (g_iWinsockRefCount.Increment() != 1)
+      return;
+
+    WSADATA data;
+    if (WSAStartup(MAKEWORD(2, 2), &data) != 0)
+    {
+      ezLog::Error("MCP: WSAStartup failed: {}", WSAGetLastError());
+    }
+  }
+
+  void ReleaseWinsockRef()
+  {
+    if (g_iWinsockRefCount.Decrement() == 0)
+    {
+      WSACleanup();
+    }
+  }
+
+  SOCKET ToSocket(ezInt64 iSocket)
+  {
+    return iSocket < 0 ? INVALID_SOCKET : static_cast<SOCKET>(iSocket);
+  }
+} // namespace
+
+ezMcpSocket::ezMcpSocket()
+{
+  AddWinsockRef();
+}
+
+ezMcpSocket::~ezMcpSocket()
+{
+  Close();
+  ReleaseWinsockRef();
+}
+
+ezResult ezMcpSocket::Listen(ezUInt16 uiPort)
+{
+  Close();
+
+  const SOCKET sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+  if (sock == INVALID_SOCKET)
+  {
+    ezLog::Error("MCP: Could not create a socket: {}", WSAGetLastError());
+    return EZ_FAILURE;
+  }
+
+  // Not SO_REUSEADDR: on Windows that does not only cover a port left over from an exited process, it
+  // lets a *second* live process bind the same port, after which which of the two gets a connection is
+  // undefined. Two editors on one port would then silently answer each other's tool calls instead of
+  // the second one failing to bind, which is what the per-editor port exists to make happen.
+  // SO_EXCLUSIVEADDRUSE is the opposite request: refuse to share, and refuse to be taken over.
+  const BOOL bExclusive = TRUE;
+  setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char*>(&bExclusive), sizeof(bExclusive));
+
+  sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(uiPort);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+  if (bind(sock, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR)
+  {
+    ezLog::Warning("MCP: Could not bind to port {}: {}", uiPort, WSAGetLastError());
+    closesocket(sock);
+    return EZ_FAILURE;
+  }
+
+  if (listen(sock, SOMAXCONN) == SOCKET_ERROR)
+  {
+    ezLog::Error("MCP: Could not listen on port {}: {}", uiPort, WSAGetLastError());
+    closesocket(sock);
+    return EZ_FAILURE;
+  }
+
+  // read the port back off the socket, so that a caller which passed 0 learns what it actually got
+  sockaddr_in bound = {};
+  int iBoundSize = sizeof(bound);
+
+  if (getsockname(sock, reinterpret_cast<sockaddr*>(&bound), &iBoundSize) == 0)
+  {
+    m_uiPort = ntohs(bound.sin_port);
+  }
+  else
+  {
+    m_uiPort = uiPort;
+  }
+
+  m_iSocket = static_cast<ezInt64>(sock);
+  return EZ_SUCCESS;
+}
+
+void ezMcpSocket::Close()
+{
+  if (m_iSocket < 0)
+    return;
+
+  closesocket(ToSocket(m_iSocket));
+
+  m_iSocket = -1;
+  m_uiPort = 0;
+}
+
+ezResult ezMcpSocket::Accept(ezMcpSocket& out_client, ezTime timeout)
+{
+  if (m_iSocket < 0)
+    return EZ_FAILURE;
+
+  const SOCKET listener = ToSocket(m_iSocket);
+
+  fd_set readable;
+  FD_ZERO(&readable);
+  FD_SET(listener, &readable);
+
+  timeval tv = {};
+  tv.tv_sec = static_cast<long>(timeout.GetSeconds());
+  tv.tv_usec = static_cast<long>((timeout - ezTime::MakeFromSeconds(tv.tv_sec)).GetMicroseconds());
+
+  // the first argument is ignored on Windows, but is part of the signature
+  if (select(0, &readable, nullptr, nullptr, &tv) != 1)
+    return EZ_FAILURE;
+
+  const SOCKET client = accept(listener, nullptr, nullptr);
+
+  if (client == INVALID_SOCKET)
+    return EZ_FAILURE;
+
+  // A client that connects and then never sends anything would otherwise hold the transport thread
+  // forever, and with it every later request.
+  const DWORD uiTimeoutMS = 10000;
+  setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&uiTimeoutMS), sizeof(uiTimeoutMS));
+
+  out_client.Close();
+  out_client.m_iSocket = static_cast<ezInt64>(client);
+  return EZ_SUCCESS;
+}
+
+ezInt32 ezMcpSocket::Receive(void* pBuffer, ezUInt32 uiSize)
+{
+  if (m_iSocket < 0)
+    return -1;
+
+  return static_cast<ezInt32>(recv(ToSocket(m_iSocket), static_cast<char*>(pBuffer), static_cast<int>(uiSize), 0));
+}
+
+ezResult ezMcpSocket::SendAll(const void* pBuffer, ezUInt32 uiSize)
+{
+  if (m_iSocket < 0)
+    return EZ_FAILURE;
+
+  const char* pBytes = static_cast<const char*>(pBuffer);
+  ezUInt32 uiSent = 0;
+
+  while (uiSent < uiSize)
+  {
+    const int iResult = send(ToSocket(m_iSocket), pBytes + uiSent, static_cast<int>(uiSize - uiSent), 0);
+
+    if (iResult <= 0)
+      return EZ_FAILURE;
+
+    uiSent += static_cast<ezUInt32>(iResult);
+  }
+
+  return EZ_SUCCESS;
+}
+
+#endif

--- a/Code/Engine/Mcp/Tools/McpAppTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpAppTool.cpp
@@ -111,7 +111,7 @@ void ezMcpAppTool::Execute(ezStringView sToolName, const ezVariantDictionary& ar
   }
 }
 
-void ezMcpAppTool::ExecutePing(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+void ezMcpAppTool::ExecutePing(const ezVariantDictionary& /*arguments*/, ezMcpToolResult& out_result)
 {
   ezMcpJsonWriter writer;
   writer.BeginObject();
@@ -212,7 +212,7 @@ void ezMcpAppTool::ExecuteCommandLineOptions(const ezVariantDictionary& argument
   out_result.m_sText = writer.GetResult();
 }
 
-void ezMcpAppTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+void ezMcpAppTool::ExecuteInfo(const ezVariantDictionary& /*arguments*/, ezMcpToolResult& out_result)
 {
   const ezMcpServer* pServer = ezMcpServer::GetInstance();
   const ezUInt16 uiPort = pServer != nullptr ? pServer->GetPort() : 0;

--- a/Code/Engine/Mcp/Tools/McpAppTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpAppTool.cpp
@@ -1,0 +1,280 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpServer.h>
+#include <Mcp/Tools/McpAppTool.h>
+
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/System/Process.h>
+#include <Foundation/Utilities/CommandLineOptions.h>
+#include <Foundation/Utilities/CommandLineUtils.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpAppTool, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezStringView ezMcpAppTool::GetBuildTimestamp() const
+{
+  // when this library was compiled - a host that ships its tools in a separate, faster moving plugin
+  // should override this with that plugin's own timestamp
+  return __DATE__ " " __TIME__;
+}
+
+void ezMcpAppTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  const ezStringView sHost = GetHostNoun();
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "app_quit";
+
+    ezStringBuilder sDesc;
+    sDesc.SetFormat("Shuts this {0} process down. The response is sent before it exits, but every other tool "
+                    "stops answering immediately afterwards - this is the last call to this {0}.\n",
+      sHost);
+    sDesc.Append(GetRelaunchHint());
+    desc.m_sDescription = sDesc;
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"discardChanges":{"type":"boolean","description":"Quit even though there are unsaved changes, losing them. Default false."}}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "app_ping";
+
+    ezStringBuilder sDesc;
+    sDesc.SetFormat("Returns immediately, to check that the {0} is still responsive. Answering requires a working main "
+                    "thread, so a reply means the {0} is genuinely usable, not merely that the port is still open. Use it "
+                    "after a call that may have blocked - a modal dialog or a long running action leaves the process stuck "
+                    "with its port bound but nothing being served, and this is the cheapest way to tell that apart from one "
+                    "that is simply busy. If it does not answer within a few seconds, the process has to be killed by process "
+                    "id; app_quit will not get through either. Get the process id from app_info up front, since it cannot be "
+                    "retrieved once the {0} stops answering.",
+      sHost);
+    desc.m_sDescription = sDesc;
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "app_info";
+
+    ezStringBuilder sDesc;
+    sDesc.SetFormat("Returns how to talk to and restart this {0}: the port it serves MCP on, the executable that runs it, the "
+                    "process id and the command line it was started with. Use it to launch another one the same way, or to "
+                    "launch a replacement after app_quit - the executable path is not otherwise discoverable, and a different "
+                    "port is what allows a second process to run alongside this one. Also returns where this process writes "
+                    "its log on disk, which is worth reading when it stopped answering: log_read only serves messages from a "
+                    "live process, and only from this one.",
+      sHost);
+    desc.m_sDescription = sDesc;
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "app_command_line_options";
+
+    ezStringBuilder sDesc;
+    sDesc.SetFormat("Lists every command line option this {0} supports, with its type, default value and description. This is "
+                    "more complete than running it with '-help': options declared by plugins - the MCP port among them - only "
+                    "exist once their plugin is loaded, which happens after '-help' has already printed. Use it to find out "
+                    "how to launch a process with a particular configuration.",
+      sHost);
+    desc.m_sDescription = sDesc;
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"contains":{"type":"string","description":"Only return options whose name or description contains this text, case insensitive. Omit for all of them."}}})";
+  }
+}
+
+void ezMcpAppTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "app_ping")
+  {
+    ExecutePing(arguments, out_result);
+  }
+  else if (sToolName == "app_quit")
+  {
+    ExecuteQuit(arguments, out_result);
+  }
+  else if (sToolName == "app_info")
+  {
+    ExecuteInfo(arguments, out_result);
+  }
+  else if (sToolName == "app_command_line_options")
+  {
+    ExecuteCommandLineOptions(arguments, out_result);
+  }
+}
+
+void ezMcpAppTool::ExecutePing(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableBool("responsive", true);
+
+  // Included so that a caller which pings once at the start has the process id on hand later, when a
+  // blocked process cannot be asked for anything at all and killing it is the only option left.
+  writer.AddVariableUInt32("processId", ezProcess::GetCurrentProcessID());
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAppTool::ExecuteCommandLineOptions(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sContains = ezMcpJson::GetString(arguments, "contains");
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezUInt32 uiTotalOptions = 0;
+  ezUInt32 uiReturned = 0;
+
+  ezStringBuilder sOptions, sShortDesc, sDefaultValue, sLongDesc, sGroup;
+
+  writer.BeginArray("options");
+
+  // The options register themselves into this list from wherever they are declared, including plugin
+  // DLLs, so anything loaded by now is covered.
+  for (ezCommandLineOption* pOpt = ezCommandLineOption::GetFirstInstance(); pOpt != nullptr; pOpt = pOpt->GetNextInstance())
+  {
+    pOpt->GetOptions(sOptions);
+    pOpt->GetLongDesc(sLongDesc);
+    sLongDesc.Trim(" \t\n\r");
+
+    ++uiTotalOptions;
+
+    if (!sContains.IsEmpty())
+    {
+      if (sOptions.FindSubString_NoCase(sContains) == nullptr && sLongDesc.FindSubString_NoCase(sContains) == nullptr)
+        continue;
+    }
+
+    pOpt->GetParamShortDesc(sShortDesc);
+    pOpt->GetParamDefaultValueDesc(sDefaultValue);
+    pOpt->GetSortingGroup(sGroup);
+
+    writer.BeginObject();
+
+    // One option can have several spellings, e.g. '-h;-help;-?', so they are reported as a list
+    // rather than as the raw separated string.
+    ezTempHybridArray<ezStringView, 4> names;
+    sOptions.Split(false, names, ";", "|");
+
+    writer.BeginArray("names");
+    for (ezStringView sName : names)
+    {
+      writer.WriteString(sName);
+    }
+    writer.EndArray();
+
+    writer.AddVariableString("type", pOpt->GetType());
+
+    if (!sShortDesc.IsEmpty())
+    {
+      writer.AddVariableString("parameter", sShortDesc);
+    }
+
+    if (!sDefaultValue.IsEmpty())
+    {
+      writer.AddVariableString("default", sDefaultValue);
+    }
+
+    if (!sLongDesc.IsEmpty())
+    {
+      writer.AddVariableString("description", sLongDesc);
+    }
+
+    if (!sGroup.IsEmpty())
+    {
+      writer.AddVariableString("group", sGroup);
+    }
+
+    writer.EndObject();
+
+    ++uiReturned;
+  }
+
+  writer.EndArray();
+
+  // Not capped, unlike the listing tools: the number of options is bounded by what is compiled in and
+  // is small, so there is nothing to truncate and no 'truncated' flag to report. 'totalOptions' is
+  // still worth having, because it tells a filtered call how much it filtered away.
+  writer.AddVariableUInt32("returned", uiReturned);
+  writer.AddVariableUInt32("totalOptions", uiTotalOptions);
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAppTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezMcpServer* pServer = ezMcpServer::GetInstance();
+  const ezUInt16 uiPort = pServer != nullptr ? pServer->GetPort() : 0;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("executable", ezOSFile::GetApplicationPath());
+  writer.AddVariableUInt32("processId", ezProcess::GetCurrentProcessID());
+
+  // Compare this against when the source last changed before concluding that a tool is missing: a
+  // binary that predates the feature reports exactly the same tool list as one that never had it.
+  writer.AddVariableString("buildTimestamp", GetBuildTimestamp());
+
+  writer.AddVariableUInt32("mcpPort", uiPort);
+
+  ezStringBuilder sUrl;
+  sUrl.SetFormat("http://127.0.0.1:{}/mcp", uiPort);
+  writer.AddVariableString("mcpUrl", sUrl);
+
+  // The command line this process was started with, so that another one can be launched the same way.
+  // Whether the executable itself appears as the first entry is platform dependent, which is why it
+  // is also reported on its own above.
+  const ezCommandLineUtils* pCmd = ezCommandLineUtils::GetGlobalInstance();
+
+  writer.BeginArray("commandLine");
+  for (ezUInt32 i = 0; i < pCmd->GetParameterCount(); ++i)
+  {
+    writer.WriteString(pCmd->GetParameter(i));
+  }
+  writer.EndArray();
+
+  AddHostInfo(writer);
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpAppTool::ExecuteQuit(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const bool bDiscardChanges = ezMcpJson::GetBool(arguments, "discardChanges", false);
+
+  const bool bRefused = CanQuit(bDiscardChanges).Failed();
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableBool("quitting", !bRefused);
+
+  if (bRefused)
+  {
+    AddQuitRefusalInfo(writer);
+    writer.EndObject();
+
+    // an error, so the agent cannot mistake this for a successful shutdown and stop waiting
+    out_result.m_sText = writer.GetResult();
+    out_result.m_bIsError = true;
+    return;
+  }
+
+  AddQuitInfo(writer);
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+
+  RequestQuit(bDiscardChanges);
+}

--- a/Code/Engine/Mcp/Tools/McpAppTool.h
+++ b/Code/Engine/Mcp/Tools/McpAppTool.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezMcpJsonWriter;
+
+/// \brief Tools that act on the process itself, rather than on whatever it has loaded.
+///
+/// These exist to close the automation loop: an agent that can launch a process (with '-mcpport' to get
+/// its own port), query it and then shut it down again can test a change without a human in between.
+///
+/// **Abstract on purpose.** Almost all of this is process level rather than editor or game level - the
+/// process id, the executable path, the command line, the bound port - so the editor and a running game
+/// answer the same four questions and should not make an agent learn two names for each. What differs
+/// is host specific and reachable through the virtuals below. ezMcpToolRegistry only instantiates
+/// providers whose RTTI can allocate, so declaring this one with ezRTTINoAllocator is what keeps the
+/// base from registering its tool names alongside the concrete host's.
+class EZ_MCP_DLL ezMcpAppTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpAppTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+protected:
+  /// \brief What this process is, e.g. "editor" or "game". Used in the tool descriptions, so that an
+  /// agent talking to two servers at once can tell which one it is addressing.
+  virtual ezStringView GetHostNoun() const = 0;
+
+  /// \brief How to start another process like this one, appended to app_quit's description.
+  ///
+  /// Everything an agent needs has to be in the tool list - it has no repo access and no prior session -
+  /// so this is where 'which executable, which arguments' gets said.
+  virtual ezStringView GetRelaunchHint() const = 0;
+
+  /// \brief When the binary serving MCP was compiled, reported by app_info as 'buildTimestamp'.
+  ///
+  /// Exists because a stale binary is indistinguishable from a missing feature: an agent working from a
+  /// `tools/list` produced by a build from a few days ago reports tools as absent, and nothing in the
+  /// protocol reveals the mismatch. Comparing this against when the source was last changed does.
+  ///
+  /// The default is when the Mcp library itself was built. A host whose own plugin changes more often
+  /// than the library should override this with its own __DATE__ " " __TIME__ - the tool list comes from
+  /// the plugin, so that is the binary whose age actually explains a missing tool.
+  virtual ezStringView GetBuildTimestamp() const;
+
+  /// \brief Anything host specific that app_info should report, added to the same object.
+  virtual void AddHostInfo(ezMcpJsonWriter& ref_writer) {}
+
+  /// \brief Whether quitting is allowed right now. Return EZ_FAILURE to refuse.
+  ///
+  /// A refusal must never be a question to the user: a modal dialog with nobody at the keyboard never
+  /// returns, and the process then hangs holding its port. Destructive choices are parameters, which is
+  /// what \a bDiscardChanges is.
+  virtual ezResult CanQuit(bool bDiscardChanges) { return EZ_SUCCESS; }
+
+  /// \brief Explains a refusal from CanQuit(). Writes into the result object, after "quitting": false.
+  virtual void AddQuitRefusalInfo(ezMcpJsonWriter& ref_writer) {}
+
+  /// \brief Anything worth reporting about a quit that is going ahead, e.g. what got discarded.
+  virtual void AddQuitInfo(ezMcpJsonWriter& ref_writer) {}
+
+  /// \brief Actually shuts the process down.
+  ///
+  /// Must defer the shutdown past the end of this call. The response has not reached the socket yet, so
+  /// quitting synchronously drops it and leaves the caller waiting on a connection that closes with no
+  /// answer - which is indistinguishable from a crash.
+  virtual void RequestQuit(bool bDiscardChanges) = 0;
+
+private:
+  void ExecutePing(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteQuit(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteCommandLineOptions(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+};

--- a/Code/Engine/Mcp/Tools/McpCVarTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpCVarTool.cpp
@@ -18,11 +18,16 @@ namespace
   {
     switch (type)
     {
-      case ezCVarType::Int: return "int";
-      case ezCVarType::Float: return "float";
-      case ezCVarType::Bool: return "bool";
-      case ezCVarType::String: return "string";
-      default: return "unknown";
+      case ezCVarType::Int:
+        return "int";
+      case ezCVarType::Float:
+        return "float";
+      case ezCVarType::Bool:
+        return "bool";
+      case ezCVarType::String:
+        return "string";
+      default:
+        return "unknown";
     }
   }
 
@@ -65,11 +70,16 @@ namespace
   {
     switch (pCVar->GetType())
     {
-      case ezCVarType::Int: return static_cast<const ezCVarInt*>(pCVar)->HasDelayedSyncValueChanged();
-      case ezCVarType::Float: return static_cast<const ezCVarFloat*>(pCVar)->HasDelayedSyncValueChanged();
-      case ezCVarType::Bool: return static_cast<const ezCVarBool*>(pCVar)->HasDelayedSyncValueChanged();
-      case ezCVarType::String: return static_cast<const ezCVarString*>(pCVar)->HasDelayedSyncValueChanged();
-      default: return false;
+      case ezCVarType::Int:
+        return static_cast<const ezCVarInt*>(pCVar)->HasDelayedSyncValueChanged();
+      case ezCVarType::Float:
+        return static_cast<const ezCVarFloat*>(pCVar)->HasDelayedSyncValueChanged();
+      case ezCVarType::Bool:
+        return static_cast<const ezCVarBool*>(pCVar)->HasDelayedSyncValueChanged();
+      case ezCVarType::String:
+        return static_cast<const ezCVarString*>(pCVar)->HasDelayedSyncValueChanged();
+      default:
+        return false;
     }
   }
 } // namespace

--- a/Code/Engine/Mcp/Tools/McpCVarTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpCVarTool.cpp
@@ -1,0 +1,363 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/Tools/McpCVarTool.h>
+
+#include <Foundation/Configuration/CVar.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpCVarTool, 1, ezRTTIDefaultAllocator<ezMcpCVarTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// The names used in tool arguments and results, lower case because that is what the AI has to type.
+  ezStringView CVarTypeToString(ezCVarType::Enum type)
+  {
+    switch (type)
+    {
+      case ezCVarType::Int: return "int";
+      case ezCVarType::Float: return "float";
+      case ezCVarType::Bool: return "bool";
+      case ezCVarType::String: return "string";
+      default: return "unknown";
+    }
+  }
+
+  /// \brief Whether the CVar still holds the value it was declared with.
+  ///
+  /// One place, because both the listing filter and the decision whether to report 'default' need it,
+  /// and each type has to be compared through its own pointer cast.
+  bool IsAtDefaultValue(const ezCVar* pCVar)
+  {
+    switch (pCVar->GetType())
+    {
+      case ezCVarType::Int:
+      {
+        const ezCVarInt* p = static_cast<const ezCVarInt*>(pCVar);
+        return p->GetValue() == p->GetValue(ezCVarValue::Default);
+      }
+      case ezCVarType::Float:
+      {
+        const ezCVarFloat* p = static_cast<const ezCVarFloat*>(pCVar);
+        return p->GetValue() == p->GetValue(ezCVarValue::Default);
+      }
+      case ezCVarType::Bool:
+      {
+        const ezCVarBool* p = static_cast<const ezCVarBool*>(pCVar);
+        return p->GetValue() == p->GetValue(ezCVarValue::Default);
+      }
+      case ezCVarType::String:
+      {
+        const ezCVarString* p = static_cast<const ezCVarString*>(pCVar);
+        return p->GetValue() == p->GetValue(ezCVarValue::Default);
+      }
+      default:
+        return true;
+    }
+  }
+
+  /// \brief Whether a value was written that the engine is not reading yet. Only ever true for CVars
+  /// flagged RequiresDelayedSync.
+  bool HasPendingValue(const ezCVar* pCVar)
+  {
+    switch (pCVar->GetType())
+    {
+      case ezCVarType::Int: return static_cast<const ezCVarInt*>(pCVar)->HasDelayedSyncValueChanged();
+      case ezCVarType::Float: return static_cast<const ezCVarFloat*>(pCVar)->HasDelayedSyncValueChanged();
+      case ezCVarType::Bool: return static_cast<const ezCVarBool*>(pCVar)->HasDelayedSyncValueChanged();
+      case ezCVarType::String: return static_cast<const ezCVarString*>(pCVar)->HasDelayedSyncValueChanged();
+      default: return false;
+    }
+  }
+} // namespace
+
+void ezMcpCVarTool::WriteValue(ezMcpJsonWriter& ref_writer, ezStringView sFieldName, const ezCVar* pCVar, ezUInt32 uiWhichValue)
+{
+  const ezCVarValue::Enum which = static_cast<ezCVarValue::Enum>(uiWhichValue);
+
+  // Written as the JSON type that matches the CVar, not as a string: a client that reads a bool and
+  // writes it straight back must not have to know it was quoted on the way out.
+  switch (pCVar->GetType())
+  {
+    case ezCVarType::Int:
+      ref_writer.AddVariableInt32(sFieldName, static_cast<const ezCVarInt*>(pCVar)->GetValue(which));
+      break;
+    case ezCVarType::Float:
+      ref_writer.AddVariableFloat(sFieldName, static_cast<const ezCVarFloat*>(pCVar)->GetValue(which));
+      break;
+    case ezCVarType::Bool:
+      ref_writer.AddVariableBool(sFieldName, static_cast<const ezCVarBool*>(pCVar)->GetValue(which));
+      break;
+    case ezCVarType::String:
+      ref_writer.AddVariableString(sFieldName, static_cast<const ezCVarString*>(pCVar)->GetValue(which).GetView());
+      break;
+    default:
+      break;
+  }
+}
+
+void ezMcpCVarTool::WriteCVar(ezMcpJsonWriter& ref_writer, const ezCVar* pCVar)
+{
+  ref_writer.BeginObject();
+
+  ref_writer.AddVariableString("name", pCVar->GetName());
+  ref_writer.AddVariableString("type", CVarTypeToString(pCVar->GetType()));
+  WriteValue(ref_writer, "value", pCVar, ezCVarValue::Current);
+
+  // Only when it differs, per the 'omit empty fields' rule - a CVar sitting at its default is the
+  // common case and repeating the same number twice costs tokens without saying anything.
+  if (!IsAtDefaultValue(pCVar))
+  {
+    WriteValue(ref_writer, "default", pCVar, ezCVarValue::Default);
+  }
+
+  const ezBitflags<ezCVarFlags> flags = pCVar->GetFlags();
+
+  if (flags.IsSet(ezCVarFlags::RequiresDelayedSync))
+  {
+    // The trap this field exists for: writing such a CVar does not change what the engine reads until
+    // the owning subsystem syncs it, so a caller that only re-read 'value' would conclude its write was
+    // ignored. Reported whenever the flag is set, not only when a write is outstanding, because that is
+    // what tells a caller in advance that a write here will not take effect immediately.
+    ref_writer.AddVariableBool("requiresRestart", true);
+
+    if (HasPendingValue(pCVar))
+    {
+      WriteValue(ref_writer, "pendingValue", pCVar, ezCVarValue::DelayedSync);
+    }
+  }
+
+  if (flags.IsSet(ezCVarFlags::Save))
+  {
+    ref_writer.AddVariableBool("saved", true);
+  }
+
+  if (!pCVar->GetPluginName().IsEmpty())
+  {
+    ref_writer.AddVariableString("plugin", pCVar->GetPluginName());
+  }
+
+  if (!pCVar->GetDescription().IsEmpty())
+  {
+    ref_writer.AddVariableString("description", pCVar->GetDescription());
+  }
+
+  ref_writer.EndObject();
+}
+
+void ezMcpCVarTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "cvar_list";
+    desc.m_sDescription = "Lists the CVars registered in this process, with their current value, type, owning plugin and "
+                          "description. CVars are the debug and configuration switches the engine and its plugins declare - "
+                          "rendering, physics and AI visualisation, resource management - so this is how to find out what can "
+                          "be toggled at runtime without knowing about each feature in advance. Filter, do not dump: a process "
+                          "registers hundreds. 'default' is only reported when the CVar has been changed away from it, and "
+                          "'requiresRestart' marks the ones whose new value the engine will not read until the owning "
+                          "subsystem syncs it.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("contains":{"type":"string","description":"Only return CVars whose name or description contains this, case insensitive."},)"
+                          R"("plugin":{"type":"string","description":"Only return CVars declared by this plugin, case insensitive. Use cvar_list without filters first to see which plugin names exist."},)"
+                          R"("changedOnly":{"type":"boolean","description":"Only return CVars whose value differs from their default. Cheap way to see what this process was configured with. Default false."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "cvar_set";
+    desc.m_sDescription = "Changes the value of one CVar. The value is converted to the CVar's own type, so a number may be "
+                          "sent as a JSON number or as a string. Returns what the value was and what it is now.\n"
+                          "If the CVar is flagged 'requiresRestart', the write goes to a pending value and what the engine "
+                          "reads does NOT change until the owning subsystem syncs it - the response says so explicitly, "
+                          "because re-reading the CVar afterwards would otherwise look as though the write was ignored.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"The CVar to change. Case insensitive. Use cvar_list to find it."},)"
+                          R"("value":{"description":"The new value. Converted to the CVar's type; booleans also accept 'true'/'false' and 0/1."})"
+                          R"(},"required":["name","value"]})";
+  }
+}
+
+void ezMcpCVarTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "cvar_list")
+  {
+    ExecuteList(arguments, out_result);
+  }
+  else if (sToolName == "cvar_set")
+  {
+    ExecuteSet(arguments, out_result);
+  }
+}
+
+void ezMcpCVarTool::ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sContains = ezMcpJson::GetString(arguments, "contains");
+  const ezStringView sPlugin = ezMcpJson::GetString(arguments, "plugin");
+  const bool bChangedOnly = ezMcpJson::GetBool(arguments, "changedOnly", false);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezUInt32 uiTotalMatches = 0;
+  ezUInt32 uiReturned = 0;
+
+  writer.BeginArray("cvars");
+
+  // ezCVar is ezEnumerable, so every CVar of every loaded plugin is on this list without registration
+  for (const ezCVar* pCVar = ezCVar::GetFirstInstance(); pCVar != nullptr; pCVar = pCVar->GetNextInstance())
+  {
+    if (!sPlugin.IsEmpty() && !pCVar->GetPluginName().IsEqual_NoCase(sPlugin))
+      continue;
+
+    if (!sContains.IsEmpty())
+    {
+      const bool bInName = pCVar->GetName().FindSubString_NoCase(sContains) != nullptr;
+      const bool bInDesc = pCVar->GetDescription().FindSubString_NoCase(sContains) != nullptr;
+
+      if (!bInName && !bInDesc)
+        continue;
+    }
+
+    if (bChangedOnly && IsAtDefaultValue(pCVar))
+      continue;
+
+    ++uiTotalMatches;
+
+    if (uiReturned >= s_uiMaxResults)
+      continue; // keep counting, so that 'totalMatches' reports how much was left out
+
+    WriteCVar(writer, pCVar);
+    ++uiReturned;
+  }
+
+  writer.EndArray();
+
+  writer.AddVariableUInt32("totalMatches", uiTotalMatches);
+  writer.AddVariableUInt32("returned", uiReturned);
+
+  if (uiTotalMatches > uiReturned)
+  {
+    writer.AddVariableBool("truncated", true);
+  }
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpCVarTool::ExecuteSet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+
+  if (sName.IsEmpty())
+  {
+    out_result.SetError("No 'name' argument given.");
+    return;
+  }
+
+  ezCVar* pCVar = ezCVar::FindCVarByName(sName);
+
+  if (pCVar == nullptr)
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("No CVar named '{}' exists in this process. Use cvar_list to find the right name; a CVar only exists once "
+                     "the plugin that declares it has been loaded.",
+      sName);
+    out_result.SetError(sError);
+    return;
+  }
+
+  const ezVariant* pValue = nullptr;
+
+  if (!arguments.TryGetValue("value", pValue) || !pValue->IsValid())
+  {
+    out_result.SetError("No 'value' argument given.");
+    return;
+  }
+
+  // The target's type decides the conversion, not the type the client happened to send: AI clients send
+  // numbers as strings and booleans as 0/1, and refusing those would be a type check dressed up as
+  // validation. Everything below fails only when the value genuinely cannot be read as that type.
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableString("name", pCVar->GetName());
+  writer.AddVariableString("type", CVarTypeToString(pCVar->GetType()));
+  WriteValue(writer, "previousValue", pCVar, ezCVarValue::Current);
+
+  ezStringBuilder sConversionError;
+
+  switch (pCVar->GetType())
+  {
+    case ezCVarType::Int:
+    {
+      ezResult res = EZ_FAILURE;
+      const ezInt32 iValue = static_cast<ezInt32>(pValue->ConvertTo<ezInt64>(&res));
+      if (res.Failed())
+        sConversionError.SetFormat("Value '{}' cannot be read as an integer.", pValue->ConvertTo<ezString>());
+      else
+        *static_cast<ezCVarInt*>(pCVar) = iValue;
+      break;
+    }
+    case ezCVarType::Float:
+    {
+      ezResult res = EZ_FAILURE;
+      const float fValue = pValue->ConvertTo<float>(&res);
+      if (res.Failed())
+        sConversionError.SetFormat("Value '{}' cannot be read as a float.", pValue->ConvertTo<ezString>());
+      else
+        *static_cast<ezCVarFloat*>(pCVar) = fValue;
+      break;
+    }
+    case ezCVarType::Bool:
+    {
+      ezResult res = EZ_FAILURE;
+      const bool bValue = pValue->ConvertTo<bool>(&res);
+      if (res.Failed())
+        sConversionError.SetFormat("Value '{}' cannot be read as a boolean. Use true/false, \"true\"/\"false\" or 1/0.", pValue->ConvertTo<ezString>());
+      else
+        *static_cast<ezCVarBool*>(pCVar) = bValue;
+      break;
+    }
+    case ezCVarType::String:
+    {
+      ezResult res = EZ_FAILURE;
+      const ezString sValue = pValue->ConvertTo<ezString>(&res);
+      if (res.Failed())
+        sConversionError = "Value cannot be read as a string.";
+      else
+        *static_cast<ezCVarString*>(pCVar) = sValue.GetView();
+      break;
+    }
+    default:
+      sConversionError = "This CVar has a type that this tool does not know how to write.";
+      break;
+  }
+
+  if (!sConversionError.IsEmpty())
+  {
+    // Abandoned rather than finished: the object was opened before the conversion was attempted, and
+    // returning from inside it would trip the JSON writer's 'stream was not closed' assert.
+    writer.EndAll();
+    out_result.SetError(sConversionError);
+    return;
+  }
+
+  WriteValue(writer, "value", pCVar, ezCVarValue::Current);
+
+  if (pCVar->GetFlags().IsSet(ezCVarFlags::RequiresDelayedSync))
+  {
+    WriteValue(writer, "pendingValue", pCVar, ezCVarValue::DelayedSync);
+    writer.AddVariableBool("requiresRestart", true);
+    writer.AddVariableString("note",
+      "This CVar only takes effect after the owning subsystem syncs it, usually at startup. 'value' is what the engine still "
+      "reads and 'pendingValue' is what was just written - so re-reading this CVar will keep reporting the old value, and that "
+      "is not a failed write.");
+  }
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/Engine/Mcp/Tools/McpCVarTool.h
+++ b/Code/Engine/Mcp/Tools/McpCVarTool.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezCVar;
+class ezMcpJsonWriter;
+
+/// \brief Reading and writing the CVars this process has registered.
+///
+/// CVars are where the engine and its plugins already expose their debug switches - render passes,
+/// physics visualisation, AI overlays, resource management - so this reaches a large amount of existing
+/// behaviour for very little code. Nothing has to be written per switch: a plugin that declares a CVar
+/// is reachable the moment it is loaded.
+///
+/// Host independent, hence concrete and living in the Mcp library. It is most useful in a game process,
+/// where the interesting switches are, but the editor registers its own and answers the same way.
+class ezMcpCVarTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpCVarTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteSet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Writes one CVar as an object: name, type, current value, and what differs from it.
+  static void WriteCVar(ezMcpJsonWriter& ref_writer, const ezCVar* pCVar);
+
+  /// \brief The 'Current' value of any CVar type, as the JSON type that matches it.
+  static void WriteValue(ezMcpJsonWriter& ref_writer, ezStringView sFieldName, const ezCVar* pCVar, ezUInt32 uiWhichValue);
+
+  /// The cap exists for the same reason as everywhere else - a process can register hundreds and an
+  /// unfiltered dump would bury the answer.
+  static constexpr ezUInt32 s_uiMaxResults = 200;
+};

--- a/Code/Engine/Mcp/Tools/McpLogTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpLogTool.cpp
@@ -1,0 +1,217 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/Tools/McpLogTool.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpLogTool, 1, ezRTTIDefaultAllocator<ezMcpLogTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// The names used in the tool arguments and in the results. Kept short and lower case, because this
+  /// is what the AI has to type.
+  ezStringView SeverityToString(ezLogMsgType::Enum type)
+  {
+    switch (type)
+    {
+      case ezLogMsgType::ErrorMsg: return "error";
+      case ezLogMsgType::SeriousWarningMsg: return "serious-warning";
+      case ezLogMsgType::WarningMsg: return "warning";
+      case ezLogMsgType::SuccessMsg: return "success";
+      case ezLogMsgType::InfoMsg: return "info";
+      case ezLogMsgType::DevMsg: return "dev";
+      case ezLogMsgType::DebugMsg: return "debug";
+      default: return "other";
+    }
+  }
+
+  ezLogMsgType::Enum SeverityFromString(ezStringView sSeverity, ezLogMsgType::Enum fallback)
+  {
+    if (sSeverity.IsEqual_NoCase("error")) return ezLogMsgType::ErrorMsg;
+    if (sSeverity.IsEqual_NoCase("serious-warning")) return ezLogMsgType::SeriousWarningMsg;
+    if (sSeverity.IsEqual_NoCase("warning")) return ezLogMsgType::WarningMsg;
+    if (sSeverity.IsEqual_NoCase("success")) return ezLogMsgType::SuccessMsg;
+    if (sSeverity.IsEqual_NoCase("info")) return ezLogMsgType::InfoMsg;
+    if (sSeverity.IsEqual_NoCase("dev")) return ezLogMsgType::DevMsg;
+    if (sSeverity.IsEqual_NoCase("debug")) return ezLogMsgType::DebugMsg;
+
+    return fallback;
+  }
+} // namespace
+
+ezMcpLogTool::ezMcpLogTool() = default;
+
+ezMcpLogTool::~ezMcpLogTool()
+{
+  OnDeactivate();
+}
+
+void ezMcpLogTool::OnActivate()
+{
+  if (m_LogSubscription != 0)
+    return;
+
+  // Hooked from OnActivate rather than when the server starts, because the provider is instantiated
+  // during plugin load and startup messages are exactly the ones worth having captured.
+  //
+  // This sees only the log of the process it runs in. The editor's engine process is a separate one, so
+  // an agent diagnosing something that happens while the game runs has to ask the engine's own server.
+  m_LogSubscription = ezGlobalLog::AddLogWriter(ezMakeDelegate(&ezMcpLogTool::LogEventHandler, this));
+}
+
+void ezMcpLogTool::OnDeactivate()
+{
+  if (m_LogSubscription == 0)
+    return;
+
+  ezGlobalLog::RemoveLogWriter(m_LogSubscription);
+  m_LogSubscription = 0;
+}
+
+void ezMcpLogTool::LogEventHandler(const ezLoggingEventData& e)
+{
+  // group markers and flushes carry no text worth keeping
+  if (e.m_EventType < ezLogMsgType::ErrorMsg || e.m_EventType > ezLogMsgType::DebugMsg)
+    return;
+
+  EZ_LOCK(m_Mutex);
+
+  if (m_Entries.GetCount() >= s_uiMaxEntries)
+  {
+    m_Entries.PopFront();
+  }
+
+  Entry& entry = m_Entries.ExpandAndGetRef();
+  entry.m_uiId = m_uiNextId++;
+  entry.m_Type = e.m_EventType;
+  entry.m_sText = e.m_sText;
+}
+
+void ezMcpLogTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "log_write";
+    desc.m_sDescription = "Writes a message to this application's log, so that it becomes visible to the user.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("message":{"type":"string","description":"The text to log."},)"
+                          R"("severity":{"type":"string","enum":["error","serious-warning","warning","success","info","dev","debug"],"description":"Defaults to 'info'."})"
+                          R"(},"required":["message"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "log_read";
+    desc.m_sDescription = "Returns the most recent log messages of THIS process, oldest first. Use this to find out what the "
+                          "application reported about an operation, e.g. why an asset failed to transform. Note that the "
+                          "editor and the engine process that runs the game are separate processes with separate logs, each "
+                          "reachable only through its own MCP server. The response's 'lastId' is "
+                          "the id of the newest entry returned; pass it back as 'sinceId' on the next call to only get "
+                          "messages that arrived after it, instead of re-reading ones already seen. 'contains' lets 'count' "
+                          "reach past the most recent messages to find one further back.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("count":{"type":"number","description":"How many messages to return. Defaults to 50."},)"
+                          R"("severity":{"type":"string","enum":["error","serious-warning","warning","success","info","dev","debug"],"description":"Only return messages at least this severe. Defaults to 'debug', i.e. everything."},)"
+                          R"("sinceId":{"type":"number","description":"Only return messages with an id greater than this, i.e. logged after a previous log_read whose 'lastId' this is. Omit to read the newest messages regardless of what was read before."},)"
+                          R"("contains":{"type":"string","description":"Only return messages whose text contains this, case insensitive. Lets 'count' reach further back than the most recent messages."})"
+                          R"(}})";
+  }
+}
+
+void ezMcpLogTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "log_write")
+  {
+    ExecuteWrite(arguments, out_result);
+  }
+  else if (sToolName == "log_read")
+  {
+    ExecuteRead(arguments, out_result);
+  }
+}
+
+void ezMcpLogTool::ExecuteWrite(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sMessage = ezMcpJson::GetString(arguments, "message");
+
+  if (sMessage.IsEmpty())
+  {
+    out_result.SetError("No 'message' argument given.");
+    return;
+  }
+
+  const ezLogMsgType::Enum severity = SeverityFromString(ezMcpJson::GetString(arguments, "severity"), ezLogMsgType::InfoMsg);
+
+  // the tag makes it obvious in the log where this came from
+  switch (severity)
+  {
+    case ezLogMsgType::ErrorMsg: ezLog::Error("MCP: {}", sMessage); break;
+    case ezLogMsgType::SeriousWarningMsg: ezLog::SeriousWarning("MCP: {}", sMessage); break;
+    case ezLogMsgType::WarningMsg: ezLog::Warning("MCP: {}", sMessage); break;
+    case ezLogMsgType::SuccessMsg: ezLog::Success("MCP: {}", sMessage); break;
+    case ezLogMsgType::DevMsg: ezLog::Dev("MCP: {}", sMessage); break;
+    case ezLogMsgType::DebugMsg: ezLog::Debug("MCP: {}", sMessage); break;
+    default: ezLog::Info("MCP: {}", sMessage); break;
+  }
+
+  out_result.m_sText = "ok";
+}
+
+void ezMcpLogTool::ExecuteRead(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezInt64 iCount = ezMath::Clamp<ezInt64>(ezMcpJson::GetInt(arguments, "count", 50), 1, s_uiMaxEntries);
+  const ezLogMsgType::Enum minSeverity = SeverityFromString(ezMcpJson::GetString(arguments, "severity"), ezLogMsgType::DebugMsg);
+  const ezUInt64 uiSinceId = static_cast<ezUInt64>(ezMath::Max<ezInt64>(ezMcpJson::GetInt(arguments, "sinceId", 0), 0));
+  const ezStringView sContains = ezMcpJson::GetString(arguments, "contains");
+
+  EZ_LOCK(m_Mutex);
+
+  // collect from the back, so 'count' means 'the newest count that pass the filter'
+  ezHybridArray<const Entry*, 64> selected;
+
+  for (ezUInt32 i = m_Entries.GetCount(); i > 0 && selected.GetCount() < iCount; --i)
+  {
+    const Entry& entry = m_Entries[i - 1];
+
+    if (entry.m_uiId <= uiSinceId)
+      break; // entries only get older from here, nothing further back can pass either
+
+    // lower enum value means more severe
+    if (entry.m_Type > minSeverity)
+      continue;
+
+    if (!sContains.IsEmpty() && entry.m_sText.FindSubString_NoCase(sContains) == nullptr)
+      continue;
+
+    selected.PushBack(&entry);
+  }
+
+  // the newest id actually seen by this call, i.e. what a follow-up call should pass as 'sinceId';
+  // falls back to whatever was asked for so a client that already knows it stays in sync
+  const ezUInt64 uiLastId = selected.IsEmpty() ? uiSinceId : selected[0]->m_uiId;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableInt64("lastId", static_cast<ezInt64>(uiLastId));
+  writer.BeginArray("messages");
+
+  // 'selected' is newest first, but the result reads better oldest first
+  for (ezUInt32 i = selected.GetCount(); i > 0; --i)
+  {
+    const Entry& entry = *selected[i - 1];
+
+    writer.BeginObject();
+    writer.AddVariableInt64("id", static_cast<ezInt64>(entry.m_uiId));
+    writer.AddVariableString("severity", SeverityToString(entry.m_Type));
+    writer.AddVariableString("text", entry.m_sText);
+    writer.EndObject();
+  }
+
+  writer.EndArray();
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/Engine/Mcp/Tools/McpLogTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpLogTool.cpp
@@ -17,26 +17,41 @@ namespace
   {
     switch (type)
     {
-      case ezLogMsgType::ErrorMsg: return "error";
-      case ezLogMsgType::SeriousWarningMsg: return "serious-warning";
-      case ezLogMsgType::WarningMsg: return "warning";
-      case ezLogMsgType::SuccessMsg: return "success";
-      case ezLogMsgType::InfoMsg: return "info";
-      case ezLogMsgType::DevMsg: return "dev";
-      case ezLogMsgType::DebugMsg: return "debug";
-      default: return "other";
+      case ezLogMsgType::ErrorMsg:
+        return "error";
+      case ezLogMsgType::SeriousWarningMsg:
+        return "serious-warning";
+      case ezLogMsgType::WarningMsg:
+        return "warning";
+      case ezLogMsgType::SuccessMsg:
+        return "success";
+      case ezLogMsgType::InfoMsg:
+        return "info";
+      case ezLogMsgType::DevMsg:
+        return "dev";
+      case ezLogMsgType::DebugMsg:
+        return "debug";
+      default:
+        return "other";
     }
   }
 
   ezLogMsgType::Enum SeverityFromString(ezStringView sSeverity, ezLogMsgType::Enum fallback)
   {
-    if (sSeverity.IsEqual_NoCase("error")) return ezLogMsgType::ErrorMsg;
-    if (sSeverity.IsEqual_NoCase("serious-warning")) return ezLogMsgType::SeriousWarningMsg;
-    if (sSeverity.IsEqual_NoCase("warning")) return ezLogMsgType::WarningMsg;
-    if (sSeverity.IsEqual_NoCase("success")) return ezLogMsgType::SuccessMsg;
-    if (sSeverity.IsEqual_NoCase("info")) return ezLogMsgType::InfoMsg;
-    if (sSeverity.IsEqual_NoCase("dev")) return ezLogMsgType::DevMsg;
-    if (sSeverity.IsEqual_NoCase("debug")) return ezLogMsgType::DebugMsg;
+    if (sSeverity.IsEqual_NoCase("error"))
+      return ezLogMsgType::ErrorMsg;
+    if (sSeverity.IsEqual_NoCase("serious-warning"))
+      return ezLogMsgType::SeriousWarningMsg;
+    if (sSeverity.IsEqual_NoCase("warning"))
+      return ezLogMsgType::WarningMsg;
+    if (sSeverity.IsEqual_NoCase("success"))
+      return ezLogMsgType::SuccessMsg;
+    if (sSeverity.IsEqual_NoCase("info"))
+      return ezLogMsgType::InfoMsg;
+    if (sSeverity.IsEqual_NoCase("dev"))
+      return ezLogMsgType::DevMsg;
+    if (sSeverity.IsEqual_NoCase("debug"))
+      return ezLogMsgType::DebugMsg;
 
     return fallback;
   }
@@ -148,13 +163,27 @@ void ezMcpLogTool::ExecuteWrite(const ezVariantDictionary& arguments, ezMcpToolR
   // the tag makes it obvious in the log where this came from
   switch (severity)
   {
-    case ezLogMsgType::ErrorMsg: ezLog::Error("MCP: {}", sMessage); break;
-    case ezLogMsgType::SeriousWarningMsg: ezLog::SeriousWarning("MCP: {}", sMessage); break;
-    case ezLogMsgType::WarningMsg: ezLog::Warning("MCP: {}", sMessage); break;
-    case ezLogMsgType::SuccessMsg: ezLog::Success("MCP: {}", sMessage); break;
-    case ezLogMsgType::DevMsg: ezLog::Dev("MCP: {}", sMessage); break;
-    case ezLogMsgType::DebugMsg: ezLog::Debug("MCP: {}", sMessage); break;
-    default: ezLog::Info("MCP: {}", sMessage); break;
+    case ezLogMsgType::ErrorMsg:
+      ezLog::Error("MCP: {}", sMessage);
+      break;
+    case ezLogMsgType::SeriousWarningMsg:
+      ezLog::SeriousWarning("MCP: {}", sMessage);
+      break;
+    case ezLogMsgType::WarningMsg:
+      ezLog::Warning("MCP: {}", sMessage);
+      break;
+    case ezLogMsgType::SuccessMsg:
+      ezLog::Success("MCP: {}", sMessage);
+      break;
+    case ezLogMsgType::DevMsg:
+      ezLog::Dev("MCP: {}", sMessage);
+      break;
+    case ezLogMsgType::DebugMsg:
+      ezLog::Debug("MCP: {}", sMessage);
+      break;
+    default:
+      ezLog::Info("MCP: {}", sMessage);
+      break;
   }
 
   out_result.m_sText = "ok";

--- a/Code/Engine/Mcp/Tools/McpLogTool.h
+++ b/Code/Engine/Mcp/Tools/McpLogTool.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+#include <Foundation/Containers/Deque.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Threading/Mutex.h>
+
+/// \brief Writing to and reading back this process's log.
+///
+/// Reading matters more than writing: it is the cheapest feedback loop an agent has. It can trigger
+/// something and then look at what the application said about it, instead of asking the user to copy
+/// the log.
+///
+/// Host independent, hence concrete and living in the Mcp library rather than in a plugin: a ring
+/// buffer over ezGlobalLog is the same thing in the editor and in a game. Each process captures its
+/// own log, which is what makes it worth running a server in both - the editor cannot see what the
+/// engine process logged, and vice versa.
+class ezMcpLogTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpLogTool, ezMcpToolProvider);
+
+public:
+  ezMcpLogTool();
+  ~ezMcpLogTool();
+
+  virtual void OnActivate() override;
+  virtual void OnDeactivate() override;
+
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  struct Entry
+  {
+    ezUInt64 m_uiId = 0;
+    ezLogMsgType::Enum m_Type = ezLogMsgType::None;
+    ezString m_sText;
+  };
+
+  void LogEventHandler(const ezLoggingEventData& e);
+
+  void ExecuteWrite(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteRead(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// How many messages are kept. The editor logs a lot, and a game logs every frame, so this is a
+  /// compromise between covering a whole operation and not holding on to megabytes of text.
+  static constexpr ezUInt32 s_uiMaxEntries = 2000;
+
+  /// Log events arrive from whatever thread produced them, everything else runs on the main thread.
+  mutable ezMutex m_Mutex;
+  ezDeque<Entry> m_Entries;
+  ezEventSubscriptionID m_LogSubscription = 0;
+
+  /// Ids are assigned in order and never reused, even once their entry falls out of m_Entries, so a
+  /// 'sinceId' from an earlier read remains meaningful no matter how much has been logged since.
+  ezUInt64 m_uiNextId = 1;
+};

--- a/Code/Engine/Mcp/Tools/McpRttiTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpRttiTool.cpp
@@ -599,8 +599,7 @@ void ezMcpRttiTool::ExecuteDerivedTypes(const ezVariantDictionary& arguments, ez
   ezUInt32 uiTotalMatches = 0;
   ezHybridArray<ezStringView, 32> names;
 
-  ezRTTI::ForEachDerivedType(pType,
-    [&](const ezRTTI* pDerived)
+  ezRTTI::ForEachDerivedType(pType, [&](const ezRTTI* pDerived)
     {
       // ForEachDerivedType includes the base type itself, which is not what 'derived types' means here
       if (pDerived == pType)
@@ -611,9 +610,7 @@ void ezMcpRttiTool::ExecuteDerivedTypes(const ezVariantDictionary& arguments, ez
       if (names.GetCount() < s_uiMaxResults)
       {
         names.PushBack(pDerived->GetTypeName());
-      }
-    },
-    options);
+      } }, options);
 
   ezMcpJsonWriter writer;
   writer.BeginObject();

--- a/Code/Engine/Mcp/Tools/McpRttiTool.cpp
+++ b/Code/Engine/Mcp/Tools/McpRttiTool.cpp
@@ -1,0 +1,636 @@
+#include <Mcp/McpPCH.h>
+
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpTranslation.h>
+#include <Mcp/Tools/McpRttiTool.h>
+
+#include <Foundation/Reflection/ReflectionUtils.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpRttiTool, 1, ezRTTIDefaultAllocator<ezMcpRttiTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// The largest number of entries any of these tools will return. A project has well over a thousand
+  /// reflected types, and an unfiltered query would otherwise fill the client's context with names it
+  /// did not ask for. Every listing reports the total number of matches alongside, so the agent can
+  /// tell 'this is all of them' from 'narrow your filter'.
+  constexpr ezUInt32 s_uiMaxResults = 200;
+
+  bool NameMatches(const ezRTTI* pType, ezStringView sFilter)
+  {
+    return sFilter.IsEmpty() || pType->GetTypeName().FindSubString_NoCase(sFilter) != nullptr;
+  }
+} // namespace
+
+void ezMcpRttiTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "rtti_find_types";
+    desc.m_sDescription = "Searches the reflected C++ types by name and returns only the matching type names. This is the entry "
+                          "point into the reflection data: narrow down to a few names here, then use rtti_type_info or "
+                          "rtti_type_properties on those. Results are capped, but the total number of matches is reported.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"Only return types whose name contains this text, case insensitive. Empty returns everything, which is a lot."},)"
+                          R"("derivedFrom":{"type":"string","description":"Only return types deriving from this type, e.g. 'ezComponent'."},)"
+                          R"("concreteOnly":{"type":"boolean","description":"If true, exclude abstract types and types that cannot be allocated. Default false."})"
+                          R"(}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "rtti_type_info";
+    desc.m_sDescription = "Returns the details of one reflected type: its parent type, the plugin it comes from, its type flags, "
+                          "its attributes, and its callable functions with full signatures. Where the type has them, also the "
+                          "name the editor's UI shows for it and a link to its documentation, which is the only description of "
+                          "what the type is actually for. Deliberately does NOT include the property list - use "
+                          "rtti_type_properties for that.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"The exact type name, e.g. 'ezMeshComponent'."})"
+                          R"(},"required":["name"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "rtti_type_properties";
+    desc.m_sDescription = "Returns the reflected properties of one type, with their value type, category (member, array, set, "
+                          "map, constant), flags and attributes. This is what tells you the exact property names and value "
+                          "types to use when reading or writing an object's properties. Properties that have one also carry "
+                          "the label the editor shows and a description of what the property does - the latter exists nowhere "
+                          "else, so consult it before guessing from a name.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"The exact type name, e.g. 'ezMeshComponent'."},)"
+                          R"("recursive":{"type":"boolean","description":"If true, also include the properties inherited from base types. Default false, which returns only the type's own properties."})"
+                          R"(},"required":["name"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "rtti_derived_types";
+    desc.m_sDescription = "Returns the names of all types deriving from the given type. Use this to answer questions like which "
+                          "component types exist ('ezComponent') or which types can go into a specific property.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("name":{"type":"string","description":"The exact base type name, e.g. 'ezComponent'."},)"
+                          R"("concreteOnly":{"type":"boolean","description":"If true, exclude abstract types and types that cannot be allocated. Default false."})"
+                          R"(},"required":["name"]})";
+  }
+}
+
+void ezMcpRttiTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "rtti_find_types")
+    ExecuteFindTypes(arguments, out_result);
+  else if (sToolName == "rtti_type_info")
+    ExecuteTypeInfo(arguments, out_result);
+  else if (sToolName == "rtti_type_properties")
+    ExecuteTypeProperties(arguments, out_result);
+  else if (sToolName == "rtti_derived_types")
+    ExecuteDerivedTypes(arguments, out_result);
+}
+
+void ezMcpRttiTool::WriteTypeFlags(ezMcpJsonWriter& ref_writer, const ezRTTI* pType)
+{
+  const ezBitflags<ezTypeFlags>& flags = pType->GetTypeFlags();
+
+  ref_writer.BeginArray("flags");
+
+  if (flags.IsSet(ezTypeFlags::StandardType))
+    ref_writer.WriteString("StandardType");
+  if (flags.IsSet(ezTypeFlags::IsEnum))
+    ref_writer.WriteString("IsEnum");
+  if (flags.IsSet(ezTypeFlags::Bitflags))
+    ref_writer.WriteString("Bitflags");
+  if (flags.IsSet(ezTypeFlags::Class))
+    ref_writer.WriteString("Class");
+  if (flags.IsSet(ezTypeFlags::Abstract))
+    ref_writer.WriteString("Abstract");
+  if (flags.IsSet(ezTypeFlags::Phantom))
+    ref_writer.WriteString("Phantom");
+  if (flags.IsSet(ezTypeFlags::Minimal))
+    ref_writer.WriteString("Minimal");
+
+  ref_writer.EndArray();
+}
+
+void ezMcpRttiTool::WritePropertyFlags(ezMcpJsonWriter& ref_writer, ezStringView sName, ezBitflags<ezPropertyFlags> flags)
+{
+  // An empty flag array says nothing that its absence does not, and these repeat for every argument of
+  // every function - which is exactly the token cost the split-tool design exists to avoid.
+  if (flags.GetValue() == 0)
+    return;
+
+  ref_writer.BeginArray(sName);
+
+  if (flags.IsSet(ezPropertyFlags::StandardType))
+    ref_writer.WriteString("StandardType");
+  if (flags.IsSet(ezPropertyFlags::IsEnum))
+    ref_writer.WriteString("IsEnum");
+  if (flags.IsSet(ezPropertyFlags::Bitflags))
+    ref_writer.WriteString("Bitflags");
+  if (flags.IsSet(ezPropertyFlags::Class))
+    ref_writer.WriteString("Class");
+  if (flags.IsSet(ezPropertyFlags::Const))
+    ref_writer.WriteString("Const");
+  if (flags.IsSet(ezPropertyFlags::Reference))
+    ref_writer.WriteString("Reference");
+  if (flags.IsSet(ezPropertyFlags::Pointer))
+    ref_writer.WriteString("Pointer");
+  if (flags.IsSet(ezPropertyFlags::PointerOwner))
+    ref_writer.WriteString("PointerOwner");
+  if (flags.IsSet(ezPropertyFlags::ReadOnly))
+    ref_writer.WriteString("ReadOnly");
+  if (flags.IsSet(ezPropertyFlags::Hidden))
+    ref_writer.WriteString("Hidden");
+  if (flags.IsSet(ezPropertyFlags::Phantom))
+    ref_writer.WriteString("Phantom");
+  if (flags.IsSet(ezPropertyFlags::VarOut))
+    ref_writer.WriteString("VarOut");
+  if (flags.IsSet(ezPropertyFlags::VarInOut))
+    ref_writer.WriteString("VarInOut");
+
+  ref_writer.EndArray();
+}
+
+void ezMcpRttiTool::WriteAttributes(ezMcpJsonWriter& ref_writer, ezArrayPtr<const ezPropertyAttribute* const> attributes)
+{
+  if (attributes.IsEmpty())
+    return;
+
+  ref_writer.BeginArray("attributes");
+
+  for (const ezPropertyAttribute* pAttr : attributes)
+  {
+    if (pAttr == nullptr)
+      continue;
+
+    WriteAttribute(ref_writer, pAttr);
+  }
+
+  ref_writer.EndArray();
+}
+
+const ezPropertyAttribute* ezMcpRttiTool::GetAttributeFromVariant(const ezVariant& value)
+{
+  if (value.GetType() != ezVariant::Type::TypedPointer)
+    return nullptr;
+
+  const ezTypedPointer ptr = value.Get<ezTypedPointer>();
+
+  if (ptr.m_pObject == nullptr || ptr.m_pType == nullptr)
+    return nullptr;
+
+  if (!ptr.m_pType->IsDerivedFrom<ezPropertyAttribute>())
+    return nullptr;
+
+  return static_cast<const ezPropertyAttribute*>(ptr.m_pObject);
+}
+
+void ezMcpRttiTool::WriteAttribute(ezMcpJsonWriter& ref_writer, const ezPropertyAttribute* pAttr)
+{
+  {
+    const ezRTTI* pAttrType = pAttr->GetDynamicRTTI();
+
+    ref_writer.BeginObject();
+    ref_writer.AddVariableString("type", pAttrType->GetTypeName());
+
+    // An attribute's own reflected members carry the interesting part - the clamp range of an
+    // ezClampValueAttribute, the type filter of an ezAssetBrowserAttribute. They are read generically,
+    // so attributes added later show up here without this tool knowing about them.
+    for (const ezAbstractProperty* pProp : pAttrType->GetProperties())
+    {
+      if (pProp->GetCategory() == ezPropertyCategory::Member)
+      {
+        const ezVariant value = ezReflectionUtils::GetMemberPropertyValue(static_cast<const ezAbstractMemberProperty*>(pProp), pAttr);
+
+        if (value.IsValid())
+        {
+          ref_writer.AddVariableVariant(pProp->GetPropertyName(), value);
+        }
+      }
+      else if (pProp->GetCategory() == ezPropertyCategory::Array)
+      {
+        // Attributes such as ezContainerAttribute keep their payload in an array. Skipping those would
+        // silently drop the only interesting part of the attribute.
+        const ezAbstractArrayProperty* pArray = static_cast<const ezAbstractArrayProperty*>(pProp);
+
+        const ezUInt32 uiCount = pArray->GetCount(pAttr);
+
+        if (uiCount == 0)
+          continue;
+
+        ref_writer.BeginArray(pProp->GetPropertyName());
+
+        for (ezUInt32 uiIndex = 0; uiIndex < uiCount; ++uiIndex)
+        {
+          const ezVariant value = ezReflectionUtils::GetArrayPropertyValue(pArray, pAttr, uiIndex);
+
+          // An attribute nested inside another one - ezFunctionArgumentAttributes holds the attributes
+          // of a single function argument this way. Writing it as a plain variant would report only its
+          // type and drop the members, which for an ezDefaultValueAttribute is the entire content.
+          if (const ezPropertyAttribute* pNested = GetAttributeFromVariant(value))
+          {
+            WriteAttribute(ref_writer, pNested);
+          }
+          else
+          {
+            ref_writer.WriteVariant(value);
+          }
+        }
+
+        ref_writer.EndArray();
+      }
+    }
+
+    ref_writer.EndObject();
+  }
+}
+
+void ezMcpRttiTool::WriteProperty(ezMcpJsonWriter& ref_writer, const ezRTTI* pOwnerType, const ezAbstractProperty* pProp)
+{
+  ref_writer.BeginObject();
+
+  ref_writer.AddVariableString("name", pProp->GetPropertyName());
+
+  // The label the property grid shows, which is not always the property name, and the text behind its
+  // tooltip - the only description of what the property does that exists anywhere in the data.
+  ezMcpTranslation::AddOptionalString(ref_writer, "displayName", ezMcpTranslation::GetPropertyDisplayName(pOwnerType, pProp->GetPropertyName()));
+  ezMcpTranslation::AddOptionalString(ref_writer, "description", ezMcpTranslation::GetPropertyTooltip(pOwnerType, pProp->GetPropertyName()));
+
+  const ezRTTI* pPropType = pProp->GetSpecificType();
+  ref_writer.AddVariableString("type", pPropType != nullptr ? pPropType->GetTypeName() : ezStringView());
+
+  switch (pProp->GetCategory())
+  {
+    case ezPropertyCategory::Constant:
+      ref_writer.AddVariableString("category", "constant");
+      break;
+    case ezPropertyCategory::Member:
+      ref_writer.AddVariableString("category", "member");
+      break;
+    case ezPropertyCategory::Function:
+      ref_writer.AddVariableString("category", "function");
+      break;
+    case ezPropertyCategory::Array:
+      ref_writer.AddVariableString("category", "array");
+      break;
+    case ezPropertyCategory::Set:
+      ref_writer.AddVariableString("category", "set");
+      break;
+    case ezPropertyCategory::Map:
+      ref_writer.AddVariableString("category", "map");
+      break;
+    default:
+      ref_writer.AddVariableString("category", "unknown");
+      break;
+  }
+
+  const ezBitflags<ezPropertyFlags>& flags = pProp->GetFlags();
+
+  WritePropertyFlags(ref_writer, "flags", flags);
+
+  // For enum and bitflags properties the valid values are the constants of the value type, and without
+  // them the agent has no way to know what may be assigned.
+  if (flags.IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags) && pPropType != nullptr)
+  {
+    ref_writer.BeginArray("enumValues");
+
+    for (const ezAbstractProperty* pConstant : pPropType->GetProperties())
+    {
+      if (pConstant->GetCategory() != ezPropertyCategory::Constant)
+        continue;
+
+      ref_writer.BeginObject();
+      ref_writer.AddVariableString("name", pConstant->GetPropertyName());
+
+      // An enum constant is registered under its fully qualified name ('ezDecalMode::BaseColorORM'),
+      // which is also the translation key, so no owner type is needed here.
+      ezMcpTranslation::AddOptionalString(ref_writer, "displayName", ezMcpTranslation::GetDisplayName(pConstant->GetPropertyName()));
+
+      ref_writer.AddVariableVariant("value", static_cast<const ezAbstractConstantProperty*>(pConstant)->GetConstant());
+      ref_writer.EndObject();
+    }
+
+    ref_writer.EndArray();
+  }
+
+  WriteAttributes(ref_writer, pProp->GetAttributes());
+
+  ref_writer.EndObject();
+}
+
+void ezMcpRttiTool::WriteFunction(ezMcpJsonWriter& ref_writer, const ezAbstractFunctionProperty* pFunc)
+{
+  ref_writer.BeginObject();
+
+  ref_writer.AddVariableString("name", pFunc->GetPropertyName());
+
+  switch (pFunc->GetFunctionType())
+  {
+    case ezFunctionType::Member:
+      ref_writer.AddVariableString("functionType", "member");
+      break;
+    case ezFunctionType::StaticMember:
+      ref_writer.AddVariableString("functionType", "static");
+      break;
+    case ezFunctionType::Constructor:
+      ref_writer.AddVariableString("functionType", "constructor");
+      break;
+    default:
+      ref_writer.AddVariableString("functionType", "unknown");
+      break;
+  }
+
+  // A null return type means void, which is not a reflected type of its own.
+  const ezRTTI* pReturnType = pFunc->GetReturnType();
+  ref_writer.AddVariableString("returnType", pReturnType != nullptr ? pReturnType->GetTypeName() : "void"_ezsv);
+
+  if (pReturnType != nullptr)
+  {
+    WritePropertyFlags(ref_writer, "returnFlags", pFunc->GetReturnFlags());
+  }
+
+  // Functions exposed to scripting carry the argument names, which the reflection data itself does not
+  // hold - without them the arguments would only be identifiable by position.
+  const ezScriptableFunctionAttribute* pScriptable = pFunc->GetAttributeByType<ezScriptableFunctionAttribute>();
+
+  if (pScriptable != nullptr)
+  {
+    ref_writer.AddVariableBool("scriptable", true);
+  }
+
+  const ezUInt32 uiArgCount = pFunc->GetArgumentCount();
+
+  if (uiArgCount == 0)
+  {
+    WriteAttributes(ref_writer, pFunc->GetAttributes());
+    ref_writer.EndObject();
+    return;
+  }
+
+  ref_writer.BeginArray("arguments");
+  for (ezUInt32 uiArg = 0; uiArg < uiArgCount; ++uiArg)
+  {
+    ref_writer.BeginObject();
+
+    if (pScriptable != nullptr && uiArg < pScriptable->GetArgumentCount())
+    {
+      ref_writer.AddVariableString("name", pScriptable->GetArgumentName(uiArg));
+    }
+
+    const ezRTTI* pArgType = pFunc->GetArgumentType(uiArg);
+    ref_writer.AddVariableString("type", pArgType != nullptr ? pArgType->GetTypeName() : ezStringView());
+
+    // The flags say whether the argument is an out or inout parameter, which decides whether a caller
+    // has to pass a value in at all.
+    WritePropertyFlags(ref_writer, "flags", pFunc->GetArgumentFlags(uiArg));
+
+    ref_writer.EndObject();
+  }
+  ref_writer.EndArray();
+
+  WriteAttributes(ref_writer, pFunc->GetAttributes());
+
+  ref_writer.EndObject();
+}
+
+void ezMcpRttiTool::ExecuteFindTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+  const ezStringView sDerivedFrom = ezMcpJson::GetString(arguments, "derivedFrom");
+  const bool bConcreteOnly = ezMcpJson::GetBool(arguments, "concreteOnly", false);
+
+  const ezRTTI* pBaseType = nullptr;
+
+  if (!sDerivedFrom.IsEmpty())
+  {
+    pBaseType = ezRTTI::FindTypeByName(sDerivedFrom);
+
+    if (pBaseType == nullptr)
+    {
+      out_result.SetError(ezStringBuilder("Unknown type '", sDerivedFrom, "' passed as 'derivedFrom'. Use rtti_find_types without it to search for the correct name."));
+      return;
+    }
+  }
+
+  const ezBitflags<ezRTTI::ForEachOptions> options = bConcreteOnly ? ezRTTI::ForEachOptions::ExcludeNotConcrete : ezRTTI::ForEachOptions::Default;
+
+  ezUInt32 uiTotalMatches = 0;
+  ezHybridArray<ezStringView, 32> names;
+
+  auto visitor = [&](const ezRTTI* pType)
+  {
+    if (!NameMatches(pType, sName))
+      return;
+
+    ++uiTotalMatches;
+
+    if (names.GetCount() < s_uiMaxResults)
+    {
+      names.PushBack(pType->GetTypeName());
+    }
+  };
+
+  if (pBaseType != nullptr)
+  {
+    ezRTTI::ForEachDerivedType(pBaseType, visitor, options);
+  }
+  else
+  {
+    ezRTTI::ForEachType(visitor, options);
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableUInt32("totalMatches", uiTotalMatches);
+  writer.AddVariableUInt32("returned", names.GetCount());
+  writer.AddVariableBool("truncated", uiTotalMatches > names.GetCount());
+
+  writer.BeginArray("types");
+  for (ezStringView sTypeName : names)
+  {
+    writer.WriteString(sTypeName);
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpRttiTool::ExecuteTypeInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+
+  if (sName.IsEmpty())
+  {
+    out_result.SetError("Argument 'name' is required.");
+    return;
+  }
+
+  const ezRTTI* pType = ezRTTI::FindTypeByName(sName);
+
+  if (pType == nullptr)
+  {
+    out_result.SetError(ezStringBuilder("Unknown type '", sName, "'. Type names are case sensitive - use rtti_find_types to search for the correct name."));
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("name", pType->GetTypeName());
+
+  // The two things reflection cannot express: what the user sees this type called in the editor UI, and
+  // a link to prose about what it is for. Both are keyed on the type name, the same way asset types are,
+  // so a component type carries them just as an asset type does.
+  ezMcpTranslation::AddOptionalString(writer, "displayName", ezMcpTranslation::GetDisplayName(pType->GetTypeName()));
+  ezMcpTranslation::AddOptionalString(writer, "helpUrl", ezMcpTranslation::GetHelpURL(pType->GetTypeName()));
+
+  const ezRTTI* pParent = pType->GetParentType();
+  writer.AddVariableString("parentType", pParent != nullptr ? pParent->GetTypeName() : ezStringView());
+
+  writer.AddVariableString("plugin", pType->GetPluginName());
+  writer.AddVariableUInt32("typeVersion", pType->GetTypeVersion());
+
+  // Whether ezRTTI can construct one. False for abstract types, and for types that are only registered
+  // for their property information.
+  const ezRTTIAllocator* pAllocator = pType->GetAllocator();
+  writer.AddVariableBool("canAllocate", pAllocator != nullptr && pAllocator->CanAllocate());
+
+  WriteTypeFlags(writer, pType);
+
+  // Counts rather than the lists themselves - this tool stays cheap on purpose, and the count is what
+  // tells the agent whether calling rtti_type_properties is worth it.
+  writer.AddVariableUInt32("numOwnProperties", pType->GetProperties().GetCount());
+
+  ezDynamicArray<const ezAbstractProperty*> allProps;
+  pType->GetAllProperties(allProps);
+  writer.AddVariableUInt32("numAllProperties", allProps.GetCount());
+
+  writer.BeginArray("functions");
+  for (const ezAbstractFunctionProperty* pFunc : pType->GetFunctions())
+  {
+    WriteFunction(writer, pFunc);
+  }
+  writer.EndArray();
+
+  WriteAttributes(writer, pType->GetAttributes());
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpRttiTool::ExecuteTypeProperties(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+  const bool bRecursive = ezMcpJson::GetBool(arguments, "recursive", false);
+
+  if (sName.IsEmpty())
+  {
+    out_result.SetError("Argument 'name' is required.");
+    return;
+  }
+
+  const ezRTTI* pType = ezRTTI::FindTypeByName(sName);
+
+  if (pType == nullptr)
+  {
+    out_result.SetError(ezStringBuilder("Unknown type '", sName, "'. Type names are case sensitive - use rtti_find_types to search for the correct name."));
+    return;
+  }
+
+  ezDynamicArray<const ezAbstractProperty*> properties;
+
+  if (bRecursive)
+  {
+    // walks the base types as well, which is exactly what the argument asks for
+    pType->GetAllProperties(properties);
+  }
+  else
+  {
+    properties = pType->GetProperties();
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("name", pType->GetTypeName());
+  writer.AddVariableBool("recursive", bRecursive);
+
+  writer.BeginArray("properties");
+  for (const ezAbstractProperty* pProp : properties)
+  {
+    WriteProperty(writer, pType, pProp);
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpRttiTool::ExecuteDerivedTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sName = ezMcpJson::GetString(arguments, "name");
+  const bool bConcreteOnly = ezMcpJson::GetBool(arguments, "concreteOnly", false);
+
+  if (sName.IsEmpty())
+  {
+    out_result.SetError("Argument 'name' is required.");
+    return;
+  }
+
+  const ezRTTI* pType = ezRTTI::FindTypeByName(sName);
+
+  if (pType == nullptr)
+  {
+    out_result.SetError(ezStringBuilder("Unknown type '", sName, "'. Type names are case sensitive - use rtti_find_types to search for the correct name."));
+    return;
+  }
+
+  const ezBitflags<ezRTTI::ForEachOptions> options = bConcreteOnly ? ezRTTI::ForEachOptions::ExcludeNotConcrete : ezRTTI::ForEachOptions::Default;
+
+  ezUInt32 uiTotalMatches = 0;
+  ezHybridArray<ezStringView, 32> names;
+
+  ezRTTI::ForEachDerivedType(pType,
+    [&](const ezRTTI* pDerived)
+    {
+      // ForEachDerivedType includes the base type itself, which is not what 'derived types' means here
+      if (pDerived == pType)
+        return;
+
+      ++uiTotalMatches;
+
+      if (names.GetCount() < s_uiMaxResults)
+      {
+        names.PushBack(pDerived->GetTypeName());
+      }
+    },
+    options);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("baseType", pType->GetTypeName());
+  writer.AddVariableUInt32("totalMatches", uiTotalMatches);
+  writer.AddVariableUInt32("returned", names.GetCount());
+  writer.AddVariableBool("truncated", uiTotalMatches > names.GetCount());
+
+  writer.BeginArray("types");
+  for (ezStringView sTypeName : names)
+  {
+    writer.WriteString(sTypeName);
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/Engine/Mcp/Tools/McpRttiTool.h
+++ b/Code/Engine/Mcp/Tools/McpRttiTool.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+class ezRTTI;
+class ezMcpJsonWriter;
+class ezAbstractProperty;
+class ezAbstractFunctionProperty;
+
+/// \brief Exposes the reflection data, so an agent can find out which types exist and what they look like.
+///
+/// Split into four narrow tools rather than one, because the codebase has well over a thousand reflected
+/// types: a single 'dump everything' call would cost more tokens than a client can spend and would bury
+/// whatever was actually asked for. The intended flow is rtti_find_types to narrow down to a few names,
+/// then the detail tools for those.
+///
+/// Host independent, hence concrete and living in the Mcp library: reflection is the same system in a
+/// game as in the editor, and it is how an agent finds out what a component or a game's own types look
+/// like. Whatever the host has registered by the time of the call is what gets reported - in the editor
+/// that includes the phantom types ezPhantomRttiManager puts into ezRTTI, which the same traversal picks
+/// up without having to know about them.
+class ezMcpRttiTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpRttiTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteFindTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteTypeInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteTypeProperties(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteDerivedTypes(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  static void WriteTypeFlags(ezMcpJsonWriter& ref_writer, const ezRTTI* pType);
+  static void WritePropertyFlags(ezMcpJsonWriter& ref_writer, ezStringView sName, ezBitflags<ezPropertyFlags> flags);
+  static void WriteAttributes(ezMcpJsonWriter& ref_writer, ezArrayPtr<const ezPropertyAttribute* const> attributes);
+
+  /// Writes one attribute as an object: its concrete type plus its reflected members.
+  static void WriteAttribute(ezMcpJsonWriter& ref_writer, const ezPropertyAttribute* pAttr);
+
+  /// Returns the attribute a variant points at, or nullptr if it does not hold one. Attributes nested
+  /// inside another attribute arrive as a TypedPointer and would otherwise lose their contents.
+  static const ezPropertyAttribute* GetAttributeFromVariant(const ezVariant& value);
+  /// \param pOwnerType The type the property was listed for. Only used to look up its translations, which
+  ///        are keyed on the declaring type - ezAbstractProperty does not know which type that is.
+  static void WriteProperty(ezMcpJsonWriter& ref_writer, const ezRTTI* pOwnerType, const ezAbstractProperty* pProp);
+  static void WriteFunction(ezMcpJsonWriter& ref_writer, const ezAbstractFunctionProperty* pFunc);
+};

--- a/Code/EnginePlugins/McpPlugin/CMakeLists.txt
+++ b/Code/EnginePlugins/McpPlugin/CMakeLists.txt
@@ -1,6 +1,6 @@
 ez_cmake_init()
 
-
+ez_requires_desktop()
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)

--- a/Code/EnginePlugins/McpPlugin/CMakeLists.txt
+++ b/Code/EnginePlugins/McpPlugin/CMakeLists.txt
@@ -1,0 +1,19 @@
+ez_cmake_init()
+
+
+
+# Get the name of this folder as the project name
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
+
+ez_create_target(LIBRARY ${PROJECT_NAME})
+
+ez_enable_strict_warnings(${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+  Mcp
+  Core
+  GameEngine
+  RendererCore
+  Texture
+)

--- a/Code/EnginePlugins/McpPlugin/McpEngineHost.cpp
+++ b/Code/EnginePlugins/McpPlugin/McpEngineHost.cpp
@@ -1,0 +1,145 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+#include <McpPlugin/McpEngineHost.h>
+
+#include <Mcp/McpServer.h>
+#include <Mcp/McpToolRegistry.h>
+
+#include <Foundation/Application/Application.h>
+#include <Foundation/Utilities/CommandLineUtils.h>
+
+/// The port to serve MCP on.
+///
+/// This is the option a standalone game is launched with. It is spelled without the 'editor-' prefix
+/// that the editor's own option carries, because the editor forwards its entire command line to the
+/// engine process that runs the game: with a single name, both processes would read the same number and
+/// the second one to start would fail to bind.
+///
+/// There is deliberately no default. This plugin is mandatory and therefore loaded by every project, so
+/// a default would have every game and every ezEditorProcessor child open a port that nobody asked for.
+/// The server only exists when it was asked for by name.
+static ezCommandLineOptionInt s_opt_McpPort("_Mcp", "-mcpport",
+  "The port that this game process serves MCP on, on 127.0.0.1.\n"
+  "Without it - and without '-editor-mcpport' - no server is started at all.",
+  0, 0, 0xFFFF);
+
+/// The editor's port, read here only to derive one from it.
+///
+/// Declared so that it shows up in app_command_line_options, and so that the +1 rule is stated in one
+/// place that an agent can actually read. The editor is what interprets the value itself.
+static ezCommandLineOptionInt s_opt_EditorMcpPort("_Mcp", "-editor-mcpport",
+  "The editor's own MCP port. This process is started by the editor with the editor's whole command line,\n"
+  "so when '-mcpport' is absent this is what it derives its port from: editor port + 1.",
+  0, 0, 0xFFFF);
+
+ezMcpServer* ezMcpEngineHost::s_pServer = nullptr;
+ezUInt64 ezMcpEngineHost::s_uiFrameCount = 0;
+bool ezMcpEngineHost::s_bQuitRequested = false;
+
+ezUInt16 ezMcpEngineHost::ResolvePort()
+{
+  const ezInt32 iOwnPort = s_opt_McpPort.GetOptionValue(ezCommandLineOption::LogMode::FirstTimeIfSpecified);
+
+  if (iOwnPort > 0)
+    return static_cast<ezUInt16>(iOwnPort);
+
+  const ezInt32 iEditorPort = s_opt_EditorMcpPort.GetOptionValue(ezCommandLineOption::LogMode::FirstTimeIfSpecified);
+
+  // The editor's port + 1. An agent that knows the editor's port can compute this one without being
+  // told, and nothing had to be added to the editor to pass it along.
+  if (iEditorPort > 0 && iEditorPort < 0xFFFF)
+    return static_cast<ezUInt16>(iEditorPort + 1);
+
+  return 0;
+}
+
+void ezMcpEngineHost::Startup()
+{
+  const ezUInt16 uiPort = ResolvePort();
+
+  if (uiPort == 0)
+    return;
+
+  ezGameApplicationBase* pApp = ezGameApplicationBase::GetGameApplicationBaseInstance();
+
+  if (pApp == nullptr)
+  {
+    ezLog::Warning("MCP: no ezGameApplicationBase, so there is no frame loop to answer requests from. Not starting the server.");
+    return;
+  }
+
+  s_pServer = EZ_DEFAULT_NEW(ezMcpServer, "ezEngine");
+
+  if (s_pServer->Start(uiPort).Failed())
+  {
+    // Most likely another process already holds the port - two games launched with the same '-mcpport',
+    // or an editor whose engine process derived the same number. Logged rather than fatal: the game
+    // itself is unaffected, and log_read is not reachable to explain it afterwards.
+    ezLog::Error("MCP: could not listen on port {}. The game runs without an MCP server.", uiPort);
+
+    EZ_DEFAULT_DELETE(s_pServer);
+    return;
+  }
+
+  pApp->m_ExecutionEvents.AddEventHandler(&ezMcpEngineHost::ExecutionEventHandler);
+
+  // The editor's engine process sleeps in its IPC wait until the editor sends it something, and an
+  // arriving MCP request is not something the editor knows about. Without this, a call to an idle
+  // engine process would simply never be answered. ezPlayer free-runs and ignores this.
+  pApp->m_HasPendingExternalWork = []() -> bool
+  {
+    return s_pServer != nullptr && s_pServer->HasPendingRequest();
+  };
+}
+
+void ezMcpEngineHost::Shutdown()
+{
+  if (s_pServer == nullptr)
+    return;
+
+  if (ezGameApplicationBase* pApp = ezGameApplicationBase::GetGameApplicationBaseInstance())
+  {
+    pApp->m_ExecutionEvents.RemoveEventHandler(&ezMcpEngineHost::ExecutionEventHandler);
+    pApp->m_HasPendingExternalWork = {};
+  }
+
+  // Stop() joins the transport thread, which finishes writing whatever response it was in the middle
+  // of. That is what makes it safe for app_quit to trigger shutdown one frame after being answered.
+  EZ_DEFAULT_DELETE(s_pServer);
+}
+
+void ezMcpEngineHost::RequestQuit()
+{
+  s_bQuitRequested = true;
+}
+
+void ezMcpEngineHost::ExecutionEventHandler(const ezGameApplicationExecutionEvent& e)
+{
+  if (e.m_Type == ezGameApplicationExecutionEvent::Type::BeforeWorldUpdates)
+  {
+    // Before the world ticks and before input is gathered, so a value written by input_set is picked up
+    // by the very frame the agent asked for rather than the one after it.
+    s_pServer->ProcessPendingRequests();
+    return;
+  }
+
+  // Counted on present rather than at the end of the tick, because 'a frame happened' has to mean 'a
+  // frame was rendered'. The editor's engine process runs its loop continuously but only renders when
+  // the editor asks it to, so an app tick is not evidence of anything - and a screenshot that waits for
+  // a frame would then be told frames were passing while none were.
+  if (e.m_Type == ezGameApplicationExecutionEvent::Type::BeforePresent)
+  {
+    ++s_uiFrameCount;
+    return;
+  }
+
+  if (e.m_Type == ezGameApplicationExecutionEvent::Type::EndAppTick)
+  {
+    if (s_bQuitRequested)
+    {
+      // One full frame after app_quit was answered. The response left the socket at the point above,
+      // and Shutdown() joins the transport thread anyway, so nothing is lost either way.
+      ezApplication::GetApplicationInstance()->QuitApplication();
+    }
+  }
+}

--- a/Code/EnginePlugins/McpPlugin/McpEngineHost.h
+++ b/Code/EnginePlugins/McpPlugin/McpEngineHost.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <McpPlugin/McpPluginDLL.h>
+
+#include <Core/GameApplication/GameApplicationBase.h>
+
+class ezMcpServer;
+
+/// \brief Owns the MCP server inside a game process, and the per-frame bookkeeping its tools need.
+///
+/// The counterpart to what EditorPluginMcp does in the editor. The difference that shapes this class is
+/// that a game process has a frame loop: 'run for a while and then look' is a meaningful request here,
+/// so tools need a frame number to wait for, and shutting down has to be deferred until after a
+/// response has left the socket.
+///
+/// Everything is static because there is one process, one server and one frame loop. There is nothing a
+/// second instance would mean.
+class ezMcpEngineHost
+{
+public:
+  /// \brief Resolves the port, starts the server and subscribes to the frame loop.
+  ///
+  /// Does nothing at all when no port was given - see the command line options in McpPlugin.cpp. That is
+  /// the normal case: this plugin is mandatory and therefore loaded by every project, so a game that was
+  /// not asked to serve MCP must not end up with an open port.
+  static void Startup();
+
+  static void Shutdown();
+
+  /// \brief How many frames the application has *rendered* since the server started.
+  ///
+  /// Monotonic, and the unit that game_wait counts in. Counts presents, not application ticks: the
+  /// editor's engine process loops continuously while rendering nothing, so ticks would report progress
+  /// that a screenshot or an input frame never sees.
+  static ezUInt64 GetFrameCount() { return s_uiFrameCount; }
+
+  /// \brief Shuts the process down at the end of the current frame.
+  ///
+  /// Deferred, because the response to app_quit has not reached the socket yet - see
+  /// ezMcpAppTool::RequestQuit(). Quitting from inside the tool call would drop it.
+  static void RequestQuit();
+
+private:
+  static void ExecutionEventHandler(const ezGameApplicationExecutionEvent& e);
+
+  /// \brief Reads -mcpport, falling back to -editor-mcpport + 1. Returns 0 for 'do not serve'.
+  static ezUInt16 ResolvePort();
+
+  static ezMcpServer* s_pServer;
+  static ezUInt64 s_uiFrameCount;
+  static bool s_bQuitRequested;
+};

--- a/Code/EnginePlugins/McpPlugin/McpInputDevice.cpp
+++ b/Code/EnginePlugins/McpPlugin/McpInputDevice.cpp
@@ -1,0 +1,104 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+#include <McpPlugin/McpInputDevice.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpInputDevice, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezMcpInputDevice* ezMcpInputDevice::s_pInstance = nullptr;
+
+ezMcpInputDevice::ezMcpInputDevice()
+{
+  // ezInputDevice is an ezEnumerable, so constructing this is all it takes for the input manager to
+  // start asking it for values. There is no registration call.
+  s_pInstance = this;
+
+  // An agent moving the mouse to a specific spot (e.g. to click a UI element) means that position
+  // literally, not 'whichever is bigger, mine or the real cursor's' - see m_bOverridesAbsoluteInput.
+  m_bOverridesAbsoluteInput = true;
+}
+
+ezMcpInputDevice::~ezMcpInputDevice()
+{
+  if (s_pInstance == this)
+  {
+    s_pInstance = nullptr;
+  }
+}
+
+void ezMcpInputDevice::SetSlotValue(ezStringView sSlot, float fValue, ezUInt32 uiFrames)
+{
+  const ezString sKey = sSlot;
+
+  m_InputSlotValues[sKey] = fValue;
+
+  if (uiFrames > 0)
+  {
+    m_RemainingFrames[sKey] = uiFrames;
+  }
+  else
+  {
+    // switching a timed hold back to an indefinite one
+    m_RemainingFrames.Remove(sKey);
+  }
+}
+
+void ezMcpInputDevice::ClearSlot(ezStringView sSlot)
+{
+  const ezString sKey = sSlot;
+
+  // Erased rather than set to zero: a zero written by this device still takes part in the Max merge,
+  // which is harmless, but leaving it in would report the slot as held by GetHeldSlots().
+  m_InputSlotValues.Remove(sKey);
+  m_RemainingFrames.Remove(sKey);
+}
+
+void ezMcpInputDevice::ClearAllSlots()
+{
+  m_InputSlotValues.Clear();
+  m_RemainingFrames.Clear();
+}
+
+void ezMcpInputDevice::QueueText(ezStringView sText)
+{
+  m_sLastCharacters.Append(sText);
+}
+
+void ezMcpInputDevice::GetHeldSlots(ezDynamicArray<HeldSlot>& out_slots) const
+{
+  for (auto it = m_InputSlotValues.GetIterator(); it.IsValid(); ++it)
+  {
+    HeldSlot& slot = out_slots.ExpandAndGetRef();
+    slot.m_sSlot = it.Key();
+    slot.m_fValue = it.Value();
+
+    if (const ezUInt32* pFrames = m_RemainingFrames.GetValue(it.Key()))
+    {
+      slot.m_uiFramesRemaining = *pFrames;
+    }
+  }
+}
+
+void ezMcpInputDevice::UpdateInputSlotValues()
+{
+  // Called once per input update, which is what makes it the place to count frames down. The values
+  // themselves need no work - they are already in m_InputSlotValues and stay there until changed.
+  for (auto it = m_RemainingFrames.GetIterator(); it.IsValid();)
+  {
+    ezUInt32& uiRemaining = it.Value();
+
+    if (uiRemaining > 1)
+    {
+      --uiRemaining;
+      ++it;
+      continue;
+    }
+
+    // The last frame of the hold has now been delivered, so stop writing the slot. Removing during
+    // iteration is why the iterator is advanced by Remove() rather than by ++it here.
+    m_InputSlotValues.Remove(it.Key());
+    it = m_RemainingFrames.Remove(it);
+  }
+}

--- a/Code/EnginePlugins/McpPlugin/McpInputDevice.h
+++ b/Code/EnginePlugins/McpPlugin/McpInputDevice.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <McpPlugin/McpPluginDLL.h>
+
+#include <Core/Input/InputDevice.h>
+
+/// \brief A synthetic input device that writes whatever an agent tells it to.
+///
+/// A real ezInputDevice rather than ezInputManager::InjectInputSlotValue(), for three reasons that all
+/// fall out of how the manager works:
+///
+///  - GatherDeviceInputSlotValues() merges every device per slot with ezMath::Max, so this coexists with
+///    the actual keyboard and mouse instead of fighting them. A human at the machine keeps control.
+///  - Key down/up transitions and dead zones are computed by the manager from the merged value, so
+///    ezKeyState::Pressed and Released come out correct without this class knowing anything about them.
+///  - Holding a key for several frames is just leaving the value in m_InputSlotValues, and letting go is
+///    erasing it. There is no per-slot bookkeeping to get wrong.
+///
+/// It registers no slots of its own. It writes the names that the real devices already registered -
+/// 'keyboard_w', 'mouse_button_0' - which is what makes the Max merge meaningful in the first place.
+/// A slot nobody registered can still be written, it just never reaches anything that reads input.
+///
+/// The header of ezInputDevice warns that a device may need integration into window message handling.
+/// That applies to hardware; there is no hardware here.
+class ezMcpInputDevice : public ezInputDevice
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpInputDevice, ezInputDevice);
+
+public:
+  ezMcpInputDevice();
+  ~ezMcpInputDevice();
+
+  /// \brief The one instance, or nullptr while the plugin's input tool does not exist.
+  static ezMcpInputDevice* GetInstance() { return s_pInstance; }
+
+  /// \brief Sets a slot's value, held until it is changed again or cleared.
+  ///
+  /// \param uiFrames How many frames to hold it for, counted down once per input update. 0 means
+  ///        indefinitely - which is what a caller who wants to press a key now and release it later
+  ///        wants, and also the way to leave a movement axis held down.
+  void SetSlotValue(ezStringView sSlot, float fValue, ezUInt32 uiFrames);
+
+  /// \brief Stops writing a slot entirely. Anything else writing it is then the only source again.
+  void ClearSlot(ezStringView sSlot);
+
+  /// \brief Stops writing every slot.
+  void ClearAllSlots();
+
+  /// \brief Injects typed text in one call, as if the OS had delivered every character within the same frame.
+  ///
+  /// Unlike SetSlotValue(), this is not held: it is consumed the next time something reads
+  /// ezInputManager::RetrieveLastCharacters() - same as a real keystroke - and gone afterwards. Queuing
+  /// again before that happens appends, it does not replace.
+  void QueueText(ezStringView sText);
+
+  /// \brief What this device is currently writing, and for how much longer.
+  struct HeldSlot
+  {
+    ezString m_sSlot;
+    float m_fValue = 0.0f;
+
+    /// 0 means 'until changed'.
+    ezUInt32 m_uiFramesRemaining = 0;
+  };
+
+  void GetHeldSlots(ezDynamicArray<HeldSlot>& out_slots) const;
+
+private:
+  virtual void InitializeDevice() override {}
+  virtual void RegisterInputSlots() override {}
+  virtual void UpdateInputSlotValues() override;
+
+  /// Slots the caller asked to be held for a limited number of frames, and the count that is left.
+  /// Slots held indefinitely are not in here at all - they just sit in m_InputSlotValues.
+  ezMap<ezString, ezUInt32> m_RemainingFrames;
+
+  static ezMcpInputDevice* s_pInstance;
+};

--- a/Code/EnginePlugins/McpPlugin/McpPlugin.cpp
+++ b/Code/EnginePlugins/McpPlugin/McpPlugin.cpp
@@ -1,0 +1,50 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+#include <McpPlugin/McpEngineHost.h>
+
+#include <Mcp/McpToolRegistry.h>
+
+#include <Foundation/Configuration/Plugin.h>
+#include <Foundation/Configuration/Startup.h>
+
+EZ_PLUGIN_ON_LOADED()
+{
+  // Created here rather than when the server starts, so that the log tool's hook is in place before the
+  // rest of engine startup runs. Otherwise log_read would come up empty for exactly the part of a
+  // session that is worth reading - loading the project, the plugins and the scene.
+  ezMcpToolRegistry::UpdateProviders();
+}
+
+EZ_PLUGIN_ON_UNLOADED()
+{
+  ezMcpToolRegistry::Clear();
+}
+
+// The registry's execute wrapper is deliberately left unset. It is what the editor uses to force a call
+// into unattended mode and to turn a failed assert into a tool error; a game process has neither dialogs
+// nor an assert handler that keeps running, so calls go straight through.
+
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(Mcp, McpPlugin)
+
+  BEGIN_SUBSYSTEM_DEPENDENCIES
+    "Foundation",
+    "Core"
+  END_SUBSYSTEM_DEPENDENCIES
+
+  ON_HIGHLEVELSYSTEMS_STARTUP
+  {
+    // Not at plugin load: the server needs the frame loop to answer requests from, and
+    // ezGameApplicationBase does not exist yet at that point.
+    ezMcpEngineHost::Startup();
+  }
+
+  ON_HIGHLEVELSYSTEMS_SHUTDOWN
+  {
+    ezMcpEngineHost::Shutdown();
+  }
+
+EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
+
+EZ_STATICLINK_FILE(McpPlugin, McpPlugin_McpPlugin);

--- a/Code/EnginePlugins/McpPlugin/McpPluginDLL.h
+++ b/Code/EnginePlugins/McpPlugin/McpPluginDLL.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <Foundation/Configuration/Plugin.h>
+
+// Configure the DLL Import/Export Define
+#if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)
+#  ifdef BUILDSYSTEM_BUILDING_MCPPLUGIN_LIB
+#    define EZ_MCPPLUGIN_DLL EZ_DECL_EXPORT
+#  else
+#    define EZ_MCPPLUGIN_DLL EZ_DECL_IMPORT
+#  endif
+#else
+#  define EZ_MCPPLUGIN_DLL
+#endif

--- a/Code/EnginePlugins/McpPlugin/McpPluginPCH.cpp
+++ b/Code/EnginePlugins/McpPlugin/McpPluginPCH.cpp
@@ -1,0 +1,7 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+EZ_STATICLINK_LIBRARY(McpPlugin)
+{
+  if (bReturn)
+    return;
+}

--- a/Code/EnginePlugins/McpPlugin/McpPluginPCH.h
+++ b/Code/EnginePlugins/McpPlugin/McpPluginPCH.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Core/GameApplication/GameApplicationBase.h>
+#include <Foundation/Basics.h>
+#include <Foundation/Configuration/Plugin.h>
+#include <Foundation/Configuration/Startup.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Utilities/CommandLineOptions.h>
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <Mcp/McpTool.h>
+
+// <StaticLinkUtil::StartHere>
+// all include's before this will be left alone and not replaced by the StaticLinkUtil
+// all include's AFTER this will be removed by the StaticLinkUtil and updated by what is actually used throughout the library
+
+#include <McpPlugin/McpPluginDLL.h>

--- a/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.cpp
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.cpp
@@ -1,0 +1,427 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+#include <McpPlugin/McpEngineHost.h>
+#include <McpPlugin/Tools/McpEngineAppTool.h>
+
+#include <Core/System/Window.h>
+#include <Core/System/WindowManager.h>
+
+#include <Foundation/IO/FileSystem/FileSystem.h>
+#include <Foundation/IO/MemoryStream.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/System/Process.h>
+#include <Foundation/Time/Clock.h>
+
+#include <Texture/Image/Formats/ImageFileFormat.h>
+#include <Texture/Image/Image.h>
+#include <Texture/Image/ImageConversion.h>
+#include <Texture/Image/ImageUtils.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpEngineAppTool, 1, ezRTTIDefaultAllocator<ezMcpEngineAppTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// \brief Collects the registered windows, so that an index means the same thing in app_info and in
+  /// app_screenshot.
+  void GetWindows(ezDynamicArray<ezRegisteredWndHandle>& out_windows)
+  {
+    if (ezWindowManager* pMan = ezWindowManager::GetSingleton())
+    {
+      pMan->GetRegistered(out_windows);
+    }
+  }
+
+  /// \brief Writes an image to an absolute path, without going through the ezFileSystem.
+  ///
+  /// ezImageView::SaveTo() uses ezFileWriter, which only reaches paths inside a writable data
+  /// directory - and the whole point of the path this tool returns is that the caller picked it, so it
+  /// is usually somewhere else entirely. ezGameApplicationBase::StoreScreenshot() is no use either: it
+  /// writes into ':appdata/Screenshots' under a generated name, on a worker task, so there is no path
+  /// to report back and no moment at which the file is known to exist.
+  ezResult WriteImageToAbsolutePath(const ezImageView& image, ezStringView sAbsolutePath)
+  {
+    const ezStringView sExtension = ezPathUtils::GetFileExtension(sAbsolutePath);
+    const ezImageFileFormat* pFormat = ezImageFileFormat::GetWriterFormat(sExtension);
+
+    if (pFormat == nullptr)
+    {
+      ezLog::Error("No image file format is available to write '{}'.", sAbsolutePath);
+      return EZ_FAILURE;
+    }
+
+    // Encoded into memory first, because ezOSFile is not an ezStreamWriter and the format writers only
+    // take one of those. A failed encode then also leaves no half-written file behind.
+    ezDefaultMemoryStreamStorage storage;
+    ezMemoryStreamWriter memoryWriter(&storage);
+
+    if (pFormat->WriteImage(memoryWriter, image, sExtension).Failed())
+    {
+      ezLog::Error("Could not encode the image as '{}'.", sExtension);
+      return EZ_FAILURE;
+    }
+
+    ezStringBuilder sFolder = sAbsolutePath;
+    sFolder.PathParentDirectory();
+
+    if (!sFolder.IsEmpty() && ezOSFile::CreateDirectoryStructure(sFolder).Failed())
+    {
+      ezLog::Error("Could not create the folder for '{}'.", sAbsolutePath);
+      return EZ_FAILURE;
+    }
+
+    ezOSFile file;
+    if (file.Open(sAbsolutePath, ezFileOpenMode::Write).Failed())
+    {
+      ezLog::Error("Could not open '{}' for writing.", sAbsolutePath);
+      return EZ_FAILURE;
+    }
+
+    ezMemoryStreamReader memoryReader(&storage);
+    ezHybridArray<ezUInt8, 4096> chunk;
+    chunk.SetCountUninitialized(4096);
+
+    while (const ezUInt64 uiRead = memoryReader.ReadBytes(chunk.GetData(), chunk.GetCount()))
+    {
+      if (file.Write(chunk.GetData(), uiRead).Failed())
+      {
+        ezLog::Error("Could not write '{}'.", sAbsolutePath);
+        return EZ_FAILURE;
+      }
+    }
+
+    return EZ_SUCCESS;
+  }
+} // namespace
+
+ezStringView ezMcpEngineAppTool::GetBuildTimestamp() const
+{
+  // this plugin's own timestamp, not the Mcp library's - the tool list comes from here
+  return __DATE__ " " __TIME__;
+}
+
+ezStringView ezMcpEngineAppTool::GetRelaunchHint() const
+{
+  return "To start a game again afterwards, run ezPlayer with "
+         "'-project <path-to-project-folder> -scene <path-to-binary-scene> -mcpport <port>'. It serves MCP at "
+         "http://127.0.0.1:<port>/mcp once the scene is loaded, which takes a few seconds - poll the port rather than "
+         "assuming a delay. Without '-mcpport' no server is started at all, which is the default. "
+         "If this process is the editor's engine process instead, it is not launched directly: quitting it ends the "
+         "editor's play-the-game session, and starting another one is done through the editor.";
+}
+
+void ezMcpEngineAppTool::AddHostInfo(ezMcpJsonWriter& ref_writer)
+{
+  // Which of the two hosts this is. They answer the same tools but are not interchangeable: one is
+  // launched directly and free-runs, the other is a child of the editor and only renders when asked.
+  ref_writer.AddVariableString("host", ezApplication::GetApplicationInstance()->GetApplicationName());
+
+  ref_writer.AddVariableUInt64("frameCount", ezMcpEngineHost::GetFrameCount());
+
+  // Where this process writes its log. Worth reporting for the same reason as in the editor: a crash
+  // takes the server with it, and the file is what is left to read afterwards.
+  ezStringBuilder sAbsLogFile;
+  if (ezFileSystem::ResolvePath(":appdata/Log.htm", &sAbsLogFile, nullptr).Succeeded())
+  {
+    ref_writer.AddVariableString("logFileFolder", sAbsLogFile.GetFileDirectory());
+  }
+
+  // The windows app_screenshot can capture, by the index it takes.
+  ezHybridArray<ezRegisteredWndHandle, 4> windows;
+  GetWindows(windows);
+
+  ezWindowManager* pMan = ezWindowManager::GetSingleton();
+
+  ref_writer.BeginArray("windows");
+  for (ezUInt32 i = 0; i < windows.GetCount(); ++i)
+  {
+    ref_writer.BeginObject();
+    ref_writer.AddVariableUInt32("index", i);
+    ref_writer.AddVariableString("name", pMan->GetName(windows[i]));
+
+    if (const ezWindowBase* pWindow = pMan->GetWindow(windows[i]))
+    {
+      const ezSizeU32 size = pWindow->GetClientAreaSize();
+      ref_writer.AddVariableUInt32("width", size.width);
+      ref_writer.AddVariableUInt32("height", size.height);
+    }
+
+    // No output target means nothing renders into it, so app_screenshot cannot use it.
+    ref_writer.AddVariableBool("canCapture", pMan->GetOutputTarget(windows[i]) != nullptr);
+    ref_writer.EndObject();
+  }
+  ref_writer.EndArray();
+}
+
+void ezMcpEngineAppTool::RequestQuit(bool bDiscardChanges)
+{
+  EZ_IGNORE_UNUSED(bDiscardChanges);
+
+  // Deferred to the end of the frame, because the response has not reached the socket yet.
+  ezMcpEngineHost::RequestQuit();
+}
+
+void ezMcpEngineAppTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  SUPER::GetSupportedTools(out_tools);
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "app_screenshot";
+    desc.m_sDescription =
+      "Captures what the game is currently rendering, writes it to an image file and returns the absolute path to it. "
+      "Read that file to actually look at the frame - this is the only way to see what the game looks like, and a "
+      "rendered frame is the evidence that a change works, not that the process did not crash.\n"
+      "The path is returned rather than the image data, because a screenshot base64s to megabytes.\n"
+      "The capture takes a frame or two, so the call blocks until the image is ready. If the game is not rendering - "
+      "which is the normal state of the editor's engine process while nobody is playing the game - this fails after a "
+      "few seconds rather than waiting forever; start play-the-game in the editor first.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"path":{"type":"string","description":"Absolute path to write to, including the file extension, which selects the format ('.png' unless there is a reason). Defaults to a generated name in the system temp folder."},"maxWidth":{"type":"number","description":"Downscale to at most this width, keeping the aspect ratio. Default 1280. Pass 0 for the full resolution."},"window":{"type":"number","description":"Which window to capture, as its index in app_info's 'windows'. Default 0."}}})";
+  }
+}
+
+void ezMcpEngineAppTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "app_screenshot")
+  {
+    ExecuteScreenshot(arguments, out_result);
+    return;
+  }
+
+  SUPER::Execute(sToolName, arguments, out_result);
+}
+
+ezMcpEngineAppTool::~ezMcpEngineAppTool()
+{
+  OnDeactivate();
+}
+
+void ezMcpEngineAppTool::OnDeactivate()
+{
+  if (m_FrameSubscription != 0)
+  {
+    if (ezGameApplicationBase* pApp = ezGameApplicationBase::GetGameApplicationBaseInstance())
+    {
+      pApp->m_ExecutionEvents.RemoveEventHandler(m_FrameSubscription);
+    }
+
+    m_FrameSubscription = 0;
+  }
+}
+
+void ezMcpEngineAppTool::ExecutionEventHandler(const ezGameApplicationExecutionEvent& e)
+{
+  if (e.m_Type != ezGameApplicationExecutionEvent::Type::BeforePresent)
+    return;
+
+  if (m_State != CaptureState::Pending)
+    return;
+
+  ezHybridArray<ezRegisteredWndHandle, 4> windows;
+  GetWindows(windows);
+
+  ezWindowOutputTargetBase* pOutputTarget = nullptr;
+
+  if (m_iCaptureWindow < static_cast<ezInt32>(windows.GetCount()))
+  {
+    pOutputTarget = ezWindowManager::GetSingleton()->GetOutputTarget(windows[m_iCaptureWindow]);
+  }
+
+  if (pOutputTarget == nullptr)
+  {
+    // the window went away mid-capture, e.g. the editor ended the play-the-game session
+    m_State = CaptureState::Failed;
+    m_sCaptureError = "The window disappeared while the screenshot was being captured.";
+    return;
+  }
+
+  const ezEnum<ezCaptureImageResult> res = pOutputTarget->WaitCaptureImage(m_CapturedImage);
+
+  if (res == ezCaptureImageResult::Ready)
+  {
+    m_State = CaptureState::Ready;
+    return;
+  }
+
+  if (res == ezCaptureImageResult::NotStarted)
+  {
+    // Accepted and then dropped - the swap chain's back buffer was not usable when the renderer got to
+    // it. Not a timing problem, so waiting longer would not help.
+    m_State = CaptureState::Failed;
+    m_sCaptureError = "The capture was discarded before it produced an image. The window's swap chain was not in a "
+                      "usable state - a window that is minimised or in the middle of being resized does this. Try "
+                      "again once it is visible.";
+  }
+}
+
+void ezMcpEngineAppTool::ExecuteScreenshot(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  // Re-entered once per frame while the capture is in flight - see ezMcpToolResult::m_bNotFinished. The
+  // arguments are the same every time, so they are only read on the first pass.
+  if (m_State == CaptureState::Idle)
+  {
+    if (BeginScreenshot(arguments, out_result).Failed())
+      return;
+
+    out_result.m_bNotFinished = true;
+    return;
+  }
+
+  if (m_State == CaptureState::Ready)
+  {
+    FinishScreenshot(out_result);
+    m_State = CaptureState::Idle;
+    return;
+  }
+
+  if (m_State == CaptureState::Failed)
+  {
+    out_result.SetError(m_sCaptureError);
+    m_State = CaptureState::Idle;
+    return;
+  }
+
+  if (ezTime::Now() - m_CaptureStarted < s_CaptureTimeout)
+  {
+    out_result.m_bNotFinished = true;
+    return;
+  }
+
+  m_State = CaptureState::Idle;
+  out_result.SetError("The screenshot never became ready. A capture only completes once another frame has been "
+                      "presented, so this means the game is not rendering: in the editor's engine process that is "
+                      "the normal state while play-the-game is not running, and the fix is to start it. A window "
+                      "that is minimised does the same thing.");
+}
+
+ezResult ezMcpEngineAppTool::BeginScreenshot(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezHybridArray<ezRegisteredWndHandle, 4> windows;
+  GetWindows(windows);
+
+  if (windows.IsEmpty())
+  {
+    out_result.SetError("This process has no window registered, so there is nothing to capture. That is normal for a "
+                        "process that was started without a graphics device.");
+    return EZ_FAILURE;
+  }
+
+  const ezInt32 iWindow = static_cast<ezInt32>(ezMcpJson::GetInt(arguments, "window", 0));
+
+  if (iWindow < 0 || iWindow >= static_cast<ezInt32>(windows.GetCount()))
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("There is no window {}. This process has {}; see 'windows' in app_info.", iWindow, windows.GetCount());
+    out_result.SetError(sError);
+    return EZ_FAILURE;
+  }
+
+  ezWindowOutputTargetBase* pOutputTarget = ezWindowManager::GetSingleton()->GetOutputTarget(windows[iWindow]);
+
+  if (pOutputTarget == nullptr)
+  {
+    out_result.SetError("That window has no output target, so nothing is rendered into it and there is nothing to capture.");
+    return EZ_FAILURE;
+  }
+
+  ezStringBuilder sPath = ezMcpJson::GetString(arguments, "path");
+
+  if (sPath.IsEmpty())
+  {
+    // Into the temp folder, and named by frame, so that repeated calls do not overwrite each other and
+    // an agent can compare two frames without having to invent file names.
+    sPath = ezOSFile::GetTempDataFolder("Screenshots");
+    sPath.AppendFormat("/{}_{}.png", ezProcess::GetCurrentProcessID(), ezMcpEngineHost::GetFrameCount());
+  }
+
+  sPath.MakeCleanPath();
+
+  if (!ezPathUtils::IsAbsolutePath(sPath))
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("'{}' is not an absolute path. The file is written straight to disk rather than into a data "
+                     "directory, so there is nothing for a relative path to be relative to.",
+      sPath);
+    out_result.SetError(sError);
+    return EZ_FAILURE;
+  }
+
+  // Subscribed lazily rather than in OnActivate(): the providers are created when the plugin loads, and
+  // there is no ezGameApplicationBase yet at that point.
+  if (m_FrameSubscription == 0)
+  {
+    ezGameApplicationBase* pApp = ezGameApplicationBase::GetGameApplicationBaseInstance();
+
+    if (pApp == nullptr)
+    {
+      out_result.SetError("There is no game application, so there is no frame loop to complete a capture.");
+      return EZ_FAILURE;
+    }
+
+    m_FrameSubscription = pApp->m_ExecutionEvents.AddEventHandler(ezMakeDelegate(&ezMcpEngineAppTool::ExecutionEventHandler, this));
+  }
+
+  if (pOutputTarget->StartCaptureImage().Failed())
+  {
+    out_result.SetError("Could not start the capture. Another one may still be in flight - try again in a moment.");
+    return EZ_FAILURE;
+  }
+
+  m_State = CaptureState::Pending;
+  m_sCapturePath = sPath;
+  m_iCaptureWindow = iWindow;
+  m_uiCaptureMaxWidth = static_cast<ezUInt32>(ezMath::Max<ezInt64>(0, ezMcpJson::GetInt(arguments, "maxWidth", 1280)));
+  m_CaptureStarted = ezTime::Now();
+
+  return EZ_SUCCESS;
+}
+
+void ezMcpEngineAppTool::FinishScreenshot(ezMcpToolResult& out_result)
+{
+  ezImage image;
+  image.ResetAndMove(std::move(m_CapturedImage));
+
+  // Downscaled before encoding rather than after: a full resolution PNG is several megabytes and the
+  // detail is not what the image is being looked at for.
+  if (m_uiCaptureMaxWidth > 0 && image.GetWidth() > m_uiCaptureMaxWidth)
+  {
+    const ezUInt32 uiHeight = ezMath::Max(1u, (image.GetHeight() * m_uiCaptureMaxWidth) / image.GetWidth());
+
+    ezImage scaled;
+    if (ezImageUtils::Scale(image, scaled, m_uiCaptureMaxWidth, uiHeight).Succeeded())
+    {
+      image.ResetAndMove(std::move(scaled));
+    }
+  }
+
+  // get rid of the alpha channel, which a back buffer carries and a viewer does not want
+  if (image.Convert(ezImageFormat::R8G8B8_UNORM_SRGB).Failed())
+  {
+    out_result.SetError("Could not convert the screenshot to RGB8.");
+    return;
+  }
+
+  if (WriteImageToAbsolutePath(image, m_sCapturePath).Failed())
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("Could not write the screenshot to '{}'. See log_read for the reason - a bad extension and a "
+                     "folder that cannot be created both end up here.",
+      m_sCapturePath);
+    out_result.SetError(sError);
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableString("path", m_sCapturePath);
+  writer.AddVariableUInt32("width", image.GetWidth());
+  writer.AddVariableUInt32("height", image.GetHeight());
+  writer.AddVariableUInt64("frame", ezMcpEngineHost::GetFrameCount());
+  writer.AddVariableString("note", "Read this file to look at the frame.");
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.h
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <McpPlugin/McpPluginDLL.h>
+
+#include <Core/GameApplication/GameApplicationBase.h>
+#include <Foundation/Time/Time.h>
+#include <Mcp/Tools/McpAppTool.h>
+#include <Texture/Image/Image.h>
+
+/// \brief The game process' half of the shared app_* tools, plus taking a screenshot.
+///
+/// The process level questions - port, executable, command line, process id - are answered by the base
+/// class, so an agent driving both an editor and the game it runs asks them the same way in both. What
+/// is added here is what only a rendering, frame-stepping process can answer.
+class ezMcpEngineAppTool : public ezMcpAppTool
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpEngineAppTool, ezMcpAppTool);
+
+public:
+  ~ezMcpEngineAppTool();
+
+  virtual void OnDeactivate() override;
+
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+protected:
+  virtual ezStringView GetHostNoun() const override { return "game"; }
+  virtual ezStringView GetRelaunchHint() const override;
+  virtual ezStringView GetBuildTimestamp() const override;
+  virtual void AddHostInfo(ezMcpJsonWriter& ref_writer) override;
+  virtual void RequestQuit(bool bDiscardChanges) override;
+
+private:
+  void ExecuteScreenshot(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Starts the capture. Fills out_result and returns EZ_FAILURE if it could not be started.
+  ezResult BeginScreenshot(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Turns a finished capture into a file. Called once m_State is Ready.
+  void FinishScreenshot(ezMcpToolResult& out_result);
+
+  /// \brief Polls the pending capture, from inside the frame.
+  ///
+  /// Subscribed to the frame loop rather than done from the tool call, because a capture only completes
+  /// once the frame that renders it is about to be presented - which is exactly where the engine polls
+  /// its own screenshots (ezGameApplication::Run_PresentImage). Polling from the tool call instead, at
+  /// the point where MCP requests are pumped, is *before* that frame has rendered, and the capture is
+  /// then perpetually pending.
+  void ExecutionEventHandler(const ezGameApplicationExecutionEvent& e);
+
+  enum class CaptureState
+  {
+    Idle,
+    Pending, ///< Started, waiting for the frame loop to hand back an image.
+    Ready,   ///< m_CapturedImage holds it.
+    Failed,  ///< Dropped by the renderer - see m_sCaptureError.
+  };
+
+  /// Capturing a back buffer is asynchronous by at least one frame, and the tool call runs *inside* a
+  /// frame - so the image cannot be ready before that call returns. The request is deferred
+  /// (ezMcpToolResult::m_bNotFinished) and this is the state that survives across the re-entries. Only
+  /// one request is ever in flight, so a single set of members is enough.
+  CaptureState m_State = CaptureState::Idle;
+  ezImage m_CapturedImage;
+  ezString m_sCaptureError;
+  ezString m_sCapturePath;
+  ezUInt32 m_uiCaptureMaxWidth = 0;
+  ezInt32 m_iCaptureWindow = 0;
+  ezTime m_CaptureStarted;
+  ezEventSubscriptionID m_FrameSubscription = 0;
+
+  /// How long to keep polling before giving up. Generous for a frame or two of latency, short enough
+  /// that the answer arrives while an agent is still waiting. The interesting case it bounds is the
+  /// editor's engine process, which renders only when the editor asks it to and may never present a
+  /// frame at all - without a limit that is indistinguishable from a hang.
+  static constexpr ezTime s_CaptureTimeout = ezTime::MakeFromSeconds(10);
+};

--- a/Code/EnginePlugins/McpPlugin/Tools/McpGameTool.cpp
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpGameTool.cpp
@@ -1,0 +1,273 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+#include <McpPlugin/McpEngineHost.h>
+#include <McpPlugin/Tools/McpGameTool.h>
+
+#include <Core/GameState/GameStateBase.h>
+#include <Core/World/World.h>
+#include <GameEngine/GameState/GameState.h>
+
+#include <Foundation/Time/Clock.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpGameTool, 1, ezRTTIDefaultAllocator<ezMcpGameTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezMcpGameTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "game_info";
+    desc.m_sDescription =
+      "Returns what the game is currently doing: whether a game state is active and of which type, the world it is "
+      "playing in with its simulation state and time, and the global clock's speed and paused state.\n"
+      "Start here. 'gameStateActive' false means nothing is being played yet - in the editor's engine process that is "
+      "the normal state until play-the-game is started, and it explains why input does nothing and why screenshots "
+      "time out. Process level facts - port, executable, log file, windows - are in app_info instead.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "game_wait";
+    desc.m_sDescription =
+      "Lets the game run for a number of frames and returns once they have happened. This is how to observe anything: "
+      "input is consumed one frame at a time and a screenshot captures a frame that was already presented, so "
+      "'press a key, wait, look' is the sequence that shows an effect.\n"
+      "It does not change how the game runs - it only waits. If frames are not being produced at all, it gives up "
+      "after a timeout and says so rather than blocking forever; the usual cause is the editor's engine process, "
+      "which renders only while the editor asks it to.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"frames":{"type":"number","description":"How many frames to wait for. Default 1."},"timeout":{"type":"number","description":"Give up after this many seconds if the frames do not happen. Default 30."}}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "game_pause";
+    desc.m_sDescription =
+      "Pauses or resumes the global clock. A paused game keeps rendering and keeps answering tools - it is the world "
+      "that stops advancing - so this is how to hold a moment still while inspecting it, and screenshots and input "
+      "still work while paused.\n"
+      "Beware what 'paused' means for a particular game: it stops the clock the engine hands out, which is not "
+      "necessarily the same thing as that game's own notion of simulation time.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"paused":{"type":"boolean","description":"True to pause, false to resume. Omit to just report the current state."}}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "game_speed";
+    desc.m_sDescription =
+      "Reads or sets the global clock's speed factor. 1 is real time, 0.1 slows everything down by ten, 5 speeds it "
+      "up. Useful either way: slowing down makes a fast event observable frame by frame, speeding up gets through a "
+      "long wait without spending the frames.\n"
+      "This scales time, not frames - the game still renders as fast as it did, each frame just covers more or less "
+      "simulated time.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"speed":{"type":"number","description":"The new speed factor. Must be greater than 0. Omit to just report the current one."}}})";
+  }
+}
+
+void ezMcpGameTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "game_info")
+  {
+    ExecuteInfo(arguments, out_result);
+  }
+  else if (sToolName == "game_wait")
+  {
+    ExecuteWait(arguments, out_result);
+  }
+  else if (sToolName == "game_pause")
+  {
+    ExecutePause(arguments, out_result);
+  }
+  else if (sToolName == "game_speed")
+  {
+    ExecuteSpeed(arguments, out_result);
+  }
+}
+
+void ezMcpGameTool::WriteClockState(ezMcpJsonWriter& ref_writer)
+{
+  const ezClock* pClock = ezClock::GetGlobalClock();
+
+  ref_writer.BeginObject("clock");
+  ref_writer.AddVariableBool("paused", pClock->GetPaused());
+  ref_writer.AddVariableDouble("speed", pClock->GetSpeed());
+  ref_writer.AddVariableDouble("accumulatedTimeSeconds", pClock->GetAccumulatedTime().GetSeconds());
+  ref_writer.AddVariableDouble("lastTimeStepSeconds", pClock->GetTimeDiff().GetSeconds());
+
+  // Non-zero means the clock reports a constant time step regardless of how long the frame really took.
+  // Worth reporting because it makes 'wait N frames' mean a fixed amount of simulated time.
+  if (pClock->GetFixedTimeStep().IsPositive())
+  {
+    ref_writer.AddVariableDouble("fixedTimeStepSeconds", pClock->GetFixedTimeStep().GetSeconds());
+  }
+
+  ref_writer.EndObject();
+}
+
+void ezMcpGameTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  EZ_IGNORE_UNUSED(arguments);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezGameApplicationBase* pApp = ezGameApplicationBase::GetGameApplicationBaseInstance();
+  ezGameStateBase* pGameState = pApp != nullptr ? pApp->GetActiveGameState() : nullptr;
+
+  writer.AddVariableBool("gameStateActive", pGameState != nullptr);
+
+  if (pGameState != nullptr)
+  {
+    // The concrete type is what identifies the game - a project's own game state is where its rules
+    // live, and its name is what a caller needs to look for tools or types belonging to it.
+    writer.AddVariableString("gameStateType", pGameState->GetDynamicRTTI()->GetTypeName());
+  }
+
+  writer.AddVariableUInt64("frameCount", ezMcpEngineHost::GetFrameCount());
+
+  WriteClockState(writer);
+
+  // Reached through the game state rather than by walking ezWorld's global table: ezWorld::GetWorld()
+  // takes a raw slot index while GetWorldCount() returns how many slots are *live*, so iterating one
+  // against the other reads freed slots as soon as any world has ever been destroyed. The game state's
+  // world is also the one the question is actually about.
+  const ezGameState* pTypedGameState = ezDynamicCast<const ezGameState*>(pGameState);
+  const ezWorld* pWorld = pTypedGameState != nullptr ? const_cast<ezGameState*>(pTypedGameState)->GetMainWorld() : nullptr;
+
+  if (pWorld != nullptr)
+  {
+    writer.BeginObject("world");
+    writer.AddVariableString("name", pWorld->GetName());
+    writer.AddVariableBool("simulating", pWorld->GetWorldSimulationEnabled());
+    writer.AddVariableDouble("timeSeconds", pWorld->GetClock().GetAccumulatedTime().GetSeconds());
+    writer.EndObject();
+  }
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpGameTool::ExecuteWait(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezUInt64 uiNow = ezMcpEngineHost::GetFrameCount();
+
+  // First entry. Every later one is a re-entry from the deferral, and must not read the arguments
+  // again - the frame count it is waiting for was decided here.
+  if (!m_bWaiting)
+  {
+    const ezInt64 iFrames = ezMcpJson::GetInt(arguments, "frames", 1);
+
+    if (iFrames < 1 || iFrames > s_uiMaxFrames)
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("'frames' must be between 1 and {}, not {}.", s_uiMaxFrames, iFrames);
+      out_result.SetError(sError);
+      return;
+    }
+
+    const ezInt64 iTimeout = ezMcpJson::GetInt(arguments, "timeout", static_cast<ezInt64>(s_DefaultTimeout.GetSeconds()));
+
+    m_bWaiting = true;
+    m_uiWaitStartFrame = uiNow;
+    m_uiWaitUntilFrame = uiNow + static_cast<ezUInt64>(iFrames);
+    m_WaitStarted = ezTime::Now();
+    m_WaitTimeout = iTimeout > 0 ? ezTime::MakeFromSeconds(static_cast<double>(iTimeout)) : s_DefaultTimeout;
+
+    out_result.m_bNotFinished = true;
+    return;
+  }
+
+  const bool bDone = uiNow >= m_uiWaitUntilFrame;
+  const bool bTimedOut = !bDone && (ezTime::Now() - m_WaitStarted >= m_WaitTimeout);
+
+  if (!bDone && !bTimedOut)
+  {
+    out_result.m_bNotFinished = true;
+    return;
+  }
+
+  const ezUInt64 uiElapsed = uiNow - m_uiWaitStartFrame;
+  const ezUInt64 uiRequested = m_uiWaitUntilFrame - m_uiWaitStartFrame;
+
+  m_bWaiting = false;
+
+  if (bTimedOut)
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("Timed out after {} seconds having waited {} of {} frames. The game is not producing frames fast "
+                     "enough, or not at all. In the editor's engine process that is the normal state while "
+                     "play-the-game is not running - it renders only when the editor asks it to - so start the game "
+                     "in the editor first. A minimised window does the same thing.",
+      (ezTime::Now() - m_WaitStarted).GetSeconds(), uiElapsed, uiRequested);
+    out_result.SetError(sError);
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableUInt64("framesWaited", uiElapsed);
+  writer.AddVariableUInt64("frameCount", uiNow);
+  writer.AddVariableDouble("elapsedSeconds", (ezTime::Now() - m_WaitStarted).GetSeconds());
+  WriteClockState(writer);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpGameTool::ExecutePause(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezClock* pClock = ezClock::GetGlobalClock();
+
+  const ezVariant* pPaused = nullptr;
+  if (arguments.TryGetValue("paused", pPaused) && pPaused->IsValid())
+  {
+    pClock->SetPaused(ezMcpJson::GetBool(arguments, "paused", false));
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  WriteClockState(writer);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpGameTool::ExecuteSpeed(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezClock* pClock = ezClock::GetGlobalClock();
+
+  const ezVariant* pSpeed = nullptr;
+  if (arguments.TryGetValue("speed", pSpeed) && pSpeed->IsValid())
+  {
+    ezResult conversion = EZ_SUCCESS;
+    const double fSpeed = pSpeed->ConvertTo<double>(&conversion);
+
+    if (conversion.Failed())
+    {
+      out_result.SetError("'speed' is not a number.");
+      return;
+    }
+
+    if (fSpeed <= 0.0)
+    {
+      // ezClock asserts on a non-positive speed, and 'stopped' is what game_pause is for.
+      out_result.SetError("'speed' must be greater than 0. Use game_pause to stop time entirely.");
+      return;
+    }
+
+    pClock->SetSpeed(fSpeed);
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  WriteClockState(writer);
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EnginePlugins/McpPlugin/Tools/McpGameTool.h
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpGameTool.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <McpPlugin/McpPluginDLL.h>
+
+#include <Foundation/Time/Time.h>
+#include <Mcp/McpTool.h>
+
+/// \brief What the game is doing, and letting it run.
+///
+/// The distinction against app_* is process versus game: the port, the executable and the log belong to
+/// the process and are answered by the shared ezMcpAppTool, while a world, a game state and a clock only
+/// exist here.
+///
+/// Frame-accurate *stepping* is deliberately absent. ezClock could do it - pause, fixed timestep,
+/// unpause for N frames - but a frame is the wrong unit for a game whose simulation is not frame driven.
+/// A turn based game that interpolates between recorded turns would find that pausing the clock freezes
+/// playback and not the simulation, so the useful stepping belongs in that game's own tool provider,
+/// which the reflection-based registry already allows any game plugin to add.
+class ezMcpGameTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpGameTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteWait(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecutePause(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteSpeed(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Writes the clock's state, shared by game_info, game_pause and game_speed.
+  static void WriteClockState(ezMcpJsonWriter& ref_writer);
+
+  /// game_wait cannot loop - it runs inside a frame, so frames only happen after it returns. It defers
+  /// instead (ezMcpToolResult::m_bNotFinished) and is re-entered once per frame until the target is
+  /// reached; this is what survives across those calls.
+  bool m_bWaiting = false;
+  ezUInt64 m_uiWaitUntilFrame = 0;
+  ezUInt64 m_uiWaitStartFrame = 0;
+  ezTime m_WaitStarted;
+  ezTime m_WaitTimeout;
+
+  /// Frames are cheap but not free, and a caller that asks for a million of them has made a mistake
+  /// that would otherwise look exactly like a hang.
+  static constexpr ezUInt32 s_uiMaxFrames = 10000;
+
+  /// How long to keep waiting when frames are not arriving at all. The case this exists for is the
+  /// editor's engine process, which renders only when the editor asks it to: without a limit,
+  /// 'wait 10 frames' there would never return.
+  static constexpr ezTime s_DefaultTimeout = ezTime::MakeFromSeconds(30);
+};

--- a/Code/EnginePlugins/McpPlugin/Tools/McpInputTool.cpp
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpInputTool.cpp
@@ -1,0 +1,436 @@
+#include <McpPlugin/McpPluginPCH.h>
+
+#include <McpPlugin/McpEngineHost.h>
+#include <McpPlugin/McpInputDevice.h>
+#include <McpPlugin/Tools/McpInputTool.h>
+
+#include <Core/Input/InputManager.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpInputTool, 1, ezRTTIDefaultAllocator<ezMcpInputTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezMcpInputTool::ezMcpInputTool() = default;
+ezMcpInputTool::~ezMcpInputTool() = default;
+
+void ezMcpInputTool::OnActivate()
+{
+  m_pDevice = EZ_DEFAULT_NEW(ezMcpInputDevice);
+}
+
+void ezMcpInputTool::OnDeactivate()
+{
+  // Destroying the device unregisters it, which also releases anything it was still holding down - a
+  // key left pressed by a plugin that is going away would otherwise stay pressed forever.
+  m_pDevice = nullptr;
+}
+
+void ezMcpInputTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "input_slots";
+    desc.m_sDescription =
+      "Lists the input slots this process knows about - the names input_set writes to. Call it before guessing a name: "
+      "the spelling is 'keyboard_w', 'mouse_button_0', 'mouse_move_pos_x', and which slots exist at all depends on "
+      "which input devices the platform registered.\n"
+      "'flags' says what kind of thing a slot is, which decides what value makes sense: a button is 0 or 1, an analog "
+      "axis is anything in between, and a relative slot like mouse movement is a per-frame delta rather than a "
+      "position. 'value' is what the slot currently reads, merged across all devices including this one.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"contains":{"type":"string","description":"Only return slots whose name or display name contains this text, case insensitive. Omit for all of them."},"activeOnly":{"type":"boolean","description":"Only return slots whose current value is not zero. Useful to find out what is being pressed right now. Default false."}}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "input_set";
+    desc.m_sDescription =
+      "Presses keys and moves the mouse, by writing input slot values that the game reads as if they came from real "
+      "hardware. Get the slot names from input_slots.\n"
+      "Values are merged with the real keyboard and mouse rather than replacing them, taking whichever is larger, so "
+      "this never locks a human out of the process.\n"
+      "'frames' is how long to hold the value. Omit it or pass 0 to hold indefinitely, which is what to use to press a "
+      "key now and release it later with a second call setting the same slot to 0 - or with 'clearAll'. A key held for "
+      "0 frames would never be seen, since the game reads input once per frame.\n"
+      "The game only consumes input while it renders frames, so follow this with game_wait to let those frames happen; "
+      "returning from this call only means the value is set, not that anything has reacted to it.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"slots":{"type":"object","description":"Slot name to value, e.g. {\"keyboard_w\":1.0,\"mouse_move_pos_x\":0.01}. A value of 0 stops writing that slot.","additionalProperties":{"type":"number"}},"frames":{"type":"number","description":"Hold the values for this many frames, then release them. 0 or omitted means until changed."},"clearAll":{"type":"boolean","description":"Release everything this tool is currently holding, before applying 'slots'. Pass it on its own to let go of everything."}}})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "input_sequence";
+    desc.m_sDescription =
+      "Runs a chain of input steps in order, in a single call, instead of one input_set/game_wait round trip "
+      "per step. Each step is exactly one of:\n"
+      "  {\"set\": {...}} - writes slot values, same as input_set's 'slots' (merged with the real hardware, "
+      "held until changed or cleared).\n"
+      "  {\"wait\": {\"frames\": n}} - lets the game run for n frames before the next step, same as game_wait.\n"
+      "  {\"text\": \"...\"} - queues typed text, delivered as one batch the next time the game reads input - "
+      "not one character per frame, so it costs no extra frames by itself.\n"
+      "  {\"clear\": true} - releases every slot this tool is currently holding.\n"
+      "A chord (several keys in the same frame) is one 'set' step naming all of them, not several steps. "
+      "The call returns once every step has run; a 'wait' step is the only thing that actually spends frames, "
+      "so a sequence with none of those returns immediately, same as input_set.";
+
+    desc.m_sInputSchema = R"({"type":"object","properties":{"steps":{"type":"array","description":"Executed in order. See the tool description for the four step shapes.","items":{"type":"object"}},"timeout":{"type":"number","description":"Give up on any individual 'wait' step after this many seconds. Default 30."}},"required":["steps"]})";
+  }
+}
+
+void ezMcpInputTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "input_slots")
+  {
+    ExecuteSlots(arguments, out_result);
+  }
+  else if (sToolName == "input_set")
+  {
+    ExecuteSet(arguments, out_result);
+  }
+  else if (sToolName == "input_sequence")
+  {
+    ExecuteSequence(arguments, out_result);
+  }
+}
+
+namespace
+{
+  /// \brief The flags of one slot, as the names a caller would recognise.
+  ///
+  /// Only the ones that change how a value should be chosen. The rest describe implementation details of
+  /// the hardware and would just be noise in every listing.
+  void WriteSlotFlags(ezMcpJsonWriter& ref_writer, ezBitflags<ezInputSlotFlags> flags)
+  {
+    ref_writer.BeginArray("flags");
+
+    if (flags.IsSet(ezInputSlotFlags::ValueBinaryZeroOrOne))
+      ref_writer.WriteString("binary");
+    if (flags.IsSet(ezInputSlotFlags::ValueRangeZeroToOne))
+      ref_writer.WriteString("analog");
+    if (flags.IsSet(ezInputSlotFlags::ReportsRelativeValues))
+      ref_writer.WriteString("relative");
+    if (flags.IsSet(ezInputSlotFlags::Pressable))
+      ref_writer.WriteString("pressable");
+    if (flags.IsSet(ezInputSlotFlags::Holdable))
+      ref_writer.WriteString("holdable");
+
+    ref_writer.EndArray();
+  }
+
+  /// \brief What the device is currently holding, shared between input_set's and input_sequence's result.
+  void WriteHeldSlots(ezMcpJsonWriter& ref_writer, const ezDynamicArray<ezMcpInputDevice::HeldSlot>& held)
+  {
+    ref_writer.BeginArray("holding");
+
+    for (const ezMcpInputDevice::HeldSlot& slot : held)
+    {
+      ref_writer.BeginObject();
+      ref_writer.AddVariableString("name", slot.m_sSlot);
+      ref_writer.AddVariableFloat("value", slot.m_fValue);
+
+      if (slot.m_uiFramesRemaining > 0)
+      {
+        ref_writer.AddVariableUInt32("framesRemaining", slot.m_uiFramesRemaining);
+      }
+
+      ref_writer.EndObject();
+    }
+
+    ref_writer.EndArray();
+  }
+} // namespace
+
+void ezMcpInputTool::ExecuteSlots(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sContains = ezMcpJson::GetString(arguments, "contains");
+  const bool bActiveOnly = ezMcpJson::GetBool(arguments, "activeOnly", false);
+
+  ezDynamicArray<ezStringView> slots;
+  ezInputManager::RetrieveAllKnownInputSlots(slots);
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.BeginArray("slots");
+
+  ezUInt32 uiMatches = 0;
+  ezUInt32 uiReturned = 0;
+
+  for (ezStringView sSlot : slots)
+  {
+    const ezStringView sDisplayName = ezInputManager::GetInputSlotDisplayName(sSlot);
+
+    if (!sContains.IsEmpty())
+    {
+      ezStringBuilder sName = sSlot;
+      ezStringBuilder sDisplay = sDisplayName;
+
+      if (sName.FindSubString_NoCase(sContains) == nullptr && sDisplay.FindSubString_NoCase(sContains) == nullptr)
+        continue;
+    }
+
+    float fValue = 0.0f;
+    ezInputManager::GetInputSlotState(sSlot, &fValue);
+
+    if (bActiveOnly && fValue == 0.0f)
+      continue;
+
+    ++uiMatches;
+
+    if (uiReturned >= s_uiMaxResults)
+      continue;
+
+    writer.BeginObject();
+    writer.AddVariableString("name", sSlot);
+
+    // The display name is what a human calls the key. It differs from the slot name often enough to be
+    // worth reporting - 'keyboard_left_ctrl' displays as 'Left Ctrl' - and it is also localised.
+    if (!sDisplayName.IsEmpty() && sDisplayName != sSlot)
+    {
+      writer.AddVariableString("displayName", sDisplayName);
+    }
+
+    writer.AddVariableFloat("value", fValue);
+    WriteSlotFlags(writer, ezInputManager::GetInputSlotFlags(sSlot));
+    writer.EndObject();
+
+    ++uiReturned;
+  }
+
+  writer.EndArray();
+
+  writer.AddVariableUInt32("returned", uiReturned);
+  writer.AddVariableUInt32("totalMatches", uiMatches);
+  writer.AddVariableBool("truncated", uiMatches > uiReturned);
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpInputTool::ExecuteSet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (m_pDevice == nullptr)
+  {
+    out_result.SetError("The synthetic input device does not exist, so no input can be written.");
+    return;
+  }
+
+  const bool bClearAll = ezMcpJson::GetBool(arguments, "clearAll", false);
+
+  if (bClearAll)
+  {
+    m_pDevice->ClearAllSlots();
+  }
+
+  const ezUInt32 uiFrames = static_cast<ezUInt32>(ezMath::Max<ezInt64>(0, ezMcpJson::GetInt(arguments, "frames", 0)));
+
+  const ezVariantDictionary* pSlots = ezMcpJson::GetDict(arguments, "slots");
+
+  if (pSlots == nullptr && !bClearAll)
+  {
+    out_result.SetError("Nothing to do: pass 'slots' with the values to write, or 'clearAll' to release everything.");
+    return;
+  }
+
+  ezUInt32 uiSet = 0;
+
+  if (pSlots != nullptr)
+  {
+    if (!ApplySlots(*pSlots, uiFrames, out_result))
+      return;
+
+    uiSet = pSlots->GetCount();
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableUInt32("slotsWritten", uiSet);
+
+  // What is being held afterwards, so that a caller never has to remember what it pressed. This is also
+  // the answer to 'did my earlier call already expire'.
+  ezDynamicArray<ezMcpInputDevice::HeldSlot> held;
+  m_pDevice->GetHeldSlots(held);
+  WriteHeldSlots(writer, held);
+
+  writer.AddVariableString("note",
+    "The game reads input once per frame. Call game_wait to let frames run before checking what happened.");
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}
+
+bool ezMcpInputTool::ApplySlots(const ezVariantDictionary& slots, ezUInt32 uiFrames, ezMcpToolResult& out_result)
+{
+  for (auto it = slots.GetIterator(); it.IsValid(); ++it)
+  {
+    // Any convertible type, because a client sends 1, 1.0 and "1" for the same thing.
+    ezResult conversion = EZ_SUCCESS;
+    const float fValue = it.Value().ConvertTo<float>(&conversion);
+
+    if (conversion.Failed())
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("The value for slot '{}' is not a number.", it.Key());
+      out_result.SetError(sError);
+      return false;
+    }
+
+    if (fValue == 0.0f)
+    {
+      m_pDevice->ClearSlot(it.Key());
+    }
+    else
+    {
+      m_pDevice->SetSlotValue(it.Key(), fValue, uiFrames);
+    }
+  }
+
+  return true;
+}
+
+void ezMcpInputTool::ExecuteSequence(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (m_pDevice == nullptr)
+  {
+    out_result.SetError("The synthetic input device does not exist, so no input can be written.");
+    return;
+  }
+
+  const ezVariantArray* pSteps = ezMcpJson::GetArray(arguments, "steps");
+
+  if (pSteps == nullptr || pSteps->IsEmpty())
+  {
+    out_result.SetError("'steps' must be a non-empty array of step objects.");
+    return;
+  }
+
+  if (pSteps->GetCount() > s_uiMaxSteps)
+  {
+    ezStringBuilder sError;
+    sError.SetFormat("'steps' has {} entries, which is more than the limit of {}.", pSteps->GetCount(), s_uiMaxSteps);
+    out_result.SetError(sError);
+    return;
+  }
+
+  const ezInt64 iTimeout = ezMcpJson::GetInt(arguments, "timeout", static_cast<ezInt64>(s_DefaultWaitTimeout.GetSeconds()));
+  const ezTime waitTimeout = iTimeout > 0 ? ezTime::MakeFromSeconds(static_cast<double>(iTimeout)) : s_DefaultWaitTimeout;
+
+  if (!m_bSequenceActive)
+  {
+    // First entry. Later ones are re-entries from a 'wait' step's deferral, with the same 'arguments'
+    // - see ezMcpToolResult::m_bNotFinished - so steps before m_uiSequenceStep must not run again.
+    m_bSequenceActive = true;
+    m_uiSequenceStep = 0;
+  }
+  else if (m_bSequenceWaiting)
+  {
+    const ezUInt64 uiNow = ezMcpEngineHost::GetFrameCount();
+    const bool bDone = uiNow >= m_uiSequenceWaitUntilFrame;
+    const bool bTimedOut = !bDone && (ezTime::Now() - m_SequenceWaitStarted >= m_SequenceWaitTimeout);
+
+    if (!bDone && !bTimedOut)
+    {
+      out_result.m_bNotFinished = true;
+      return;
+    }
+
+    m_bSequenceWaiting = false;
+
+    if (bTimedOut)
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("Sequence timed out on step {} (a 'wait') after {} seconds. The game is not producing "
+                       "frames fast enough, or not at all - see game_wait's error for the usual cause.",
+        m_uiSequenceStep, (ezTime::Now() - m_SequenceWaitStarted).GetSeconds());
+      out_result.SetError(sError);
+      m_bSequenceActive = false;
+      return;
+    }
+
+    // The 'wait' step that was in flight is now done; move on to whatever follows it.
+    ++m_uiSequenceStep;
+  }
+
+  for (; m_uiSequenceStep < pSteps->GetCount(); ++m_uiSequenceStep)
+  {
+    const ezVariant& step = (*pSteps)[m_uiSequenceStep];
+
+    if (!step.IsA<ezVariantDictionary>())
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("Step {} is not an object.", m_uiSequenceStep);
+      out_result.SetError(sError);
+      m_bSequenceActive = false;
+      return;
+    }
+
+    const ezVariantDictionary& stepDict = step.Get<ezVariantDictionary>();
+
+    if (const ezVariantDictionary* pSet = ezMcpJson::GetDict(stepDict, "set"))
+    {
+      if (!ApplySlots(*pSet, 0, out_result))
+      {
+        m_bSequenceActive = false;
+        return;
+      }
+    }
+    else if (ezMcpJson::GetBool(stepDict, "clear", false))
+    {
+      m_pDevice->ClearAllSlots();
+    }
+    else
+    {
+      const ezVariant* pText = nullptr;
+      const ezVariantDictionary* pWait = ezMcpJson::GetDict(stepDict, "wait");
+
+      if (pWait != nullptr)
+      {
+        const ezInt64 iFrames = ezMcpJson::GetInt(*pWait, "frames", 1);
+
+        if (iFrames < 1 || iFrames > s_uiMaxWaitFrames)
+        {
+          ezStringBuilder sError;
+          sError.SetFormat("Step {}: 'frames' must be between 1 and {}, not {}.", m_uiSequenceStep, s_uiMaxWaitFrames, iFrames);
+          out_result.SetError(sError);
+          m_bSequenceActive = false;
+          return;
+        }
+
+        m_uiSequenceWaitUntilFrame = ezMcpEngineHost::GetFrameCount() + static_cast<ezUInt64>(iFrames);
+        m_SequenceWaitStarted = ezTime::Now();
+        m_SequenceWaitTimeout = waitTimeout;
+        m_bSequenceWaiting = true;
+
+        out_result.m_bNotFinished = true;
+        return;
+      }
+      else if (stepDict.TryGetValue("text", pText) && pText->CanConvertTo<ezString>())
+      {
+        m_pDevice->QueueText(pText->ConvertTo<ezString>());
+      }
+      else
+      {
+        ezStringBuilder sError;
+        sError.SetFormat("Step {} is none of 'set', 'wait', 'text' or 'clear'.", m_uiSequenceStep);
+        out_result.SetError(sError);
+        m_bSequenceActive = false;
+        return;
+      }
+    }
+  }
+
+  m_bSequenceActive = false;
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+  writer.AddVariableUInt32("stepsRun", pSteps->GetCount());
+  writer.AddVariableUInt64("frameCount", ezMcpEngineHost::GetFrameCount());
+
+  ezDynamicArray<ezMcpInputDevice::HeldSlot> held;
+  m_pDevice->GetHeldSlots(held);
+  WriteHeldSlots(writer, held);
+
+  writer.EndObject();
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EnginePlugins/McpPlugin/Tools/McpInputTool.h
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpInputTool.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <McpPlugin/McpPluginDLL.h>
+
+#include <Foundation/Time/Time.h>
+#include <Foundation/Types/UniquePtr.h>
+#include <Foundation/Types/Variant.h>
+#include <Mcp/McpTool.h>
+
+class ezMcpInputDevice;
+
+/// \brief Pressing keys and moving the mouse, as the game sees it.
+///
+/// Owns the synthetic ezInputDevice that does the actual writing - see ezMcpInputDevice for why it is a
+/// device rather than injected values. The provider's lifetime is the plugin's, so the device exists for
+/// as long as there is a server to ask for input.
+///
+/// Deliberately shaped to grow: an agent driving a game will eventually want recorded sequences and
+/// timed scripts, and those are new tool names on this provider writing to the same device, not a
+/// different mechanism.
+class ezMcpInputTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpInputTool, ezMcpToolProvider);
+
+public:
+  ezMcpInputTool();
+  ~ezMcpInputTool();
+
+  virtual void OnActivate() override;
+  virtual void OnDeactivate() override;
+
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteSlots(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteSet(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteSequence(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// \brief Writes every slot in \a slots via m_pDevice, the same way ExecuteSet() does. Shared with
+  /// ExecuteSequence()'s 'set' steps. Returns false (and has already set out_result) on the first
+  /// value that is not a number.
+  bool ApplySlots(const ezVariantDictionary& slots, ezUInt32 uiFrames, ezMcpToolResult& out_result);
+
+  ezUniquePtr<ezMcpInputDevice> m_pDevice;
+
+  /// Same reason as everywhere else: a process registers hundreds of slots and an unfiltered dump of
+  /// them buries whatever the caller was looking for.
+  static constexpr ezUInt32 s_uiMaxResults = 200;
+
+  /// input_sequence cannot loop across a 'wait' step - like game_wait, it defers instead
+  /// (ezMcpToolResult::m_bNotFinished) and is re-entered once per frame until the wait is over. This is
+  /// what survives across those re-entries: which step is in flight, and until when.
+  bool m_bSequenceActive = false;
+  bool m_bSequenceWaiting = false;
+  ezUInt32 m_uiSequenceStep = 0;
+  ezUInt64 m_uiSequenceWaitUntilFrame = 0;
+  ezTime m_SequenceWaitStarted;
+  ezTime m_SequenceWaitTimeout;
+
+  /// A caller that asks for a sequence of a million steps has made a mistake that would otherwise look
+  /// exactly like a hang - same reasoning as game_wait's s_uiMaxFrames.
+  static constexpr ezUInt32 s_uiMaxSteps = 200;
+  static constexpr ezUInt32 s_uiMaxWaitFrames = 10000;
+  static constexpr ezTime s_DefaultWaitTimeout = ezTime::MakeFromSeconds(30);
+};

--- a/Code/EnginePlugins/McpPlugin/finalize.cmake
+++ b/Code/EnginePlugins/McpPlugin/finalize.cmake
@@ -1,0 +1,14 @@
+if (TARGET Player AND TARGET McpPlugin)
+
+    # The plugin is loaded at runtime through the plugin bundle, so nothing links against it and the
+    # build system would otherwise be free to skip it. ezPlayer without it has no MCP server at all.
+    add_dependencies(Player McpPlugin)
+
+endif()
+
+if (TARGET Editor AND TARGET McpPlugin)
+
+    # Same reason, for the engine process that the editor starts.
+    add_dependencies(Editor McpPlugin)
+
+endif()


### PR DESCRIPTION
Adds shared MCP server infrastructure and an editor plugin and an engine plugin which each open up an MCP server for their processes.

MCP servers are used by AI coding agents to connect to an application to ask questions or let them execute actions.

This is mainly useful for coding agents to be able to do things that require the editor's functionality, such as correctly importing assets, transforming assets or modifying them. Agents can already do quite a lot even without an MCP, since they are able to read the OpenDDL file formats, deduct a lot of information and even modify them. However, many details are out of reach still. Using an MCP closes this gap.

For example, it is now possible to tell an agent to import a texture and use that in a particle effect, instead of the previous one. It will then import the texture as the correct diffuse texture asset, open the particle effect, find where a texture was used, replace the reference, adjust properties (such as flipbook tiling) and save and transform the particle asset. It can do that both with a running editor by directly connecting to that, as well as with no editor running, in which case it will launch its own temporarily.

There are many more things that an agent can do, though usually a human is faster. But it can help detect issues or tell you how to achieve things much better now. This is not meant for AI driven scene or asset creation, but rather to let an agent be a side-kick that can help figuring out complicated problems.

It can even launch a game, send some input to it, to make the game do certain things (though this has quite some lag, so don't expect it to "play" a game) and then make a screenshot and check for results, such that it can now test new functionality much better.

The MCPs have access to a lot of engine internals:

* All RTTI information
* Access to all CVars
* Access to the logs
* Sending any input
* Knowledge about translations (button names etc)
* All editor actions (menu items, buttons)
* Asset import and health stats
* C++ plugin compilation
* Open, close, create, enumerate documents
* Iterate through a document's object hierarchy
* Create, delete objects and components
* Modify any property (with undo/redo)
* Create new projects
* See, modify object selection in a document

The agent can discover all this on its own through the MCP protocol. A custom Claude skill additionally helps with bootstrapping, since the agent needs to talk to the processes through raw HTTP, for which it would usually use curl.

In development builds, any custom game exe also automatically enables this, when the `-mcpport` command line option is given.