### PR TITLE
Cleanup Visual Graph Node Title Rendering

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.cpp
@@ -1,113 +1,37 @@
 #include <EditorPluginAssets/EditorPluginAssetsPCH.h>
 
-#include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.h>
+#include <Foundation/CodeUtils/TokenParseUtils.h>
 
 ezQtAnimationGraphNode::ezQtAnimationGraphNode() = default;
 
 void ezQtAnimationGraphNode::UpdateState()
 {
-  ezQtVisualGraphNode::UpdateState();
+  TitleFormat format;
+  format.m_uiMaxStringLength = 0;
+  format.m_uiMaxTitleLength = 30;
+  format.m_bQuoteStrings = false;
+  format.m_bIgnoreInvalidProperties = true;
+
+  ezStringBuilder sTemplate;
+  if (!TryGetTitleTemplateFromProperty("CustomTitle", sTemplate) && !TryGetTitleTemplateFromAttribute(sTemplate))
+  {
+    GetDefaultTitleTemplate(sTemplate);
+  }
 
   ezStringBuilder sTitle;
+  ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
+    sTitle);
 
-  const ezRTTI* pRtti = GetObject()->GetType();
-
-  ezVariant customTitle = GetObject()->GetTypeAccessor().GetValue("CustomTitle");
-  if (customTitle.IsValid() && customTitle.CanConvertTo<ezString>())
-  {
-    sTitle = customTitle.ConvertTo<ezString>();
-  }
-
-  if (sTitle.IsEmpty())
-  {
-    if (const ezTitleAttribute* pAttr = pRtti->GetAttributeByType<ezTitleAttribute>())
-    {
-      sTitle = pAttr->GetTitle();
-
-      ezStringBuilder tmp, tmp2;
-      ezVariant val;
-
-      // replace enum properties with translated strings
-      {
-        ezTempHybridArray<const ezAbstractProperty*, 32> properties;
-        pRtti->GetAllProperties(properties);
-
-        for (const auto& prop : properties)
-        {
-          if (prop->GetSpecificType()->IsDerivedFrom<ezEnumBase>() || prop->GetSpecificType()->IsDerivedFrom<ezBitflagsBase>())
-          {
-            val = GetObject()->GetTypeAccessor().GetValue(prop->GetPropertyName());
-
-            ezReflectionUtils::EnumerationToString(prop->GetSpecificType(), val.ConvertTo<ezInt64>(), tmp);
-
-            tmp2.Set("{", prop->GetPropertyName(), "}");
-            sTitle.ReplaceAll(tmp2, ezTranslate(tmp));
-          }
-        }
-      }
-
-      // replace the rest
-      while (true)
-      {
-        const char* szOpen = sTitle.FindSubString("{");
-
-        if (szOpen == nullptr)
-          break;
-
-        const char* szClose = sTitle.FindSubString("}", szOpen);
-
-        if (szClose == nullptr)
-          break;
-
-        tmp.SetSubString_FromTo(szOpen + 1, szClose);
-
-        // three array indices should be enough for everyone
-        if (tmp.TrimWordEnd("[0]"))
-          val = GetObject()->GetTypeAccessor().GetValue(tmp, 0);
-        else if (tmp.TrimWordEnd("[1]"))
-          val = GetObject()->GetTypeAccessor().GetValue(tmp, 1);
-        else if (tmp.TrimWordEnd("[2]"))
-          val = GetObject()->GetTypeAccessor().GetValue(tmp, 2);
-        else
-          val = GetObject()->GetTypeAccessor().GetValue(tmp);
-
-        if (val.IsValid())
-        {
-
-          tmp.SetFormat("{}", val);
-
-          if (ezConversionUtils::IsStringUuid(tmp))
-          {
-            if (auto pAsset = ezAssetCurator::GetSingleton()->FindSubAsset(tmp))
-            {
-              tmp = pAsset->GetName();
-            }
-          }
-
-          sTitle.ReplaceSubString(szOpen, szClose + 1, tmp);
-        }
-        else
-        {
-          sTitle.ReplaceSubString(szOpen, szClose + 1, "");
-        }
-      }
-    }
-  }
-
+  // placeholders that resolved to nothing leave empty quotes and duplicate spaces behind
   sTitle.ReplaceAll("''", "");
   sTitle.ReplaceAll("\"\"", "");
   sTitle.ReplaceAll("  ", " ");
   sTitle.Trim(" ");
 
-  if (sTitle.GetCharacterCount() > 30)
-  {
-    sTitle.Shrink(0, sTitle.GetCharacterCount() - 31);
-    sTitle.Append("...");
-  }
+  if (sTitle.IsEmpty())
+    return;
 
-  if (!sTitle.IsEmpty())
-  {
-    m_pTitleLabel->setPlainText(sTitle.GetData());
-  }
+  SetTitleAndSubtitle(sTitle, format);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.cpp
@@ -21,8 +21,7 @@ void ezQtAnimationGraphNode::UpdateState()
 
   ezStringBuilder sTitle;
   ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
-    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
-    sTitle);
+    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); }, sTitle);
 
   // placeholders that resolved to nothing leave empty quotes and duplicate spaces behind
   sTitle.ReplaceAll("''", "");

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderScene.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderScene.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorPluginAssets/VisualShader/VisualShaderNodeManager.h>
 #include <EditorPluginAssets/VisualShader/VisualShaderScene.moc.h>
+#include <Foundation/CodeUtils/TokenParseUtils.h>
 
 
 ezQtVisualShaderScene::ezQtVisualShaderScene(QObject* pParent)
