### PR TITLE
Added position offset option to mesh import

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -75,7 +75,7 @@ void ezMeshAssetDocument::CreateMeshFromGeom(ezMeshAssetProperties* pProp, ezMes
   // const ezMat4 mTrans(mTransformation, ezVec3::MakeZero());
 
   ezGeometry::GeoOptions opt;
-  opt.m_Transform = ezMat4(mTransformation, ezVec3::MakeZero());
+  opt.m_Transform = ezMat4(mTransformation, pProp->m_vPositionOffset);
 
   auto detail1 = pProp->m_uiDetail;
   auto detail2 = pProp->m_uiDetail2;
@@ -227,6 +227,7 @@ ezTransformStatus ezMeshAssetDocument::CreateMeshFromFile(ezMeshAssetProperties*
   opt.m_bHighPrecision = pProp->m_bHighPrecision;
   opt.m_MeshVertexColorConversion = pProp->m_VertexColorConversion;
   opt.m_RootTransform = CalculateTransformationMatrix(pProp);
+  opt.m_vRootPosition = pProp->m_vPositionOffset;
   opt.m_pMeshOutput = &desc;
 
   // include tags

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
@@ -17,6 +17,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetProperties, 6, ezRTTIDefaultAllocator
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::NegativeX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
     EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir),
+    EZ_MEMBER_PROPERTY("PositionOffset", m_vPositionOffset),
     EZ_MEMBER_PROPERTY("UniformScaling", m_fUniformScaling)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0001f, 10000.0f)),
     EZ_MEMBER_PROPERTY("RecalculateNormals", m_bRecalculateNormals),
     EZ_MEMBER_PROPERTY("RecalculateTangents", m_bRecalculateTangents)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
@@ -60,6 +60,7 @@ public:
   ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::NegativeX;
   ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveY;
   bool m_bFlipForwardDir = false;
+  ezVec3 m_vPositionOffset = ezVec3::MakeZero();
 
   ezMeshPrimitive::Enum m_PrimitiveType = ezMeshPrimitive::Default;
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -95,7 +95,7 @@ ezTransformStatus ezJoltCollisionMeshAssetDocument::InternalTransformAsset(ezStr
 
       ezGeometry geom;
       ezGeometry::GeoOptions opt;
-      opt.m_Transform = ezMat4(mTransformation, ezVec3::MakeZero());
+      opt.m_Transform = ezMat4(mTransformation, pProp->m_vPositionOffset);
 
       meshDesc.m_bFlipNormals = ezGraphicsUtils::IsTriangleFlipRequired(mTransformation);
 
@@ -192,6 +192,7 @@ ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltMeshDesc& ou
   opt.m_sSourceFile = sAbsFilename;
   opt.m_pMeshOutput = &meshDesc;
   opt.m_RootTransform = CalculateTransformationMatrix(pProp);
+  opt.m_vRootPosition = pProp->m_vPositionOffset;
 
   // include tags
   {

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -37,6 +37,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 3, ezRTTIDef
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::NegativeX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
     EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir),
+    EZ_MEMBER_PROPERTY("PositionOffset", m_vPositionOffset),
     EZ_MEMBER_PROPERTY("UniformScaling", m_fUniformScaling)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("IsConvexMesh", m_bIsConvexMesh)->AddAttributes(new ezHiddenAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("ConvexMeshType", ezJoltConvexCollisionMeshType, m_ConvexMeshType),

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
@@ -68,6 +68,7 @@ public:
   ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::NegativeX;
   ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveY;
   bool m_bFlipForwardDir = false;
+  ezVec3 m_vPositionOffset = ezVec3::MakeZero();
   bool m_bIsConvexMesh = false;
   ezEnum<ezJoltConvexCollisionMeshType> m_ConvexMeshType;
   ezUInt16 m_uiMaxConvexPieces = 2;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.cpp
@@ -183,7 +183,13 @@ void ezProcGenGraphAssetDocumentWindow::SelectionEventHandler(const ezSelectionM
         // Check again if the selection is empty. This could have changed due to the delayed execution.
         if (pSelectionManager->IsSelectionEmpty())
         {
-          pSelectionManager->SetSelection(pDocument->GetObjectManager()->GetRootObject()->GetChildren()[0]);
+          EZ_ASSERT_DEV(pDocument, "");
+          EZ_ASSERT_DEV(pDocument->GetObjectManager(), "");
+          EZ_ASSERT_DEV(pDocument->GetObjectManager()->GetRootObject(), "");
+          if (pDocument->GetObjectManager()->GetRootObject()->GetChildren().IsEmpty() == false)
+          {
+            pSelectionManager->SetSelection(pDocument->GetObjectManager()->GetRootObject()->GetChildren()[0]);
+          }
         }
       });
   }

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1702,7 +1702,7 @@ void ezGALDeviceVulkan::FillCapabilitiesPlatform()
     m_Capabilities.m_uiDedicatedVRAM = static_cast<ezUInt64>(dedicatedMemory);
     m_Capabilities.m_uiDedicatedSystemRAM = static_cast<ezUInt64>(systemMemory);
     m_Capabilities.m_uiSharedSystemRAM = static_cast<ezUInt64>(0); // TODO
