### PR TITLE
MCP and asset import improvements

### DIFF
--- a/.claude/skills/ez-mcp/SKILL.md
+++ b/.claude/skills/ez-mcp/SKILL.md
@@ -84,11 +84,25 @@ Nothing works on a closed document, and nothing opens implicitly:
 
 1. `asset_find` → path or guid. Its paths start with the data directory name
    (`Testing Chambers/Scenes/DynamicFog.ezScene`) - that is the form other tools want.
-2. `document_open` with `focus` false, unless the user is meant to look at it.
+2. `document_open` with `path` (not `document` - see below) and `focus` false, unless the user is meant
+   to look at it.
 3. `object_tree` → guids. Asset documents have one top level object, so `object_properties` with only
    `document` already reads an asset's whole configuration. Scenes have many.
 4. `object_properties` / `object_modify`.
 5. `document_save` - nothing saves on its own, and the asset system sees nothing until it is saved.
+
+**Which argument names a tool takes**, because guessing costs a round trip and they follow a rule:
+
+| Argument | Tools | Why |
+| --- | --- | --- |
+| `path` | `document_open`, `document_create`, `document_delete` | act on a file that need not be open yet |
+| `document` | `object_*`, `selection_*`, `document_save`/`_close`/`_focus`, and the `document` argument of the action tools | act on an already open document |
+| `asset` | `asset_info`, `asset_transform`, `asset_thumbnail`, `asset_uses` | act on the asset database, open or not |
+| `name` | `action_execute`, `action_state`, `rtti_*`, `cvar_set` | the thing named is not a document at all |
+
+So it is `document_open` `path`, `action_execute` `name`, `rtti_derived_types` `name`. When in doubt read
+the schema from `tools/list` rather than guessing - and note that a wrong name fails with a message that
+says the right one.
 
 A scene's game objects and components live in the same hierarchy, told apart by the parent property they
 sit in. Building one is all `object_modify`:

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessViewContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessViewContext.cpp
@@ -132,7 +132,19 @@ void ezEngineProcessViewContext::HandleWindowUpdate(ezWindowHandle hWnd, ezUInt1
       SetupRenderTarget(pOutput->m_hSwapChain, nullptr, static_cast<ezUInt16>(wndSize.width), static_cast<ezUInt16>(wndSize.height));
     }
 
-    m_hEditorWindow = pWinMan->Register("EditorView", this, std::move(pWindow));
+    // The document guid goes into the name because this process registers one window per open document
+    // window, and they are otherwise indistinguishable: anything that picks a window by index or by
+    // name (app_info and app_screenshot over MCP) could only ever guess which document it got.
+    ezStringBuilder sWindowName("EditorView");
+
+    if (m_pDocumentContext != nullptr)
+    {
+      ezStringBuilder sGuid;
+      ezConversionUtils::ToString(m_pDocumentContext->GetDocumentGuid(), sGuid);
+      sWindowName.AppendFormat(" {}", sGuid);
+    }
+
+    m_hEditorWindow = pWinMan->Register(sWindowName, this, std::move(pWindow));
     pWinMan->SetOutputTarget(m_hEditorWindow, std::move(pOutput));
   }
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
@@ -18,6 +18,33 @@ namespace ezMeshImportUtils
     sSeparated.Split(false, out_list, ";", "*", ".");
   }
 