@@ -103,201 +104,101 @@ void ezQtVisualShaderNode::InitNode(const ezVisualGraphObjectManager* pManager, 
 
 void ezQtVisualShaderNode::UpdateState()
 {
-  ezStringBuilder sTitle = GetObject()->GetTypeAccessor().GetType()->GetTypeName();
-  if (sTitle.StartsWith_NoCase("ShaderNode::"))
-    sTitle.Shrink(12, 0);
+  TitleFormat format;
+  format.m_uiMaxStringLength = 0;
+  format.m_bQuoteStrings = false;
+  format.m_bSplitAtDoubleColon = false;
 
   auto pDesc = ezVisualShaderTypeRegistry::GetSingleton()->GetDescriptorForType(GetObject()->GetType());
+
+  ezStringBuilder sTemplate;
   if (pDesc != nullptr && !pDesc->m_sTitle.IsEmpty())
   {
-    // Use the configured title and replace placeholders
-    sTitle = pDesc->m_sTitle;
-
-    // Replace input pin placeholders (e.g., {$in0}, {$in1})
-    ezStringBuilder temp;
-    ezStringBuilder sVal;
-    ezVariant val;
-    const auto& inputPins = GetInputPins();
-
-    for (ezUInt32 i = 0; i < pDesc->m_InputPins.GetCount(); ++i)
+    sTemplate = pDesc->m_sTitle;
+  }
+  else
+  {
+    sTemplate = GetObject()->GetType()->GetTypeName();
+    if (sTemplate.StartsWith_NoCase("ShaderNode::"))
     {
-      const ezVisualShaderPinDescriptor& pinDesc = pDesc->m_InputPins[i];
-
-      // Build placeholder string: {$in0}, {$in1}, etc.
-      temp.SetFormat("$in{}", i);
-      temp.Prepend("{");
-      temp.Append("}");
-
-      if (i < inputPins.GetCount() && inputPins[i]->HasAnyConnections())
-      {
-        // Pin is connected, show pin name
-        sTitle.ReplaceAll(temp, pinDesc.m_sName);
-      }
-      else if (pinDesc.m_bExposeAsProperty)
-      {
-        // Pin is exposed as a property, get the actual property value
-        ezVariant val = GetObject()->GetTypeAccessor().GetValue(pinDesc.m_PropertyDesc.m_sName);
-
-        if (val.IsA<ezColor>())
-        {
-          ezColor color = val.Get<ezColor>();
-          sVal = ezConversionUtils::GetColorName(color);
-        }
-        else if (val.IsA<ezColorGammaUB>())
-        {
-          ezColorGammaUB colorGamma = val.Get<ezColorGammaUB>();
-          ezColor color = colorGamma;
-          sVal = ezConversionUtils::GetColorName(color);
-        }
-        else if (val.IsA<ezVec2>())
-        {
-          ezVec2 v = val.Get<ezVec2>();
-          sVal.SetFormat("({}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2));
-        }
-        else if (val.IsA<ezVec3>())
-        {
-          ezVec3 v = val.Get<ezVec3>();
-          sVal.SetFormat("({}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2));
-        }
-        else if (val.IsA<ezVec4>())
-        {
-          ezVec4 v = val.Get<ezVec4>();
-          sVal.SetFormat("({}, {}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2), ezArgF(v.w, 2));
-        }
-        else if (val.CanConvertTo<ezString>())
-        {
-          sVal = val.ConvertTo<ezString>();
-        }
-        else
-        {
-          sVal = pinDesc.m_sDefaultValue;
-        }
-
-        sTitle.ReplaceAll(temp, sVal);
-      }
-      else if (!pinDesc.m_sDefaultValue.IsEmpty())
-      {
-        // Pin is not connected and not exposed, use default value
-        sTitle.ReplaceAll(temp, pinDesc.m_sDefaultValue);
-      }
-      else
-      {
-        // No default value, show pin name
-        sTitle.ReplaceAll(temp, pinDesc.m_sName);
-      }
-    }
-
-    // Replace property index placeholders (e.g., {$prop0}, {$prop1})
-    for (ezUInt32 i = 0; i < pDesc->m_Properties.GetCount(); ++i)
-    {
-      const ezReflectedPropertyDescriptor& propDesc = pDesc->m_Properties[i];
-
-      // Build placeholder string: {$prop0}, {$prop1}, etc.
-      temp.SetFormat("$prop{}", i);
-      temp.Prepend("{");
-      temp.Append("}");
-
-      val = GetObject()->GetTypeAccessor().GetValue(propDesc.m_sName);
-
-      // Get the actual property to check its type
-      const ezAbstractProperty* pProp = GetObject()->GetType()->FindPropertyByName(propDesc.m_sName);
-      if (pProp != nullptr && (pProp->GetSpecificType()->IsDerivedFrom<ezEnumBase>() || pProp->GetSpecificType()->IsDerivedFrom<ezBitflagsBase>()))
-      {
-        ezReflectionUtils::EnumerationToString(pProp->GetSpecificType(), val.ConvertTo<ezInt64>(), sVal);
-      }
-      else if (val.IsA<ezColor>())
-      {
-        ezColor color = val.Get<ezColor>();
-        sVal = ezConversionUtils::GetColorName(color);
-      }
-      else if (val.IsA<ezColorGammaUB>())
-      {
-        ezColorGammaUB colorGamma = val.Get<ezColorGammaUB>();
-        ezColor color = colorGamma;
-        sVal = ezConversionUtils::GetColorName(color);
-      }
-      else if (val.IsA<ezVec2>())
-      {
-        ezVec2 v = val.Get<ezVec2>();
-        sVal.SetFormat("({}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2));
-      }
-      else if (val.IsA<ezVec3>())
-      {
-        ezVec3 v = val.Get<ezVec3>();
-        sVal.SetFormat("({}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2));
-      }
-      else if (val.IsA<ezVec4>())
-      {
-        ezVec4 v = val.Get<ezVec4>();
-        sVal.SetFormat("({}, {}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2), ezArgF(v.w, 2));
-      }
-      else if (val.CanConvertTo<ezString>())
-      {
-        sVal = val.ConvertTo<ezString>();
-      }
-      else
-      {
-        sVal = "<Invalid>";
-      }
-
-      sTitle.ReplaceAll(temp, sVal);
-    }
-
-    // Replace property name placeholders (e.g., {PropertyName} or {$PropertyName})
-    ezTempHybridArray<const ezAbstractProperty*, 32> properties;
-    GetObject()->GetType()->GetAllProperties(properties);
-
-    for (const auto& prop : properties)
-    {
-      val = GetObject()->GetTypeAccessor().GetValue(prop->GetPropertyName());
-
-      if (prop->GetSpecificType()->IsDerivedFrom<ezEnumBase>() || prop->GetSpecificType()->IsDerivedFrom<ezBitflagsBase>())
-      {
-        ezReflectionUtils::EnumerationToString(prop->GetSpecificType(), val.ConvertTo<ezInt64>(), sVal);
-      }
-      else if (val.IsA<ezColor>())
-      {
-        ezColor color = val.Get<ezColor>();
-        sVal = ezConversionUtils::GetColorName(color);
-      }
-      else if (val.IsA<ezColorGammaUB>())
-      {
-        ezColorGammaUB colorGamma = val.Get<ezColorGammaUB>();
-        ezColor color = colorGamma;
-        sVal = ezConversionUtils::GetColorName(color);
-      }
-      else if (val.IsA<ezVec2>())
-      {
-        ezVec2 v = val.Get<ezVec2>();
-        sVal.SetFormat("({}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2));
-      }
-      else if (val.IsA<ezVec3>())
-      {
-        ezVec3 v = val.Get<ezVec3>();
-        sVal.SetFormat("({}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2));
-      }
-      else if (val.IsA<ezVec4>())
-      {
-        ezVec4 v = val.Get<ezVec4>();
-        sVal.SetFormat("({}, {}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2), ezArgF(v.w, 2));
-      }
-      else if (val.CanConvertTo<ezString>())
-      {
-        sVal = val.ConvertTo<ezString>();
-      }
-      else
-      {
-        sVal = "<Invalid>";
-      }
-
-      // Replace both {PropertyName} and {$PropertyName} patterns
-      temp.Set("{", prop->GetPropertyName(), "}");
-      sTitle.ReplaceAll(temp, sVal);
-
-      temp.Set("{$", prop->GetPropertyName(), "}");
-      sTitle.ReplaceAll(temp, sVal);
+      sTemplate.Shrink(12, 0);
     }
   }
 
-  m_pTitleLabel->setPlainText(sTitle.GetData());
+  ezStringBuilder sTitle;
+  ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
+    sTitle);
+
+  SetTitleAndSubtitle(sTitle, format);
+}
+
+void ezQtVisualShaderNode::ResolvePlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput)
+{
+  auto pDesc = ezVisualShaderTypeRegistry::GetSingleton()->GetDescriptorForType(GetObject()->GetType());
+
+  if (pDesc != nullptr)
+  {
+    // the titles refer to pins and properties by position, e.g. {$in0} and {$prop0}
+    ezUInt32 uiSlot = 0;
+
+    if (TryParseSlotPlaceholder(sPlaceholder, "in"_ezsv, pDesc->m_InputPins.GetCount(), uiSlot))
+    {
+      AppendInputPinValue(pDesc->m_InputPins[uiSlot], uiSlot, format, ref_sOutput);
+      return;
+    }
+
+    if (TryParseSlotPlaceholder(sPlaceholder, "prop"_ezsv, pDesc->m_Properties.GetCount(), uiSlot))
+    {
+      ResolvePropertyPlaceholder(pDesc->m_Properties[uiSlot].m_sName, index, bOptional, format, ref_sOutput);
+      return;
+    }
+  }
+
+  ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput);
+}
+
+bool ezQtVisualShaderNode::TryParseSlotPlaceholder(ezStringView sPlaceholder, ezStringView sPrefix, ezUInt32 uiSlotCount, ezUInt32& out_uiSlot)
+{
+  if (!sPlaceholder.StartsWith(sPrefix))
+    return false;
+
+  sPlaceholder.Shrink(sPrefix.GetElementCount(), 0);
+
+  ezInt32 iSlot = 0;
+  if (ezConversionUtils::StringToInt(sPlaceholder, iSlot).Failed() || iSlot < 0 || static_cast<ezUInt32>(iSlot) >= uiSlotCount)
+    return false;
+
+  out_uiSlot = static_cast<ezUInt32>(iSlot);
+  return true;
+}
+
+void ezQtVisualShaderNode::AppendInputPinValue(const ezVisualShaderPinDescriptor& pinDesc, ezUInt32 uiPin, const TitleFormat& format, ezStringBuilder& ref_sOutput)
+{
+  const auto& inputPins = GetInputPins();
+
+  if (uiPin < inputPins.GetCount() && inputPins[uiPin]->HasAnyConnections())
+  {
+    ref_sOutput.Append(pinDesc.m_sName.GetView());
+    return;
+  }
+
+  if (pinDesc.m_bExposeAsProperty)
+  {
+    const ezAbstractProperty* pProp = GetObject()->GetType()->FindPropertyByName(pinDesc.m_PropertyDesc.m_sName);
+    const ezVariant value = GetObject()->GetTypeAccessor().GetValue(pinDesc.m_PropertyDesc.m_sName);
+
+    if (pProp != nullptr && value.IsValid() && value.CanConvertTo<ezString>())
+    {
+      AppendPropertyValue(pProp, {}, false, format, ref_sOutput);
+    }
+    else
+    {
+      ref_sOutput.Append(pinDesc.m_sDefaultValue.GetView());
+    }
+
+    return;
+  }
+
+  ref_sOutput.Append(pinDesc.m_sDefaultValue.IsEmpty() ? pinDesc.m_sName.GetView() : pinDesc.m_sDefaultValue.GetView());
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderScene.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderScene.cpp
@@ -127,8 +127,7 @@ void ezQtVisualShaderNode::UpdateState()
 
   ezStringBuilder sTitle;
   ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
-    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
-    sTitle);
+    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); }, sTitle);
 
   SetTitleAndSubtitle(sTitle, format);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderScene.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderScene.moc.h
@@ -7,6 +7,7 @@
 #include <GuiFoundation/VisualGraph/Scene.moc.h>
 
 class ezQtVisualGraphView;
+struct ezVisualShaderPinDescriptor;
 
 /// Qt scene for visual shader asset editing.
 ///
@@ -43,4 +44,9 @@ public:
   virtual void InitNode(const ezVisualGraphObjectManager* pManager, const ezDocumentObject* pObject) override;
 
   virtual void UpdateState() override;
+
+private:
+  static bool TryParseSlotPlaceholder(ezStringView sPlaceholder, ezStringView sPrefix, ezUInt32 uiSlotCount, ezUInt32& out_uiSlot);
+  void ResolvePlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput);
+  void AppendInputPinValue(const ezVisualShaderPinDescriptor& pinDesc, ezUInt32 uiPin, const TitleFormat& format, ezStringBuilder& ref_sOutput);
 };

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
@@ -61,8 +61,7 @@ void ezQtProcGenNode::UpdateState()
 
   ezStringBuilder sTitle;
   ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
-    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
-    sTitle);
+    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); }, sTitle);
 
   SetTitleAndSubtitle(sTitle, format);
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h>
 #include <EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.h>
