### PR TITLE
Fixed #1970: Show manual transform errors in Asset Curator

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1769,7 +1769,10 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
     pDoc = ezQtEditorApp::GetSingleton()->OpenDocument(pAssetInfo->m_Path.GetAbsolutePath(), ezDocumentFlags::None);
 
   if (pDoc == nullptr)
+  {
+    UpdateAssetTransformState(pAssetInfo->m_Info->m_DocumentID, ezAssetInfo::TransformState::TransformError);
     return ezTransformStatus(ezFmt("Could not open asset document '{0}'", pAssetInfo->m_Path.GetDataDirParentRelativePath()));
+  }
 
   EZ_SCOPE_EXIT(if (!pDoc->HasWindowBeenRequested() && !bWasOpen) pDoc->GetDocumentManager()->CloseDocument(pDoc););
 
@@ -1786,6 +1789,14 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
       {
         m_pAssetTableWriter->NeedsReloadResource(subAssetUuid);
       }
+    }
+    else if (ret.m_Result == ezTransformResult::NeedsImport)
+    {
+      UpdateAssetTransformState(pAssetInfo->m_Info->m_DocumentID, ezAssetInfo::TransformState::NeedsImport);
+    }
+    else
+    {
+      UpdateAssetTransformState(pAssetInfo->m_Info->m_DocumentID, ezAssetInfo::TransformState::TransformError);
     }
   }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1790,11 +1790,7 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
         m_pAssetTableWriter->NeedsReloadResource(subAssetUuid);
       }
     }
-    else if (ret.m_Result == ezTransformResult::NeedsImport)
-    {
-      UpdateAssetTransformState(pAssetInfo->m_Info->m_DocumentID, ezAssetInfo::TransformState::NeedsImport);
-    }
-    else
+    else if (ret.m_Result != ezTransformResult::NeedsImport)
     {
       UpdateAssetTransformState(pAssetInfo->m_Info->m_DocumentID, ezAssetInfo::TransformState::TransformError);
     }

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -3,7 +3,6 @@
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorTest/AssetDocument/AssetDocumentTest.h>
-#include <Foundation/IO/FileSystem/FileWriter.h>
 #include <Foundation/IO/OSFile.h>
 #include <TestFramework/Utilities/TestLogInterface.h>
 #include <ToolsFoundation/FileSystem/FileSystemModel.h>
@@ -168,15 +167,8 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Verify Failed Transform State")
   {
-    ezStringBuilder sInvalidMeshFile = m_sProjectPath;
-    sInvalidMeshFile.AppendPath("Meshes", "Invalid.obj");
-    ezFileWriter file;
-    EZ_TEST_BOOL(file.Open(sInvalidMeshFile) == EZ_SUCCESS);
-    file.WriteString("invalid mesh data").AssertSuccess();
-    file.Close();
-
     pAcc->StartTransaction("Set Invalid Mesh");
-    EZ_TEST_BOOL(pAcc->SetValueByName(pMeshAsset, "MeshFile", "Meshes/Invalid.obj").Succeeded());
+    EZ_TEST_BOOL(pAcc->SetValueByName(pMeshAsset, "MeshFile", "Meshes/Missing.obj").Succeeded());
     pAcc->FinishTransaction();
     EZ_TEST_BOOL(pDoc->SaveDocument().Succeeded());
 
@@ -188,8 +180,6 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
     {
       EZ_TEST_BOOL(subAsset->m_pAssetInfo->m_TransformState == ezAssetInfo::TransformState::TransformError);
     }
-
-    ezOSFile::DeleteFile(sInvalidMeshFile).IgnoreResult();
   }
   pDoc->GetDocumentManager()->CloseDocument(pDoc);
 }

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -183,11 +183,10 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
     const ezTransformStatus res = ezAssetCurator::GetSingleton()->TransformAsset(pDoc->GetGuid(), ezTransformFlags::ForceTransform | ezTransformFlags::TriggeredManually);
     EZ_TEST_BOOL(res.Failed());
 
-    ezAssetInfo* pAssetInfo = ezAssetCurator::GetSingleton()->GetAssetInfo(pDoc->GetGuid());
-    EZ_TEST_BOOL(pAssetInfo != nullptr);
-    if (pAssetInfo != nullptr)
+    const ezAssetCurator::ezLockedSubAsset subAsset = ezAssetCurator::GetSingleton()->GetSubAsset(pDoc->GetGuid());
+    if (EZ_TEST_BOOL(subAsset))
     {
-      EZ_TEST_BOOL(pAssetInfo->m_TransformState == ezAssetInfo::TransformState::TransformError);
+      EZ_TEST_BOOL(subAsset->m_pAssetInfo->m_TransformState == ezAssetInfo::TransformState::TransformError);
     }
 
     ezOSFile::DeleteFile(sInvalidMeshFile).IgnoreResult();

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -3,6 +3,7 @@
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorTest/AssetDocument/AssetDocumentTest.h>
+#include <Foundation/IO/FileSystem/FileWriter.h>
 #include <Foundation/IO/OSFile.h>
 #include <TestFramework/Utilities/TestLogInterface.h>
 #include <ToolsFoundation/FileSystem/FileSystemModel.h>
@@ -163,6 +164,33 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
 
     ezString sLabel = pAcc->GetByName<ezString>(pSubObject, "Label");
     EZ_TEST_STRING(sLabel, "initialShadingGroup");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Verify Failed Transform State")
+  {
+    ezStringBuilder sInvalidMeshFile = m_sProjectPath;
+    sInvalidMeshFile.AppendPath("Meshes", "Invalid.obj");
+    ezFileWriter file;
+    EZ_TEST_BOOL(file.Open(sInvalidMeshFile) == EZ_SUCCESS);
+    file.WriteString("invalid mesh data").AssertSuccess();
+    file.Close();
+
+    pAcc->StartTransaction("Set Invalid Mesh");
+    EZ_TEST_BOOL(pAcc->SetValueByName(pMeshAsset, "MeshFile", "Meshes/Invalid.obj").Succeeded());
+    pAcc->FinishTransaction();
+    EZ_TEST_BOOL(pDoc->SaveDocument().Succeeded());
+
+    const ezTransformStatus res = ezAssetCurator::GetSingleton()->TransformAsset(pDoc->GetGuid(), ezTransformFlags::ForceTransform | ezTransformFlags::TriggeredManually);
+    EZ_TEST_BOOL(res.Failed());
+
+    ezAssetInfo* pAssetInfo = ezAssetCurator::GetSingleton()->GetAssetInfo(pDoc->GetGuid());
+    EZ_TEST_BOOL(pAssetInfo != nullptr);
+    if (pAssetInfo != nullptr)
+    {
+      EZ_TEST_BOOL(pAssetInfo->m_TransformState == ezAssetInfo::TransformState::TransformError);
+    }
+
+    ezOSFile::DeleteFile(sInvalidMeshFile).IgnoreResult();
   }
   pDoc->GetDocumentManager()->CloseDocument(pDoc);
 }


### PR DESCRIPTION
## Why

A manual transform that cannot open its asset document, or fails while transforming it, only writes an error to the log. Its transform state stays unchanged, so the Asset Curator filter does not list the broken asset.

## Changes

- record `TransformError` for a failed manual transform
- use the sub-asset's asset info when reporting the error
- extend `Asset Document Tests / Save on Transform` with the invalid OBJ case and assert the two expected path errors

## Verification

- `git diff --check`: pass
- the Windows editor test remains the runtime check for this patch

Fixes #1970