+  static ezStringView TextureSemanticToString(ezModelImporter2::TextureSemantic semantic)
+  {
+    switch (semantic)
+    {
+      case ezModelImporter2::TextureSemantic::DiffuseMap:
+        return "diffuse";
+      case ezModelImporter2::TextureSemantic::DiffuseAlphaMap:
+        return "diffuse+alpha";
+      case ezModelImporter2::TextureSemantic::OcclusionMap:
+        return "occlusion";
+      case ezModelImporter2::TextureSemantic::RoughnessMap:
+        return "roughness";
+      case ezModelImporter2::TextureSemantic::MetallicMap:
+        return "metallic";
+      case ezModelImporter2::TextureSemantic::OrmMap:
+        return "ORM";
+      case ezModelImporter2::TextureSemantic::DisplacementMap:
+        return "displacement";
+      case ezModelImporter2::TextureSemantic::NormalMap:
+        return "normal";
+      case ezModelImporter2::TextureSemantic::EmissiveMap:
+        return "emissive";
+      default:
+        return "unknown";
+    }
+  }
+
   ezString ImportOrResolveTexture(const char* szImportSourceFolder, const char* szImportTargetFolder, ezStringView sTexturePath, ezModelImporter2::TextureSemantic hint, bool bTextureClamp, const ezModelImporter2::Importer* pImporter)
   {
     if (!ezUnicodeUtils::IsValidUtf8(sTexturePath.GetStartPointer(), sTexturePath.GetEndPointer()))
@@ -78,9 +105,16 @@ namespace ezMeshImportUtils
       pAccessor->StartTransaction("Import Texture");
       ezDocumentObject* pTextureAsset = textureDocument->GetPropertyObject();
 
+      ezStringBuilder sOriginalReference = szImportSourceFolder;
+      sOriginalReference.AppendPath(sTexturePath);
+      sOriginalReference.MakeCleanPath();
+
       if (ezAssetCurator::GetSingleton()->FindBestMatchForFile(relTexturePath, allowedExtensions).Failed())
       {
-        relTexturePath = sFinalTextureName;
+        relTexturePath = sOriginalReference;
+        ezQtEditorApp::GetSingleton()->MakePathDataDirectoryRelative(relTexturePath);
+
+        ezLog::Warning("Could not find the {} texture '{}' referenced by the mesh, in any of the supported image formats. The texture asset is created pointing at '{}', which does not exist, so it has to be corrected manually.", TextureSemanticToString(hint), sTexturePath, relTexturePath);
       }
 
       pAccessor->SetValueByName(pTextureAsset, "Input1", relTexturePath.GetData()).LogFailure();

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/ObjectTool.cpp
@@ -26,6 +26,8 @@ namespace
   /// How many objects one object_tree call may report before it says it truncated.
   constexpr ezUInt32 c_uiMaxTreeObjects = 200;
 
+  constexpr ezInt32 c_iMaxReportedElements = 64;
+
   ezStringView ObjectToolCategoryToString(ezPropertyCategory::Enum category)
   {
     // Deliberately the same words rtti_type_properties reports, so an agent that looked a type up
@@ -491,8 +493,36 @@ void ezMcpObjectTool::WritePropertyValue(ezMcpJsonWriter& ref_writer, ezObjectAc
     case ezPropertyCategory::Set:
     {
       ezInt32 iCount = 0;
-      if (pAccessor->GetCountByName(pObject, pProp->GetPropertyName(), iCount).Succeeded())
-        ref_writer.AddVariableInt32("count", iCount);
+      if (pAccessor->GetCountByName(pObject, pProp->GetPropertyName(), iCount).Failed())
+        break;
+
+      ref_writer.AddVariableInt32("count", iCount);
+
+      if (flags.IsAnySet(ezPropertyFlags::Class | ezPropertyFlags::Pointer) && !flags.IsSet(ezPropertyFlags::StandardType))
+        break;
+
+      const ezInt32 iWritten = ezMath::Min(iCount, c_iMaxReportedElements);
+
+      ref_writer.BeginArray("values");
+      for (ezInt32 i = 0; i < iWritten; ++i)
+      {
+        ezVariant value;
+        if (pAccessor->GetValueByName(pObject, pProp->GetPropertyName(), value, i).Failed())
+          break;
+        ezStringBuilder sName;
+        if (flags.IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags) && pPropType != nullptr && value.CanConvertTo<ezInt64>() &&
+            ezReflectionUtils::EnumerationToString(pPropType, value.ConvertTo<ezInt64>(), sName, ezReflectionUtils::EnumConversionMode::ValueNameOnly))
+        {
+          ref_writer.WriteString(sName);
+          continue;
+        }
+
+        ref_writer.WriteVariant(value);
+      }
+      ref_writer.EndArray();
+
+      if (iWritten < iCount)
+        ref_writer.AddVariableInt32("valuesTruncated", iCount - iWritten);
 
       break;
     }
@@ -682,9 +712,10 @@ void ezMcpObjectTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools
       "Reads the properties of one object inside an open document, with their current values. With no 'object' argument this is the "
       "document's top level object, which for most asset types is the single object holding all of the asset's settings - so reading "
       "an asset's configuration is one call with just 'document'. "
-      "Only direct properties are returned: a property whose value is another object reports that object's guid under 'objectGuid', "
-      "and arrays, sets and maps report a count (and, for maps, their keys) rather than their elements. Pass 'property' with an "
-      "'index' to read one element. The document has to be open - use 'document_open' with 'focus' false to open it invisibly.";
+      "Only direct properties are returned: a property whose value is another object reports that object's guid under 'objectGuid'. "
+      "An array or set of plain values reports them under 'values' (capped, with 'valuesTruncated' saying how many were left out); "
+      "one holding objects reports only a count, and maps report a count and their keys. Pass 'property' with an 'index' to read one "
+      "element. The document has to be open - use 'document_open' with 'focus' false to open it invisibly.";
     desc.m_sInputSchema = R"({"type":"object","properties":{)"
                           R"("document":{"type":"string","description":"Guid or path of an open document. 'document_list' reports both."},)"
                           R"("object":{"type":"string","description":"Guid of the object to read, as reported by a previous call. Omit for the document's top level object."},)"

--- a/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.cpp
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.cpp
@@ -177,9 +177,13 @@ void ezMcpEngineAppTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_to
       "The path is returned rather than the image data, because a screenshot base64s to megabytes.\n"
       "The capture takes a frame or two, so the call blocks until the image is ready. If the game is not rendering - "
       "which is the normal state of the editor's engine process while nobody is playing the game - this fails after a "
-      "few seconds rather than waiting forever; start play-the-game in the editor first.";
+      "few seconds rather than waiting forever; start play-the-game in the editor first.\n"
+      "The result reports 'window' and 'windowName' for what was actually captured - worth checking, because in the "
+      "editor's engine process there is one window per open document window and the default index 0 is whichever "
+      "document was opened first, which is often a leftover asset preview rather than the scene. Target a specific one "
+      "with 'windowName': an editor view is named 'EditorView <document guid>', so passing the guid alone finds it.";
 
-    desc.m_sInputSchema = R"({"type":"object","properties":{"path":{"type":"string","description":"Absolute path to write to, including the file extension, which selects the format ('.png' unless there is a reason). Defaults to a generated name in the system temp folder."},"maxWidth":{"type":"number","description":"Downscale to at most this width, keeping the aspect ratio. Default 1280. Pass 0 for the full resolution."},"window":{"type":"number","description":"Which window to capture, as its index in app_info's 'windows'. Default 0."}}})";
+    desc.m_sInputSchema = R"({"type":"object","properties":{"path":{"type":"string","description":"Absolute path to write to, including the file extension, which selects the format ('.png' unless there is a reason). Defaults to a generated name in the system temp folder."},"maxWidth":{"type":"number","description":"Downscale to at most this width, keeping the aspect ratio. Default 1280. Pass 0 for the full resolution."},"window":{"type":"number","description":"Which window to capture, as its index in app_info's 'windows'. Default 0. Ignored if 'windowName' is given."},"windowName":{"type":"string","description":"Capture the window whose name contains this, instead of picking by index. An editor view is named 'EditorView <document guid>', so the document guid alone selects that document's view."}}})";
   }
 }
 