+#include <Foundation/CodeUtils/TokenParseUtils.h>
 
 
 #include <QMenu>
@@ -41,98 +42,62 @@ void ezQtProcGenNode::InitNode(const ezVisualGraphObjectManager* pManager, const
 
 void ezQtProcGenNode::UpdateState()
 {
+  TitleFormat format;
+  format.m_uiMaxStringLength = 0;
+  format.m_bQuoteStrings = false;
+  format.m_bSplitAtDoubleColon = false;
+  format.m_bBoolsAsTicks = true;
+
+  ezStringBuilder sTemplate;
+  if (!TryGetTitleTemplateFromAttribute(sTemplate))
+  {
+    sTemplate = GetObject()->GetType()->GetTypeName();
+    if (sTemplate.StartsWith_NoCase("ezProcGen"))
+    {
+      sTemplate.Shrink(9, 0);
+    }
+    sTemplate.TrimLeft("_");
+  }
+
   ezStringBuilder sTitle;
+  ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
+    sTitle);
 
-  const ezRTTI* pRtti = GetObject()->GetType();
-  auto& typeAccessor = GetObject()->GetTypeAccessor();
+  SetTitleAndSubtitle(sTitle, format);
 
-  if (const ezTitleAttribute* pAttr = pRtti->GetAttributeByType<ezTitleAttribute>())
+  ezVariant active = GetObject()->GetTypeAccessor().GetValue("Active");
+  if (active.IsA<bool>())
   {
-    ezStringBuilder temp;
-    ezStringBuilder temp2;
-
-    ezTempHybridArray<const ezAbstractProperty*, 32> properties;
-    pRtti->GetAllProperties(properties);
-
-    sTitle = pAttr->GetTitle();
-
-    for (const auto& pin : GetInputPins())
-    {
-      temp.Set("{", pin->GetPin()->GetName(), "}");
-
-      if (pin->HasAnyConnections())
-      {
-        sTitle.ReplaceAll(temp, pin->GetPin()->GetName());
-      }
-      else
-      {
-        temp2.Set("{Input", pin->GetPin()->GetName(), "}");
-        sTitle.ReplaceAll(temp, temp2);
-      }
-    }
-
-    ezVariant val;
-    ezStringBuilder sVal;
-    ezStringBuilder sEnumVal;
-
-    for (const auto& prop : properties)
-    {
-      if (prop->GetCategory() == ezPropertyCategory::Set)
-      {
-        sVal = "{";
-
-        ezTempHybridArray<ezVariant, 16> values;
-        typeAccessor.GetValues(prop->GetPropertyName(), values);
-        for (auto& setVal : values)
-        {
-          if (sVal.GetElementCount() > 1)
-          {
-            sVal.Append(", ");
-          }
-          sVal.Append(setVal.ConvertTo<ezString>().GetView());
-        }
-
-        sVal.Append("}");
-      }
-      else
-      {
-        val = typeAccessor.GetValue(prop->GetPropertyName());
-
-        if (prop->GetSpecificType()->IsDerivedFrom<ezEnumBase>() || prop->GetSpecificType()->IsDerivedFrom<ezBitflagsBase>())
-        {
-          ezReflectionUtils::EnumerationToString(prop->GetSpecificType(), val.ConvertTo<ezInt64>(), sEnumVal);
-          sVal = ezTranslate(sEnumVal);
-        }
-        else if (prop->GetSpecificType() == ezGetStaticRTTI<bool>())
-        {
-          sVal = val.Get<bool>() ? "[x]" : "[ ]";
-
-          if (ezStringUtils::IsEqual(prop->GetPropertyName(), "Active"))
-          {
-            SetActive(val.Get<bool>());
-          }
-        }
-        else if (val.CanConvertTo<ezString>())
-        {
-          sVal = val.ConvertTo<ezString>();
-        }
-      }
-
-      temp.Set("{", prop->GetPropertyName(), "}");
-      sTitle.ReplaceAll(temp, sVal);
-    }
+    SetActive(active.Get<bool>());
   }
-  else
+}
+
+void ezQtProcGenNode::ResolvePlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput)
+{
+  for (const auto& pin : GetInputPins())
   {
-    sTitle = pRtti->GetTypeName();
-    if (sTitle.StartsWith_NoCase("ezProcGen"))
+    if (pin->GetPin()->GetName() != sPlaceholder)
+      continue;
+
+    if (pin->HasAnyConnections())
     {
-      sTitle.Shrink(9, 0);
+      if (!bOptional)
+      {
+        ref_sOutput.Append(sPlaceholder);
+      }
     }
-    sTitle.TrimLeft("_");
+    else
+    {
+      // an unconnected pin falls back to the constant stored in the matching 'Input<PinName>' property
+      ezStringBuilder sInputProperty("Input", sPlaceholder);
+      ResolvePropertyPlaceholder(sInputProperty, index, bOptional, format, ref_sOutput);
+    }
+
+    return;
   }
 
-  m_pTitleLabel->setPlainText(sTitle.GetData());
+  ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.h
@@ -15,6 +15,9 @@ public:
   virtual void InitNode(const ezVisualGraphObjectManager* pManager, const ezDocumentObject* pObject) override;
 
   virtual void UpdateState() override;
+
+private:
+  void ResolvePlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput);
 };
 
 /// Qt graphics item for procedural generation pins.

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
@@ -1,9 +1,9 @@
 #include <EditorPluginAssets/EditorPluginAssetsPCH.h>
 