-    m_Capabilities.m_bHardwareAccelerated = m_Properties.properties.deviceType == vk::PhysicalDeviceType::eDiscreteGpu;
+    m_Capabilities.m_bHardwareAccelerated = m_Properties.properties.deviceType != vk::PhysicalDeviceType::eCpu;
     m_Capabilities.m_bSupportsTexelBuffer = true;
     m_Capabilities.m_bSupportsMultiSampledArrays = true;
   }

--- a/Code/Tools/Libs/ModelImporter2/Importer/Importer.h
+++ b/Code/Tools/Libs/ModelImporter2/Importer/Importer.h
@@ -30,6 +30,9 @@ namespace ezModelImporter2
     ezEnum<ezMeshVertexColorConversion> m_MeshVertexColorConversion = ezMeshVertexColorConversion::Default;
     bool m_bHighPrecision = false;
     ezMat3 m_RootTransform = ezMat3::MakeIdentity();
+    /// Translation that is applied to the mesh vertices after m_RootTransform.
+    /// Not applied to skinned meshes, animations or skeletons.
+    ezVec3 m_vRootPosition = ezVec3::MakeZero();
 
     // if non-empty, only import meshes whose names start or end with any of these strings
     ezDynamicArray<ezString> m_MeshIncludeTags;

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
@@ -105,9 +105,14 @@ namespace ezModelImporter2
 
     if (aiNode* node = m_pScene->mRootNode)
     {
+      // the position offset is only meant for static geometry,
+      // applying it to skinned meshes would move them away from their skeleton
+      const ezVec3 vRootPosition = m_Options.m_bImportSkinningData ? ezVec3::MakeZero() : m_Options.m_vRootPosition;
+
       ezMat4 tmp;
       tmp.SetIdentity();
       tmp.SetRotationalPart(m_Options.m_RootTransform);
+      tmp.SetTranslationVector(vRootPosition);
       tmp.Transpose(); // aiMatrix4x4 is row-major
 
       const aiMatrix4x4 transform = reinterpret_cast<aiMatrix4x4&>(tmp);

--- a/Code/Tools/Libs/ModelImporter2/ImporterMagicaVoxel/ImporterMagicaVoxel.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterMagicaVoxel/ImporterMagicaVoxel.cpp
@@ -105,7 +105,7 @@ namespace ezModelImporter2
         {
           ezVec3 pos = ezVec3(-mesh->vertices[i].pos.x, mesh->vertices[i].pos.z, mesh->vertices[i].pos.y);
           pos -= originOffset;
-          positions.ExpandAndGetRef() = m_Options.m_RootTransform * pos;
+          positions.ExpandAndGetRef() = (m_Options.m_RootTransform * pos) + m_Options.m_vRootPosition;
 
           ezVec3 norm = ezVec3(-mesh->vertices[i].normal.x, mesh->vertices[i].normal.z, mesh->vertices[i].normal.y);
           normals.ExpandAndGetRef() = m_Options.m_RootTransform.TransformDirection(norm);


### PR DESCRIPTION
Allows to make sure a mesh is properly centered, such that this isn't necessary to do in a prefab afterwards.