@@ -309,17 +313,49 @@ ezResult ezMcpEngineAppTool::BeginScreenshot(const ezVariantDictionary& argument
     return EZ_FAILURE;
   }
 
-  const ezInt32 iWindow = static_cast<ezInt32>(ezMcpJson::GetInt(arguments, "window", 0));
+  ezWindowManager* pWinMan = ezWindowManager::GetSingleton();
 
-  if (iWindow < 0 || iWindow >= static_cast<ezInt32>(windows.GetCount()))
+  ezInt32 iWindow = 0;
+
+  const ezStringBuilder sWantedName = ezMcpJson::GetString(arguments, "windowName");
+
+  if (!sWantedName.IsEmpty())
   {
-    ezStringBuilder sError;
-    sError.SetFormat("There is no window {}. This process has {}; see 'windows' in app_info.", iWindow, windows.GetCount());
-    out_result.SetError(sError);
-    return EZ_FAILURE;
+    iWindow = -1;
+
+    for (ezUInt32 i = 0; i < windows.GetCount(); ++i)
+    {
+      // Substring, so that a document guid alone finds 'EditorView { guid }'.
+      if (pWinMan->GetName(windows[i]).FindSubString_NoCase(sWantedName) != nullptr)
+      {
+        iWindow = static_cast<ezInt32>(i);
+        break;
+      }
+    }
+
+    if (iWindow < 0)
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("No window's name contains '{}'. This process has {}; see 'windows' in app_info for their names.",
+        sWantedName, windows.GetCount());
+      out_result.SetError(sError);
+      return EZ_FAILURE;
+    }
+  }
+  else
+  {
+    iWindow = static_cast<ezInt32>(ezMcpJson::GetInt(arguments, "window", 0));
+
+    if (iWindow < 0 || iWindow >= static_cast<ezInt32>(windows.GetCount()))
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("There is no window {}. This process has {}; see 'windows' in app_info.", iWindow, windows.GetCount());
+      out_result.SetError(sError);
+      return EZ_FAILURE;
+    }
   }
 