-#include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraph.h>
 #include <EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.moc.h>
 #include <EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.h>
+#include <Foundation/CodeUtils/TokenParseUtils.h>
 
 // clang-format off
 EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorPluginVisualScript, Factories)
@@ -112,125 +112,30 @@ ezQtVisualScriptNode::ezQtVisualScriptNode() = default;
 
 void ezQtVisualScriptNode::UpdateState()
 {
+  const TitleFormat format;
+
+  ezStringBuilder sTemplate;
+  if (!TryGetTitleTemplateFromAttribute(sTemplate))
+  {
+    sTemplate = ezVisualScriptNodeManager::GetNiceTypeName(GetObject());
+  }
+
   ezStringBuilder sTitle;
+  ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
+    sTitle);
+
+  SetTitleAndSubtitle(sTitle, format);
 
   auto pManager = static_cast<const ezVisualScriptNodeManager*>(GetObject()->GetDocumentObjectManager());
-  auto pType = GetObject()->GetType();
 
-  if (auto pTitleAttribute = pType->GetAttributeByType<ezTitleAttribute>())
+  if (m_pSubtitleLabel->toPlainText().isEmpty())
   {
-    sTitle = pTitleAttribute->GetTitle();
-
-    ezTempHybridArray<const ezAbstractProperty*, 32> properties;
-    GetObject()->GetType()->GetAllProperties(properties);
-
-    ezStringBuilder temp;
-    for (const auto& pin : GetInputPins())
-    {
-      if (pin->HasAnyConnections())
-      {
-        temp.Set("{", pin->GetPin()->GetName(), "}");
-        if (static_cast<const ezVisualScriptPin*>(pin->GetPin())->GetScriptDataType() == ezVisualScriptDataType::String)
-        {
-          sTitle.ReplaceAll(temp, "");
-        }
-        else
-        {
-          sTitle.ReplaceAll(temp, pin->GetPin()->GetName());
-        }
-
-        temp.Set("{?", pin->GetPin()->GetName(), "}");
-        sTitle.ReplaceAll(temp, "");
-      }
-    }
-
-    ezVariant val;
-    ezStringBuilder sVal;
-    for (const auto& prop : properties)
-    {
-      val = GetObject()->GetTypeAccessor().GetValue(prop->GetPropertyName());
-
-      if (prop->GetSpecificType()->IsDerivedFrom<ezEnumBase>() || prop->GetSpecificType()->IsDerivedFrom<ezBitflagsBase>())
-      {
-        ezReflectionUtils::EnumerationToString(prop->GetSpecificType(), val.ConvertTo<ezInt64>(), sVal);
-        sVal = ezTranslate(sVal);
-      }
-      else if (val.IsA<ezString>() || val.IsA<ezHashedString>())
-      {
-        sVal = val.ConvertTo<ezString>();
-
-        if (prop->GetAttributeByType<ezAssetBrowserAttribute>())
-        {
-          if (ezConversionUtils::IsStringUuid(sVal))
-          {
-            const ezUuid AssetGuid = ezConversionUtils::ConvertStringToUuid(sVal);
-
-            auto pAsset = ezAssetCurator::GetSingleton()->GetSubAsset(AssetGuid);
-
-            if (pAsset)
-              sVal = pAsset->m_pAssetInfo->m_Path.GetDataDirRelativePath().GetFileName();
-            else
-              sVal = "<unknown>";
-          }
-        }
-
-        sVal.ReplaceAll("\n", " ");
-        sVal.ReplaceAll("\t", " ");
-
-        if (sVal.GetCharacterCount() > 23)
-        {
-          sVal.Shrink(0, sVal.GetCharacterCount() - 21);
-          sVal.Append("...");
-        }
-        sVal.Prepend("\"");
-        sVal.Append("\"");
-      }
-      else if (val.CanConvertTo<ezString>())
-      {
-        sVal = val.ConvertTo<ezString>();
-      }
-      else
-      {
-        sVal = "<Invalid>";
-      }
-
-      temp.Set("{", prop->GetPropertyName(), "}");
-      sTitle.ReplaceAll(temp, sVal);
-
-      temp.Set("{?", prop->GetPropertyName(), "}");
-      if (val == ezVariant(0))
-      {
-        sTitle.ReplaceAll(temp, "");
-      }
-      else
-      {
-        sTitle.ReplaceAll(temp, sVal);
-      }
-    }
-  }
-  else
-  {
-    sTitle = ezVisualScriptNodeManager::GetNiceTypeName(GetObject());
-  }
-
-  if (const char* szSeparator = sTitle.FindSubString("::"))
-  {
-    m_pTitleLabel->setPlainText(szSeparator + 2);
-
-    ezStringBuilder sSubTitle = ezStringView(sTitle.GetData(), szSeparator);
-    sSubTitle.Trim("\"");
-    m_pSubtitleLabel->setPlainText(sSubTitle.GetData());
-  }
-  else
-  {
-    m_pTitleLabel->setPlainText(sTitle.GetData());
-
-    auto pNodeDesc = ezVisualScriptNodeRegistry::GetSingleton()->GetNodeDescForType(pType);
+    auto pNodeDesc = ezVisualScriptNodeRegistry::GetSingleton()->GetNodeDescForType(GetObject()->GetType());
     if (pNodeDesc != nullptr && pNodeDesc->NeedsTypeDeduction())
     {
       ezVisualScriptDataType::Enum deductedType = pManager->GetDeductedType(GetObject());
-      const char* sSubTitle = deductedType != ezVisualScriptDataType::Invalid ? ezVisualScriptDataType::GetName(deductedType) : "Unknown";
-      m_pSubtitleLabel->setPlainText(sSubTitle);
+      m_pSubtitleLabel->setPlainText(deductedType != ezVisualScriptDataType::Invalid ? ezVisualScriptDataType::GetName(deductedType) : "Unknown");
     }
   }
 
@@ -250,6 +155,25 @@ void ezQtVisualScriptNode::UpdateState()
   {
     m_pIcon->setPixmap(QPixmap());
   }
+}
+
+void ezQtVisualScriptNode::ResolvePlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput)
+{
+  for (const auto& pin : GetInputPins())
+  {
+    if (pin->GetPin()->GetName() != sPlaceholder || !pin->HasAnyConnections())
+      continue;
+
+    // the value of a connected string pin is unknown here, so nothing is shown for it
+    if (!bOptional && static_cast<const ezVisualScriptPin*>(pin->GetPin())->GetScriptDataType() != ezVisualScriptDataType::String)
+    {
+      ref_sOutput.Append(sPlaceholder);
+    }
+
+    return;
+  }
+
+  ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
@@ -122,8 +122,7 @@ void ezQtVisualScriptNode::UpdateState()
 
   ezStringBuilder sTitle;
   ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
-    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
-    sTitle);
+    { ResolvePlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); }, sTitle);
 
   SetTitleAndSubtitle(sTitle, format);
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.moc.h
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.moc.h
@@ -41,6 +41,9 @@ public:
   ezQtVisualScriptNode();
 
   virtual void UpdateState() override;
+
+private:
+  void ResolvePlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput);
 };
 
 /// Qt scene for visual script graphs.