-  ezWindowOutputTargetBase* pOutputTarget = ezWindowManager::GetSingleton()->GetOutputTarget(windows[iWindow]);
+  ezWindowOutputTargetBase* pOutputTarget = pWinMan->GetOutputTarget(windows[iWindow]);
 
   if (pOutputTarget == nullptr)
   {
@@ -373,6 +409,7 @@ ezResult ezMcpEngineAppTool::BeginScreenshot(const ezVariantDictionary& argument
   m_State = CaptureState::Pending;
   m_sCapturePath = sPath;
   m_iCaptureWindow = iWindow;
+  m_sCaptureWindowName = pWinMan->GetName(windows[iWindow]);
   m_uiCaptureMaxWidth = static_cast<ezUInt32>(ezMath::Max<ezInt64>(0, ezMcpJson::GetInt(arguments, "maxWidth", 1280)));
   m_CaptureStarted = ezTime::Now();
 
@@ -420,6 +457,10 @@ void ezMcpEngineAppTool::FinishScreenshot(ezMcpToolResult& out_result)
   writer.AddVariableUInt32("width", image.GetWidth());
   writer.AddVariableUInt32("height", image.GetHeight());
   writer.AddVariableUInt64("frame", ezMcpEngineHost::GetFrameCount());
+
+  writer.AddVariableInt32("window", m_iCaptureWindow);
+  writer.AddVariableString("windowName", m_sCaptureWindowName);
+
   writer.AddVariableString("note", "Read this file to look at the frame.");
   writer.EndObject();
 

--- a/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.h
+++ b/Code/EnginePlugins/McpPlugin/Tools/McpEngineAppTool.h
@@ -67,6 +67,9 @@ private:
   ezString m_sCapturePath;
   ezUInt32 m_uiCaptureMaxWidth = 0;
   ezInt32 m_iCaptureWindow = 0;
+  /// Name of the window the capture was started on, so the result can say what was captured. Recorded
+  /// up front because a window can go away while the capture is in flight.
+  ezString m_sCaptureWindowName;
   ezTime m_CaptureStarted;
   ezEventSubscriptionID m_FrameSubscription = 0;
 

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -127,6 +127,14 @@ void ezQtDocumentWindow::TriggerRedraw()
 
 void ezQtDocumentWindow::UIServicesTickEventHandler(const ezQtUiServices::TickEvent& e)
 {
+  // s_TickEvent is an ezCopyOnBroadcastEvent, so it iterates a snapshot of the handlers taken before the
+  // first one ran. A window that is destroyed from within a tick (closing a document ends in
+  // 'delete this', and that can be reached from a tick handler) therefore stays in that snapshot for the
+  // rest of the broadcast, and this would be called on freed memory. Only the static registry may be
+  // touched to detect it - by that point 'this' must not be dereferenced.
+  if (!s_AllDocumentWindows.Contains(this))
+    return;
+
   auto ShouldRender = [&]() -> bool
   {
     if (!m_bIsVisibleInContainer)

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -18,7 +18,7 @@
 EZ_IMPLEMENT_SINGLETON(ezQtUiServices);
 
 ezEvent<const ezQtUiServices::Event&, ezMutex> ezQtUiServices::s_Events;
-ezEvent<const ezQtUiServices::TickEvent&> ezQtUiServices::s_TickEvent;
+ezCopyOnBroadcastEvent<const ezQtUiServices::TickEvent&> ezQtUiServices::s_TickEvent;
 
 ezMap<ezString, QIcon> ezQtUiServices::s_IconsCache;
 ezMap<ezString, QImage> ezQtUiServices::s_ImagesCache;

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -64,7 +64,7 @@ public:
     mutable ezUInt32 m_uiForceCancelFrame = 0; ///< Only valid for Type::BeforeFrame. Increased by an event handler to cancel the frame. Regardless of m_uiFrameRequest, no frame is started if != zero.
   };
 
-  static ezEvent<const ezQtUiServices::TickEvent&> s_TickEvent;
+  static ezCopyOnBroadcastEvent<const ezQtUiServices::TickEvent&> s_TickEvent;
 
 public:
   ezQtUiServices();


### PR DESCRIPTION
* Improves MCP tools to be able to take editor view captures
* Fixes a crash when modifying an event handler during the event
* Improves error reporting for failed mesh texture import