--- a/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
@@ -2,6 +2,8 @@
 
 #include <Foundation/CodeUtils/TokenParseUtils.h>
 #include <Foundation/CodeUtils/Tokenizer.h>
+#include <Foundation/Types/Variant.h>
+#include <Foundation/Utilities/ConversionUtils.h>
 
 namespace ezTokenParseUtils
 {
@@ -258,5 +260,103 @@ namespace ezTokenParseUtils
       sTemp = Tokens[t]->m_DataView;
       ref_sResult.Append(sTemp.GetView());
     }
+  }
+
+  void RenderTemplate(ezStringView sTemplate, const ezDelegate<void(ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)>& resolveAndAppendPlaceholder, ezStringBuilder& out_sOutput)
+  {
+    ezTokenizer tokenizer(ezTempAllocator::Get());
+    tokenizer.Tokenize(ezMakeByteArrayPtr(sTemplate.GetStartPointer(), sTemplate.GetElementCount()), ezLog::GetThreadLocalLogSystem(), false);
+
+    ezUInt32 uiCurToken = 0;
+    ezTempHybridArray<const ezToken*, 32> tokens;
+    tokens.Reserve(tokenizer.GetTokens().GetCount());
+    for (const ezToken& token : tokenizer.GetTokens())
+    {
+      tokens.PushBack(&token);
+    }
+
+    out_sOutput.Clear();
+    out_sOutput.Reserve(sTemplate.GetElementCount());
+
+    const char* szStart = sTemplate.GetStartPointer();
+    while (!Accept(tokens, uiCurToken, ezTokenType::EndOfFile))
+    {
+      const ezToken* pToken = tokens[uiCurToken];
+
+      // Find '{', an optional '?' and '$', a NAME, an optional '[INDEX]' and finally '}'.
+      ezUInt32 uiNextToken = uiCurToken;
+      ezUInt32 uiOpenToken = 0;
+      ezUInt32 uiNameToken = 0;
+      ezUInt32 uiCloseToken = 0;
+      bool bOptional = false;
+      bool bMatched = false;
+      ezVariant index;
+
+      if (Accept(tokens, uiNextToken, "{"_ezsv, &uiOpenToken))
+      {
+        bOptional = Accept(tokens, uiNextToken, "?"_ezsv);
+
+        // the '$' carries no meaning, {$NAME} and {NAME} are equivalent
+        Accept(tokens, uiNextToken, "$"_ezsv);
+
+        if (Accept(tokens, uiNextToken, ezTokenType::Identifier, &uiNameToken))
+        {
+          bool bIndexValid = true;
+
+          ezUInt32 uiIndexToken = 0;
+          if (Accept(tokens, uiNextToken, "["_ezsv))
+          {
+            bIndexValid = Accept(tokens, uiNextToken, ezTokenType::Integer, &uiIndexToken) && Accept(tokens, uiNextToken, "]"_ezsv);
+
+            if (bIndexValid)
+            {
+              // an integer token that doesn't fit into ezInt32 is not treated as a placeholder
+              ezInt32 iIndex = 0;
+              bIndexValid = ezConversionUtils::StringToInt(tokens[uiIndexToken]->m_DataView, iIndex).Succeeded();
+
+              if (bIndexValid)
+              {
+                index = iIndex;
+              }
+            }
+          }
+
+          bMatched = bIndexValid && Accept(tokens, uiNextToken, "}"_ezsv, &uiCloseToken);
+        }
+      }
+
+      if (bMatched)
+      {
+        out_sOutput.Append(ezStringView(szStart, tokens[uiOpenToken]->m_DataView.GetStartPointer()));
+        resolveAndAppendPlaceholder(tokens[uiNameToken]->m_DataView, index, bOptional, out_sOutput);
+        szStart = tokens[uiCloseToken]->m_DataView.GetEndPointer();
+        uiCurToken = uiNextToken;
+      }
+      else if (pToken->m_iType == ezTokenType::String1 || pToken->m_iType == ezTokenType::String2)
+      {
+        // The tokenizer turns a quoted section into a single string token, so placeholders inside it have to be resolved by rendering the string content (without the enclosing quotes) separately.
+        const char* szContentStart = pToken->m_DataView.GetStartPointer() + 1;
+        const char* szContentEnd = pToken->m_DataView.GetEndPointer();
+
+        // an unterminated string literal has no closing quote to exclude
+        if (szContentEnd > szContentStart && *(szContentEnd - 1) == *pToken->m_DataView.GetStartPointer())
+        {
+          --szContentEnd;
+        }
+
+        ezStringBuilder sContent(ezTempAllocator::Get());
+        RenderTemplate(ezStringView(szContentStart, szContentEnd), resolveAndAppendPlaceholder, sContent);
+
+        out_sOutput.Append(ezStringView(szStart, szContentStart));
+        out_sOutput.Append(sContent.GetView());
+        szStart = szContentEnd;
+        ++uiCurToken;
+      }
+      else
+      {
+        ++uiCurToken;
+      }
+    }
+    out_sOutput.Append(ezStringView(szStart, sTemplate.GetEndPointer()));
   }
 } // namespace ezTokenParseUtils

--- a/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
+++ b/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
@@ -122,4 +122,13 @@ namespace ezTokenParseUtils
   /// \param uiCurToken The start location inside 'tokens' from which point the tokens should be copied to 'ref_destination'.
   /// \param ref_destination Target stream to store the cleaned up tokens into.
   EZ_FOUNDATION_DLL void CreateCleanTokenStream(const TokenStream& tokens, ezUInt32 uiCurToken, TokenStream& ref_destination);
+
+  /// \brief Replaces instances of {PLACEHOLDER} or {PLACEHOLDER[INDEX]} inside a template string with the data appended by a given delegate.
+  ///
+  /// The placeholder name may be prefixed with a '?' to mark it as optional and with a '$', which is stripped, so that {$NAME} and {NAME} are equivalent. Both prefixes can be combined as {?$NAME}, in that order. The name must be an identifier and the index must be an integer, otherwise the text is left untouched. Whitespace between the individual tokens of a placeholder is allowed and removed. Placeholders inside quoted sections are resolved as well, the quotes themselves are preserved.
+  ///
+  /// \param sTemplate The string containing the templated placeholders.
+  /// \param resolveAndAppendPlaceholder The callback that is executed for each found placeholder. The implementation needs to resolve the placeholder and append the result to 'ref_sOutput'. The index is invalid for placeholders without an index. 'bOptional' tells the implementation that the placeholder was marked with '?', it is up to the implementation what to do with that information, typically to append nothing for empty or default values.
+  /// \param out_sOutput The resulting output string after placeholder replacement. Cleared before rendering.
+  EZ_FOUNDATION_DLL void RenderTemplate(ezStringView sTemplate, const ezDelegate<void(ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)>& resolveAndAppendPlaceholder, ezStringBuilder& out_sOutput); // [tested]
 } // namespace ezTokenParseUtils

--- a/Code/Tools/Libs/GuiFoundation/VisualGraph/Implementation/Node.cpp
+++ b/Code/Tools/Libs/GuiFoundation/VisualGraph/Implementation/Node.cpp
@@ -186,8 +186,7 @@ void ezQtVisualGraphNode::UpdateState()
 
   ezStringBuilder sTitle;
   ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
-    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
-    sTitle);
+    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); }, sTitle);
 
   SetTitleAndSubtitle(sTitle, format);
 }

--- a/Code/Tools/Libs/GuiFoundation/VisualGraph/Implementation/Node.cpp
+++ b/Code/Tools/Libs/GuiFoundation/VisualGraph/Implementation/Node.cpp
@@ -1,9 +1,12 @@
 #include <GuiFoundation/GuiFoundationPCH.h>
 
+#include <Foundation/CodeUtils/TokenParseUtils.h>
+#include <Foundation/CodeUtils/Tokenizer.h>
 #include <Foundation/Strings/TranslationLookup.h>
 #include <GuiFoundation/VisualGraph/Node.h>
 #include <GuiFoundation/VisualGraph/Pin.h>
 #include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Project/ToolsProject.h>
 
 #include <QApplication>
 #include <QGraphicsDropShadowEffect>
@@ -173,17 +176,218 @@ void ezQtVisualGraphNode::UpdateGeometry()
 
 void ezQtVisualGraphNode::UpdateState()
 {
-  auto& typeAccessor = m_pObject->GetTypeAccessor();
+  const TitleFormat format;
+
+  ezStringBuilder sTemplate;
+  if (!TryGetTitleTemplateFromProperty("CustomTitle", sTemplate) && !TryGetTitleTemplateFromAttribute(sTemplate))
+  {
+    GetDefaultTitleTemplate(sTemplate);
+  }
+
+  ezStringBuilder sTitle;
+  ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
+    sTitle);
+
+  SetTitleAndSubtitle(sTitle, format);
+}
+
+bool ezQtVisualGraphNode::TryGetTitleTemplateFromProperty(ezStringView sPropertyName, ezStringBuilder& out_sTemplate)
+{
+  const ezVariant value = GetObject()->GetTypeAccessor().GetValue(sPropertyName);
+  if (!value.IsValid() || !value.CanConvertTo<ezString>())
+    return false;
+
+  out_sTemplate = value.ConvertTo<ezString>();
+  return !out_sTemplate.IsEmpty();
+}
+
+bool ezQtVisualGraphNode::TryGetTitleTemplateFromAttribute(ezStringBuilder& out_sTemplate)
+{
+  auto pTitleAttribute = GetObject()->GetType()->GetAttributeByType<ezTitleAttribute>();
+  if (pTitleAttribute == nullptr)
+    return false;
+
+  out_sTemplate = pTitleAttribute->GetTitle();
+  return true;
+}
+
+void ezQtVisualGraphNode::GetDefaultTitleTemplate(ezStringBuilder& out_sTemplate)
+{
+  auto& typeAccessor = GetObject()->GetTypeAccessor();
 
   ezVariant name = typeAccessor.GetValue("Name");
-  if (name.IsA<ezString>() && name.Get<ezString>().IsEmpty() == false)
+  if (name.IsA<ezString>() && !name.Get<ezString>().IsEmpty())
   {
-    m_pTitleLabel->setPlainText(name.Get<ezString>().GetData());
+    out_sTemplate = name.Get<ezString>();
   }
   else
   {
-    ezStringBuilder tmp;
-    m_pTitleLabel->setPlainText(ezMakeQString(ezTranslate(typeAccessor.GetType()->GetTypeName().GetData(tmp))));
+    out_sTemplate = ezTranslate(typeAccessor.GetType()->GetTypeName());
+  }
+}
+
+void ezQtVisualGraphNode::ResolvePropertyPlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput)
+{
+  const ezAbstractProperty* pProp = GetObject()->GetType()->FindPropertyByName(sPlaceholder);
+  if (pProp == nullptr)
+    return;
+
+  AppendPropertyValue(pProp, index, bOptional, format, ref_sOutput);
+}
+
+void ezQtVisualGraphNode::AppendPropertyValue(const ezAbstractProperty* pProp, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput)
+{
+  if ((pProp->GetCategory() == ezPropertyCategory::Set || pProp->GetCategory() == ezPropertyCategory::Array) && !index.IsValid())
+  {
+    ezTempHybridArray<ezVariant, 16> values;
+    GetObject()->GetTypeAccessor().GetValues(pProp->GetPropertyName(), values);
+
+    if (bOptional && values.IsEmpty())
+      return;
+
+    ezStringBuilder sSet("{");
+    for (const auto& setValue : values)
+    {
+      if (sSet.GetElementCount() > 1)
+      {
+        sSet.Append(", ");
+      }
+      sSet.Append(setValue.ConvertTo<ezString>().GetView());
+    }
+    sSet.Append("}");
+
+    ref_sOutput.Append(sSet.GetView());
+    return;
+  }
+
+  const ezVariant value = GetObject()->GetTypeAccessor().GetValue(pProp->GetPropertyName(), index);
+
+  if (!value.IsValid())
+  {
+    if (format.m_bIgnoreInvalidProperties || bOptional)
+      return;
+
+    ref_sOutput.Append("<Invalid>");
+    return;
+  }
+
+  if (bOptional)
+  {
+    if (value == ezVariant(0))
+      return;
+
+    if ((value.IsA<ezString>() || value.IsA<ezHashedString>()) && value.ConvertTo<ezString>().IsEmpty())
+      return;
+  }
+
+
+  ezStringBuilder sValue;
+  if (pProp->GetSpecificType()->IsDerivedFrom<ezEnumBase>() || pProp->GetSpecificType()->IsDerivedFrom<ezBitflagsBase>())
+  {
+    ezReflectionUtils::EnumerationToString(pProp->GetSpecificType(), value.ConvertTo<ezInt64>(), sValue);
+    sValue = ezTranslate(sValue);
+  }
+  else if (value.IsA<bool>())
+  {
+    if (format.m_bBoolsAsTicks)
+      sValue.Set(value.Get<bool>() ? "[x]" : "[ ]");
+    else
+      sValue.Set(value.Get<bool>() ? "true" : "false");
+  }
+  else if (value.IsA<ezColor>())
+  {
+    sValue = ezConversionUtils::GetColorName(value.Get<ezColor>());
+  }
+  else if (value.IsA<ezColorGammaUB>())
+  {
+    sValue = ezConversionUtils::GetColorName(ezColor(value.Get<ezColorGammaUB>()));
+  }
+  else if (value.IsA<ezVec2>())
+  {
+    const ezVec2 v = value.Get<ezVec2>();
+    sValue.SetFormat("({}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2));
+  }
+  else if (value.IsA<ezVec3>())
+  {
+    const ezVec3 v = value.Get<ezVec3>();
+    sValue.SetFormat("({}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2));
+  }
+  else if (value.IsA<ezVec4>())
+  {
+    const ezVec4 v = value.Get<ezVec4>();
+    sValue.SetFormat("({}, {}, {}, {})", ezArgF(v.x, 2), ezArgF(v.y, 2), ezArgF(v.z, 2), ezArgF(v.w, 2));
+  }
+  else if (value.IsA<ezString>() || value.IsA<ezHashedString>())
+  {
+    sValue = value.ConvertTo<ezString>();
+
+    // asset references are stored as document GUIDs, which are meaningless to the user
+    if (ezConversionUtils::IsStringUuid(sValue) && ezToolsProject::GetSingleton() != nullptr)
+    {
+      const ezStringBuilder sPath = ezToolsProject::GetSingleton()->GetPathForDocumentGuid(ezConversionUtils::ConvertStringToUuid(sValue));
+
+      if (!sPath.IsEmpty())
+      {
+        sValue = ezPathUtils::GetFileName(sPath);
+      }
+    }
+
+    sValue.ReplaceAll("\n", " ");
+    sValue.ReplaceAll("\t", " ");
+
+    if (format.m_uiMaxStringLength > 0 && sValue.GetCharacterCount() > format.m_uiMaxStringLength)
+    {
+      sValue.Shrink(0, sValue.GetCharacterCount() - (format.m_uiMaxStringLength - 2));
+      sValue.Append("...");
+    }
+
+    if (format.m_bQuoteStrings && !sValue.IsEmpty())
+    {
+      sValue.Prepend("\"");
+      sValue.Append("\"");
+    }
+  }
+  else if (value.CanConvertTo<ezString>())
+  {
+    sValue = value.ConvertTo<ezString>();
+  }
+  else
+  {
+    sValue = "<not-implemented>";
+  }
+
+  ref_sOutput.Append(sValue.GetView());
+}
+
+void ezQtVisualGraphNode::SetTitleAndSubtitle(ezStringView sTitle, const TitleFormat& format)
+{
+  ezStringBuilder sCleaned = sTitle;
+
+  if (format.m_uiMaxTitleLength > 0 && sCleaned.GetCharacterCount() > format.m_uiMaxTitleLength)
+  {
+    sCleaned.Shrink(0, sCleaned.GetCharacterCount() - (format.m_uiMaxTitleLength + 1));
+    sCleaned.Append("...");
+  }
+
+  if (!format.m_bSplitAtDoubleColon)
+  {
+    m_pTitleLabel->setPlainText(ezMakeQString(sCleaned));
+    return;
+  }
+
+  if (const char* szSeparator = sCleaned.FindSubString("::"))
+  {
+    m_pTitleLabel->setPlainText(szSeparator + 2);
+
+    ezStringBuilder sSubTitle = ezStringView(sCleaned.GetData(), szSeparator);
+    sSubTitle.Trim("\"");
+    m_pSubtitleLabel->setPlainText(ezMakeQString(sSubTitle));
+  }
+  else
+  {
+    m_pTitleLabel->setPlainText(ezMakeQString(sCleaned));
+    m_pSubtitleLabel->setPlainText(QString());
   }
 }
 

--- a/Code/Tools/Libs/GuiFoundation/VisualGraph/Node.h
+++ b/Code/Tools/Libs/GuiFoundation/VisualGraph/Node.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Types/Delegate.h>
+#include <Foundation/Types/Variant.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/VisualGraph/Scene.moc.h>
 #include <QGraphicsWidget>
@@ -17,6 +20,7 @@ class ezDocumentObject;
 class QGraphicsTextItem;
 class QGraphicsPixmapItem;
 class QGraphicsDropShadowEffect;
+class ezAbstractProperty;
 
 struct ezQtVisualGraphNodeFlags
 {
@@ -75,6 +79,24 @@ public:
 protected:
   virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
   virtual QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
+
+  /// Controls how UpdateState() turns values into title text.
+  struct TitleFormat
+  {
+    ezUInt32 m_uiMaxStringLength = 23;       ///< Strings longer than this are truncated. 0 disables truncation.
+    ezUInt32 m_uiMaxTitleLength = 0;         ///< The fully rendered title is truncated to this length. 0 disables truncation.
+    bool m_bQuoteStrings = true;             ///< Whether string values are enclosed in quotes.
+    bool m_bSplitAtDoubleColon = true;       ///< Whether the part of the title before a '::' becomes the subtitle.
+    bool m_bBoolsAsTicks = false;            ///< If set, bools turn into [x]/[ ] instead of 'true'/'false'
+    bool m_bIgnoreInvalidProperties = false; ///< If set, any invalid property value is ignored, i.e. resolves to "".
+  };
+
+  bool TryGetTitleTemplateFromProperty(ezStringView sPropertyName, ezStringBuilder& out_sTemplate);
+  bool TryGetTitleTemplateFromAttribute(ezStringBuilder& out_sTemplate);
+  void GetDefaultTitleTemplate(ezStringBuilder& out_sTemplate);
+  void ResolvePropertyPlaceholder(ezStringView sPlaceholder, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput);
+  void AppendPropertyValue(const ezAbstractProperty* pProp, const ezVariant& index, bool bOptional, const TitleFormat& format, ezStringBuilder& ref_sOutput);
+  void SetTitleAndSubtitle(ezStringView sTitle, const TitleFormat& format);
 
   QColor m_HeaderColor;
   QRectF m_HeaderRect;

--- a/Code/UnitTests/FoundationTest/CodeUtils/TokenParseUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/TokenParseUtilsTest.cpp
@@ -199,4 +199,157 @@ Identifier
     EZ_TEST_BOOL(ezTokenParseUtils::Accept(result, uiCurToken, templatePattern, nullptr));
     EZ_TEST_INT(uiCurToken, 5);
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "RenderTemplate")
+  {
+    // Renders every placeholder as '<NAME>' or '<NAME:INDEX>' so that both the resolved name and index are visible in the result. Optional placeholders use '(..)' instead of '<..>'.
+    auto Resolver = [](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    {
+      ref_sOutput.Append(bOptional ? "(" : "<", sPlaceholder);
+      if (index.IsValid())
+      {
+        const ezString sIndex = index.ConvertTo<ezString>();
+        ref_sOutput.Append(":", sIndex.GetView());
+      }
+      ref_sOutput.Append(bOptional ? ")" : ">");
+    };
+
+    ezStringBuilder sOutput;
+
+    struct TemplateTest
+    {
+      ezStringView m_sTemplate;
+      ezStringView m_sExpected;
+    };
+
+    TemplateTest tests[] = {
+      // trivial cases
+      {""_ezsv, ""_ezsv},
+      {"Perlin Noise"_ezsv, "Perlin Noise"_ezsv},
+      {"{Name}"_ezsv, "<Name>"_ezsv},
+
+      // examples taken from existing ezTitleAttribute usages
+      {"Random: {Seed}"_ezsv, "Random: <Seed>"_ezsv},
+      {"Subgraph: {Name}"_ezsv, "Subgraph: <Name>"_ezsv},
+      {"{Active} Placement Output: {Name}"_ezsv, "<Active> Placement Output: <Name>"_ezsv},
+      {"{Operator}({A}, {B})"_ezsv, "<Operator>(<A>, <B>)"_ezsv},
+      {"Remap: [{InputMin}, {InputMax}] -> [{OutputMin}, {OutputMax}]"_ezsv, "Remap: [<InputMin>, <InputMax>] -> [<OutputMin>, <OutputMax>]"_ezsv},
+      {"Height: [{MinHeight}, {MaxHeight}]"_ezsv, "Height: [<MinHeight>, <MaxHeight>]"_ezsv},
+      {"Coroutine::MoveTo {TargetPos}"_ezsv, "Coroutine::MoveTo <TargetPos>"_ezsv},
+      {"= {Expression}"_ezsv, "= <Expression>"_ezsv},
+      {"Compare: Number {Comparison} {ReferenceValue}"_ezsv, "Compare: Number <Comparison> <ReferenceValue>"_ezsv},
+      {"{Type}::Set {Property} = {Value}"_ezsv, "<Type>::Set <Property> = <Value>"_ezsv},
+      {"ForLoop [{FirstIndex}..{LastIndex}]"_ezsv, "ForLoop [<FirstIndex>..<LastIndex>]"_ezsv},
+      {"Array::GetElement[{Index}]"_ezsv, "Array::GetElement[<Index>]"_ezsv},
+      {"Clamp({X}, {Min}, {Max})"_ezsv, "Clamp(<X>, <Min>, <Max>)"_ezsv},
+      {"{Condition} ? {A} : {B}"_ezsv, "<Condition> ? <A> : <B>"_ezsv},
+      {"Expression::{Expression}"_ezsv, "Expression::<Expression>"_ezsv},
+      {"Variant::ConvertTo {Type}"_ezsv, "Variant::ConvertTo <Type>"_ezsv},
+
+      // indexed placeholders
+      {"BlendSpace 1D: {Clips[0]} {Clips[1]} {Clips[2]}"_ezsv, "BlendSpace 1D: <Clips:0> <Clips:1> <Clips:2>"_ezsv},
+      {"Bone Weights {RootBones[10]}"_ezsv, "Bone Weights <RootBones:10>"_ezsv},
+
+      // whitespace between the placeholder tokens is tolerated and stripped
+      {"{ Name }"_ezsv, "<Name>"_ezsv},
+      {"{ Clips [ 2 ] }"_ezsv, "<Clips:2>"_ezsv},
+
+      // the optional '$' prefix is stripped, as used by the visual shader titles
+      {"{$Name}"_ezsv, "<Name>"_ezsv},
+      {"{$Clips[0]}"_ezsv, "<Clips:0>"_ezsv},
+      {"{$in0} + {$in1}"_ezsv, "<in0> + <in1>"_ezsv},
+      {"Color: {$prop0}"_ezsv, "Color: <prop0>"_ezsv},
+      {"Lerp: {$in0} -> {$in1} ({$in2})"_ezsv, "Lerp: <in0> -> <in1> (<in2>)"_ezsv},
+      {"{ $ Name }"_ezsv, "<Name>"_ezsv},
+
+      // the optional '?' prefix marks a placeholder as optional and can be combined with '$'
+      {"{?Name}"_ezsv, "(Name)"_ezsv},
+      {"{?Clips[2]}"_ezsv, "(Clips:2)"_ezsv},
+      {"{?$in0}"_ezsv, "(in0)"_ezsv},
+      {"{?$Clips[1]}"_ezsv, "(Clips:1)"_ezsv},
+      {"{ ? Name }"_ezsv, "(Name)"_ezsv},
+      {"Set Bool: '{BlackboardEntry}' to {?Bool}"_ezsv, "Set Bool: '<BlackboardEntry>' to (Bool)"_ezsv},
+
+      // placeholders don't need to be separated by anything
+      {"{A}{B}"_ezsv, "<A><B>"_ezsv},
+
+      // the index goes through the integer conversion, which strips leading zeros
+      {"{Clips[007]}"_ezsv, "<Clips:7>"_ezsv},
+
+      // a template may span several lines
+      {"{A}\n{B}"_ezsv, "<A>\n<B>"_ezsv},
+
+      // non-ASCII text is passed through unchanged
+      {"Gr\u00f6\u00dfe: {Size}"_ezsv, "Gr\u00f6\u00dfe: <Size>"_ezsv},
+
+      // comments count as whitespace inside a placeholder and are swallowed with it
+      {"{ /*c*/ Name }"_ezsv, "<Name>"_ezsv},
+
+      // a comment is a single token, so a placeholder inside one is not resolved
+      {"/* {Name} */"_ezsv, "/* {Name} */"_ezsv},
+
+      // nothing that doesn't form a complete placeholder is touched
+      {"{Name"_ezsv, "{Name"_ezsv},
+      {"Name}"_ezsv, "Name}"_ezsv},
+      {"{}"_ezsv, "{}"_ezsv},
+      {"{123}"_ezsv, "{123}"_ezsv},
+      {"{Clips[]}"_ezsv, "{Clips[]}"_ezsv},
+      {"{Clips[a]}"_ezsv, "{Clips[a]}"_ezsv},
+      {"{Clips[-1]}"_ezsv, "{Clips[-1]}"_ezsv},
+      {"{Clips[99999999999999]}"_ezsv, "{Clips[99999999999999]}"_ezsv},
+      {"{$}"_ezsv, "{$}"_ezsv},
+      {"{$$Name}"_ezsv, "{$$Name}"_ezsv},
+      {"{$0}"_ezsv, "{$0}"_ezsv},
+      {"{?}"_ezsv, "{?}"_ezsv},
+      {"{??Name}"_ezsv, "{??Name}"_ezsv},
+      {"{$?Name}"_ezsv, "{$?Name}"_ezsv},
+      {"{{Name}}"_ezsv, "{<Name>}"_ezsv},
+      {"100% {Name} & <stuff>"_ezsv, "100% <Name> & <stuff>"_ezsv},
+
+      // placeholders inside quoted sections are resolved as well, the quotes are preserved
+      {"Sample Clip: '{Clip}'"_ezsv, "Sample Clip: '<Clip>'"_ezsv},
+      {"Log: \"{Text}\""_ezsv, "Log: \"<Text>\""_ezsv},
+      {"Set Number: '{BlackboardEntry}' to {Number}"_ezsv, "Set Number: '<BlackboardEntry>' to <Number>"_ezsv},
+      {"BlendSpace 1D: '{Clips[0]}' '{Clips[1]}'"_ezsv, "BlendSpace 1D: '<Clips:0>' '<Clips:1>'"_ezsv},
+      {"'\"{A}\"'"_ezsv, "'\"<A>\"'"_ezsv},
+      {"'{?A}'"_ezsv, "'(A)'"_ezsv},
+      {"Log: 'nothing here'"_ezsv, "Log: 'nothing here'"_ezsv},
+      {"''"_ezsv, "''"_ezsv},
+      {"\"\""_ezsv, "\"\""_ezsv},
+    };
+
+    for (const auto& test : tests)
+    {
+      ezTokenParseUtils::RenderTemplate(test.m_sTemplate, Resolver, sOutput);
+      EZ_TEST_STRING(sOutput, test.m_sExpected);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "RenderTemplate: optional flag")
+  {
+    // Mimics a node title that omits optional placeholders.
+    auto Resolver = [](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
+    {
+      EZ_IGNORE_UNUSED(index);
+      if (!bOptional)
+      {
+        ref_sOutput.Append(sPlaceholder);
+      }
+    };
+
+    ezStringBuilder sOutput;
+
+    ezTokenParseUtils::RenderTemplate("{?A}"_ezsv, Resolver, sOutput);
+    EZ_TEST_STRING(sOutput, "");
+
+    ezTokenParseUtils::RenderTemplate("{?A}{?B}{C}"_ezsv, Resolver, sOutput);
+    EZ_TEST_STRING(sOutput, "C");
+
+    ezTokenParseUtils::RenderTemplate("Set {Name} to {?Value}"_ezsv, Resolver, sOutput);
+    EZ_TEST_STRING(sOutput, "Set Name to ");
+
+    // the quotes around a dropped placeholder remain, which is what callers have to clean up afterwards
+    ezTokenParseUtils::RenderTemplate("['{?A}' '{?B}']"_ezsv, Resolver, sOutput);
+    EZ_TEST_STRING(sOutput, "['' '']");
+  }
 }


### PR DESCRIPTION
## Foundation

Added `ezTokenParseUtils::RenderTemplate`. This replaces instances of `{PLACEHOLDER}` inside a template string with text produced by a delegate. Intended to replace the hand-rolled `ezStringBuilder::ReplaceAll` loops that each visual graph uses to expand `ezTitleAttribute` strings.

### Syntax

These placeholders are supported:

    {NAME}          basic placeholder
    {NAME[INDEX]}   placeholder with int index
    {$NAME}         optional '$' prefix, stripped and ignored
    {?NAME}         optional '?' prefix, reported to the delegate as `bOptional`
    {?$NAME[0]}     both prefixes plus an index, in that order

The name must be an identifier and the index an integer. Anything that does not form a complete placeholder is copied to the output verbatim. Whitespace between the individual tokens of a placeholder is allowed and removed.

The `$` form exists because the visual shader titles in `Data/Tools/ezEditor/VisualShader/*.ddl` use `{$in0}` / `{$prop0}`; supporting it here avoids migrating those data files.

## GuiFoundation

Most of the title template rendering code is now implemented in `ezQtVisualGraphNode` as helper functions. As various implementations slightly differ, a `TitleFormat` struct was added that configures certain aspects of template rendering.

## Plugins

All the changed assets now implement an exntended version of the base implementation in `UpdateState`

```C++
  const TitleFormat format;
  // Find the template string from various sources:
  ezStringBuilder sTemplate;
  if (!TryGetTitleTemplateFromProperty("CustomTitle", sTemplate) && !TryGetTitleTemplateFromAttribute(sTemplate))
  {
    GetDefaultTitleTemplate(sTemplate);
  }

  // Render the template with your placeholder resolver:
  ezStringBuilder sTitle;
  ezTokenParseUtils::RenderTemplate(sTemplate, [&](ezStringView sPlaceholder, ezVariant index, bool bOptional, ezStringBuilder& ref_sOutput)
    { ResolvePropertyPlaceholder(sPlaceholder, index, bOptional, format, ref_sOutput); },
    sTitle);

  // Set the result:
  SetTitleAndSubtitle(sTitle, format);
```

## Tests

Tests have been added to verifies the behaviour of `RenderTemplate` against most of the static examples from the code base and various dynamic constructs from shaders etc.