### PR TITLE
Introduced asset info files

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -8,6 +8,7 @@
 #include <Foundation/Algorithm/HashHelperString.h>
 #include <Foundation/Application/Config/FileSystemConfig.h>
 #include <Foundation/Configuration/Singleton.h>
+#include <Foundation/Containers/Deque.h>
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/IO/DirectoryWatcher.h>
 #include <Foundation/Logging/LogEntry.h>
@@ -18,6 +19,7 @@
 #include <Foundation/Threading/Mutex.h>
 #include <Foundation/Threading/TaskSystem.h>
 #include <Foundation/Time/Timestamp.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <ToolsFoundation/Document/DocumentManager.h>
 #include <ToolsFoundation/FileSystem/DataDirPath.h>
 #include <ToolsFoundation/FileSystem/Declarations.h>
@@ -101,7 +103,32 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
 
   ezSet<ezUuid> m_SubAssets; ///< Main asset uses the same GUID as this (see m_Info), but is NOT stored in m_SubAssets
 
+  /// Returns the values that the last transform recorded. \see ezAssetInfoFile
+  ///
+  /// Returns nullptr when the asset type recorded nothing, when the asset was never transformed, or when the file on
+  /// disk belongs to an older transform.
+  ///
+  /// Only call this while holding the ezAssetCurator lock (see ezLockedSubAsset and ezLockedAssetTable).
+  const ezAssetInfoFile* GetTransformInfo(ezStringView sOutputTag = {}, const ezPlatformProfile* pAssetProfile = nullptr) const;
+
+  /// Drops what GetTransformInfo() cached.
+  void ClearTransformInfoCache() { m_TransformInfoCache.Clear(); }
+
 private:
+  // Filled on demand by GetTransformInfo(). Mutable, because reading a file lazily is not a logical change to the asset.
+  // Keyed by everything that selects a different file: an asset type that transforms per profile has one file per profile.
+  struct TransformInfoCache
+  {
+    ezUInt64 m_uiAssetHash = 0;
+    ezString m_sOutputTag;
+    const ezPlatformProfile* m_pAssetProfile = nullptr;
+    bool m_bValid = false; ///< Whether a file was found. A miss is cached too, so it is not retried on every call.
+    ezAssetInfoFile m_Info;
+  };
+
+  // A deque, so that adding an entry does not invalidate pointers that GetTransformInfo() handed out earlier.
+  mutable ezDeque<TransformInfoCache> m_TransformInfoCache;
+
   EZ_DISALLOW_COPY_AND_ASSIGN(ezAssetInfo);
 };
 

--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -4,6 +4,7 @@
 #include <EditorFramework/Assets/Declarations.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/IPC/IPCObjectMirrorEditor.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <ToolsFoundation/Document/Document.h>
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
 
@@ -102,6 +103,13 @@ public:
   /// \brief Returns the RTTI type version of this asset document type. E.g. when the algorithm to transform an asset changes,
   /// Increase the RTTI version. This will ensure that assets get re-transformed, even though their settings and dependencies might not have changed.
   ezUInt16 GetAssetTypeVersion() const;
+
+  /// Values that InternalTransformAsset() may fill out, to record facts only known after the transform. \see ezAssetInfoFile
+  ///
+  /// Cleared before each output is generated. Leaving it empty means that no file is written, which is the case for most
+  /// asset types. An asset whose output is produced by an external tool may instead have that tool write the file.
+  ezAssetInfoFile& GetTransformInfo() { return m_TransformInfo; }
+  const ezAssetInfoFile& GetTransformInfo() const { return m_TransformInfo; }
 
   ///@}
   /// \name IPC Functions
@@ -303,4 +311,6 @@ protected:
   mutable ezDeque<ezEditorEngineSyncObject*> m_SyncObjects;
 
   mutable ezHybridArray<ezUuid, 32> m_DeletedObjects;
+
+  ezAssetInfoFile m_TransformInfo;
 };

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
@@ -4,6 +4,7 @@
 #include <EditorFramework/Assets/Declarations.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <Foundation/Types/Status.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <ToolsFoundation/Document/DocumentManager.h>
 
 struct ezSubAsset;
@@ -76,6 +77,15 @@ public:
   virtual ezStringView GetOutputDocumentType(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const { return pTypeDesc->m_sDocumentTypeName; }
 
   virtual bool GeneratesProfileSpecificAssets() const = 0;
+
+  /// Reads the info that the last transform recorded for the given asset output. \see ezAssetInfoFile
+  ///
+  /// Fails if there is no such file, which is the normal case for most asset types, or if it is stale. Treat a failure
+  /// as 'no information available' rather than as an error.
+  ezResult ReadAssetInfoFile(ezAssetInfoFile& out_info, const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sDocumentPath, ezUInt64 uiHash, ezStringView sOutputTag = {}, const ezPlatformProfile* pAssetProfile = nullptr) const;
+
+  /// Override this to append the values from an ezAssetInfoFile that are worth showing at a glance, e.g. in a tooltip.
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const {}
 
   bool IsOutputUpToDate(ezStringView sDocumentPath, const ezDynamicArray<ezString>& outputs, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
   virtual bool IsOutputUpToDate(ezStringView sDocumentPath, ezStringView sOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -4,6 +4,7 @@
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocumentGenerator.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <GuiFoundation/UIServices/ImageCache.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 
@@ -598,6 +599,15 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int iRole) const
             break;
           default:
             break;
+        }
+
+        // What the last transform measured, e.g. the triangle count and size of a mesh.
+        if (pSubAsset->m_bMainAsset)
+        {
+          if (const ezAssetInfoFile* pInfo = pSubAsset->m_pAssetInfo->GetTransformInfo())
+          {
+            pSubAsset->m_pAssetInfo->GetManager()->AppendAssetInfoSummary(sToolTip, *pInfo);
+          }
         }
 
         return QString::fromUtf8(sToolTip, sToolTip.GetElementCount());

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -70,7 +70,60 @@ void ezAssetInfo::Update(ezUniquePtr<ezAssetInfo>& rhs)
   m_MissingPackageDeps = std::move(rhs->m_MissingPackageDeps);
   m_CircularDependencies = std::move(rhs->m_CircularDependencies);
   // Don't copy m_SubAssets, we want to update it independently.
+
+  // Not copied from rhs, which never has one: anything cached may belong to a previous transform.
+  ClearTransformInfoCache();
+
   rhs = nullptr;
+}
+
+const ezAssetInfoFile* ezAssetInfo::GetTransformInfo(ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const
+{
+  // Nothing was transformed yet, so there is nothing to describe, and no path to read from either.
+  if (m_pDocumentTypeDescriptor == nullptr || m_AssetHash == 0)
+    return nullptr;
+
+  // Resolved here, so that a null profile and an explicit pointer to the same profile share one entry.
+  const ezPlatformProfile* pProfile = ezAssetDocumentManager::DetermineFinalTargetProfile(pAssetProfile);
+
+  TransformInfoCache* pEntry = nullptr;
+
+  for (TransformInfoCache& cache : m_TransformInfoCache)
+  {
+    if (cache.m_pAssetProfile == pProfile && cache.m_sOutputTag == sOutputTag)
+    {
+      // A hit for the current hash. Otherwise the entry is stale and is overwritten below, rather than
+      // added to, so that the cache cannot grow with every transform.
+      if (cache.m_uiAssetHash == m_AssetHash)
+        return cache.m_bValid ? &cache.m_Info : nullptr;
+
+      pEntry = &cache;
+      break;
+    }
+  }
+
+  if (pEntry == nullptr)
+  {
+    pEntry = &m_TransformInfoCache.ExpandAndGetRef();
+  }
+
+  pEntry->m_uiAssetHash = m_AssetHash;
+  pEntry->m_sOutputTag = sOutputTag;
+  pEntry->m_pAssetProfile = pProfile;
+
+  ezAssetDocumentManager* pManager = static_cast<ezAssetDocumentManager*>(m_pDocumentTypeDescriptor->m_pManager);
+
+  // A failure is the normal case, so it is cached as well, otherwise every call would try to open a
+  // file that is known not to be there.
+  pEntry->m_bValid = pManager->ReadAssetInfoFile(pEntry->m_Info, m_pDocumentTypeDescriptor, m_Path, m_AssetHash, sOutputTag, pProfile).Succeeded();
+
+  if (!pEntry->m_bValid)
+  {
+    pEntry->m_Info.Clear();
+    return nullptr;
+  }
+
+  return &pEntry->m_Info;
 }
 
 ezStringView ezSubAsset::GetName() const

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -497,13 +497,31 @@ ezTransformStatus ezAssetDocument::DoTransformAsset(const ezPlatformProfile* pAs
     auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus
     {
       const ezString sTargetFile = GetAssetDocumentManager()->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), szOutputTag, pAssetProfile);
+
+      m_TransformInfo.Clear();
+
       ezTransformStatus ret = InternalTransformAsset(sTargetFile, szOutputTag, pAssetProfile, AssetHeader, transformFlags);
+
+      const ezStringBuilder sInfoFile = ezAssetInfoFile::GetInfoFilePathForOutput(sTargetFile);
 
       // if writing failed, make sure the output file does not exist
       if (ret.Failed())
       {
         ezFileSystem::DeleteFile(sTargetFile);
+        ezOSFile::DeleteFile(sInfoFile).IgnoreResult();
       }
+      else if (!m_TransformInfo.IsEmpty())
+      {
+        // An empty map is left alone rather than deleting the file, because some asset types have the
+        // external tool that generates the output write this file directly (e.g. TexConv).
+        if (m_TransformInfo.WriteToFile(sInfoFile, AssetHeader).Failed())
+        {
+          ezLog::Warning("Failed to write asset info file '{}'", sInfoFile);
+        }
+      }
+
+      m_TransformInfo.Clear();
+
       ezAssetCurator::GetSingleton()->NotifyOfFileChange(sTargetFile);
       return ret;
     };

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentManager.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentManager.cpp
@@ -149,6 +149,14 @@ ezString ezAssetDocumentManager::GetRelativeOutputFileName(const ezAssetDocument
   return sRelativePath;
 }
 
+ezResult ezAssetDocumentManager::ReadAssetInfoFile(ezAssetInfoFile& out_info, const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sDocumentPath, ezUInt64 uiHash, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const
+{
+  const ezString sOutputFile = GetAbsoluteOutputFileName(pTypeDesc, sDocumentPath, sOutputTag, pAssetProfile);
+  const ezStringBuilder sInfoFile = ezAssetInfoFile::GetInfoFilePathForOutput(sOutputFile);
+
+  return out_info.ReadFromFile(sInfoFile, uiHash, static_cast<ezUInt16>(pTypeDesc->m_pDocumentType->GetTypeVersion()));
+}
+
 bool ezAssetDocumentManager::IsOutputUpToDate(ezStringView sDocumentPath, const ezDynamicArray<ezString>& outputs, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor)
 {
   CURATOR_PROFILE(sDocumentPath);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -614,6 +614,7 @@ void ezAssetCurator::InvalidateAssetTransformState(const ezUuid& assetGuid)
       pAssetInfo->m_AssetHash = 0;
       pAssetInfo->m_ThumbHash = 0;
       pAssetInfo->m_PackageHash = 0;
+      pAssetInfo->ClearTransformInfoCache();
     }
   }
 }

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
@@ -116,6 +116,14 @@ void ezQtDynamicStringEnumPropertyWidget::onMenuAboutToShow()
     [this](const QString& sText)
     { s_LastSearch[m_sEnumAttribute] = sText; });
 
+  {
+    ezDynamicStringEnum::RefreshValuesEvent e;
+    e.m_sEnumName = m_sEnumAttribute;
+    e.m_pDocument = m_pGrid->GetDocument();
+    e.m_pEnum = m_pEnum;
+    ezDynamicStringEnum::s_RefreshValuesEvent.Broadcast(e);
+  }
+
   const auto& AllValues = m_pEnum->GetAllValidValues();
 
   for (const auto& val : AllValues)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -7,7 +7,7 @@
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetDocument, 9, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetDocument, 10, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
@@ -45,6 +45,8 @@ ezTransformStatus ezAnimatedMeshAssetDocument::InternalTransformAsset(ezStreamWr
   }
 
   desc.Save(stream);
+
+  ezMeshImportUtils::RecordMeshTransformInfo(GetTransformInfo(), desc);
 
   return ezStatus(EZ_SUCCESS);
 }
@@ -108,6 +110,8 @@ ezStatus ezAnimatedMeshAssetDocument::CreateMeshFromFile(ezAnimatedMeshAssetProp
 
   if (pImporter->Import(opt).Failed())
     return ezStatus("Model importer was unable to read this asset.");
+
+  ezMeshImportUtils::RecordAvailableMeshes(GetTransformInfo(), pImporter.Borrow());
 
   if (desc.GetSubMeshes().IsEmpty() || !desc.GetBounds().IsValid())
     return ezStatus("Imported mesh is empty.");

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -55,3 +55,9 @@ void ezAnimatedMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDyn
 {
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
+
+void ezAnimatedMeshAssetDocumentManager::AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix) const
+{
+  const ezStringView keys[] = {ezAssetInfoFile::Keys::NumTriangles, ezAssetInfoFile::Keys::BoundsHalfExtents};
+  info.AppendValuesToDisplayString(ref_sOut, keys, sLinePrefix);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
@@ -18,6 +18,7 @@ private:
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const override;
 
   ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -1,7 +1,9 @@
 #include <EditorPluginAssets/EditorPluginAssetsPCH.h>
 
 #include <EditorFramework/Assets/AssetBrowserDlg.moc.h>
+#include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <Foundation/Utilities/Progress.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/UIServices/DynamicStringEnum.h>
@@ -38,7 +40,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 4, ezRTTIDefault
   {
     EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Animation", ezFileBrowserAttribute::MeshesWithAnimations), new ezRequiredAttribute()),
     EZ_MEMBER_PROPERTY("PreviewMesh", m_sPreviewMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned", ezDependencyFlags::Thumbnail)),
-    EZ_MEMBER_PROPERTY("UseAnimationClip", m_sAnimationClipToExtract),
+    // \see ezAnimationClipAssetDocument::OnRefreshDynamicStringEnum()
+    EZ_MEMBER_PROPERTY("UseAnimationClip", m_sAnimationClipToExtract)->AddAttributes(new ezDynamicStringEnumAttribute("AnimationClipsInSourceFile")),
     EZ_MEMBER_PROPERTY("FirstFrame", m_uiFirstFrame),
     EZ_MEMBER_PROPERTY("NumFrames", m_uiNumFrames),
     EZ_MEMBER_PROPERTY("Additive", m_bAdditive),
@@ -49,19 +52,49 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 4, ezRTTIDefault
     EZ_MEMBER_PROPERTY("RootMotionDistance", m_fConstantRootMotionLength),
     EZ_MEMBER_PROPERTY("AdjustScale", m_fAnimationPositionScale)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0001f, 10000.0f), new ezGroupAttribute("Adjustments")),
     EZ_ARRAY_MEMBER_PROPERTY("Curves", m_Curves),
-    EZ_ARRAY_MEMBER_PROPERTY("AvailableClips", m_AvailableClips)->AddAttributes(new ezReadOnlyAttribute, new ezTemporaryAttribute(), new ezContainerAttribute(false, false, false), new ezGroupAttribute("Infos")),
     EZ_MEMBER_PROPERTY("EventTrack", m_EventTrack)->AddAttributes(new ezHiddenAttribute()),
   }
   EZ_END_PROPERTIES;
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetDocument, 5, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetDocument, 6, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezAnimationClipAssetProperties::ezAnimationClipAssetProperties() = default;
 ezAnimationClipAssetProperties::~ezAnimationClipAssetProperties() = default;
+
+void ezAnimationClipAssetDocument::OnRefreshDynamicStringEnum(ezDynamicStringEnum::RefreshValuesEvent& e)
+{
+  if (e.m_sEnumName != "AnimationClipsInSourceFile"_ezsv)
+    return;
+
+  e.m_pEnum->Clear();
+
+  if (e.m_pDocument == nullptr)
+    return;
+
+  const ezAssetCurator::ezLockedSubAsset asset = ezAssetCurator::GetSingleton()->GetSubAsset(e.m_pDocument->GetGuid());
+
+  if (!asset.isValid())
+    return;
+
+  const ezAssetInfoFile* pInfo = asset->m_pAssetInfo->GetTransformInfo();
+
+  if (pInfo == nullptr)
+    return;
+
+  const ezVariant clips = pInfo->GetValue(ezAssetInfoFile::Keys::AvailableClips);
+
+  if (!clips.IsA<ezVariantArray>())
+    return;
+
+  for (const ezVariant& clip : clips.Get<ezVariantArray>())
+  {
+    e.m_pEnum->AddValidValue(clip.ConvertTo<ezString>());
+  }
+}
 
 void ezAnimationClipAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e)
 {
@@ -187,17 +220,19 @@ ezTransformStatus ezAnimationClipAssetDocument::InternalTransformAsset(ezStreamW
     EZ_SUCCEED_OR_RETURN(desc.Serialize(stream));
   }
 
-  // if we found information about animation clips, update the UI, even if the transform failed
+  // Fills the drop down of the 'UseAnimationClip' property, so that a clip can be picked without
+  // opening the source file again.
   if (!pImporter->m_OutputAnimationNames.IsEmpty())
   {
-    pProp->m_AvailableClips.SetCount(pImporter->m_OutputAnimationNames.GetCount());
-    for (ezUInt32 clip = 0; clip < pImporter->m_OutputAnimationNames.GetCount(); ++clip)
+    ezVariantArray clipNames;
+    clipNames.Reserve(pImporter->m_OutputAnimationNames.GetCount());
+
+    for (const auto& sName : pImporter->m_OutputAnimationNames)
     {
-      pProp->m_AvailableClips[clip] = pImporter->m_OutputAnimationNames[clip];
+      clipNames.PushBack(ezVariant(sName));
     }
 
-    // merge the new data with the actual asset document
-    ApplyNativePropertyChangesToObjectManager(true);
+    GetTransformInfo().SetValue(ezAssetInfoFile::Keys::AvailableClips, ezVariant(clipNames));
   }
 
   if (res.Failed())

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -3,6 +3,7 @@
 #include <EditorFramework/Assets/AssetDocumentGenerator.h>
 #include <EditorFramework/Assets/SimpleAssetDocument.h>
 #include <Foundation/Tracks/CurveEditData.h>
+#include <GuiFoundation/UIServices/DynamicStringEnum.h>
 #include <GuiFoundation/Widgets/EventTrackEditData.h>
 
 class ezAnimationClipAssetDocument;
@@ -68,7 +69,6 @@ public:
 
   ezString m_sSourceFile;
   ezString m_sAnimationClipToExtract;
-  ezDynamicArray<ezString> m_AvailableClips;
   bool m_bAdditive = false;
   ezUInt32 m_uiFirstFrame = 0;
   ezUInt32 m_uiNumFrames = 0;
@@ -99,6 +99,11 @@ public:
   virtual double GetCommonAssetUiState(ezCommonAssetUiState::Enum state) const override;
 
   ezUuid InsertEventTrackCpAt(ezInt64 iTickX, const char* szValue);
+
+  /// Fills the 'AnimationClipsInSourceFile' enum with the clips that the last transform found.
+  ///
+  /// Subscribed to ezDynamicStringEnum::s_RefreshValuesEvent, so that the values match the document being shown.
+  static void OnRefreshDynamicStringEnum(ezDynamicStringEnum::RefreshValuesEvent& e);
 
 protected:
   virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -281,6 +281,7 @@ static void ConfigureAnimationClipAsset()
   ezAnimationClipActions::RegisterActions();
 
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezAnimationClipAssetProperties::PropertyMetaStateEventHandler);
+  ezDynamicStringEnum::s_RefreshValuesEvent.AddEventHandler(ezAnimationClipAssetDocument::OnRefreshDynamicStringEnum);
 
   // Menu Bar
   {
@@ -471,6 +472,7 @@ void OnUnloadPlugin()
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezMaterialAssetProperties::PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezSkeletonAssetDocument::PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezAnimationClipAssetProperties::PropertyMetaStateEventHandler);
+  ezDynamicStringEnum::s_RefreshValuesEvent.RemoveEventHandler(ezAnimationClipAssetDocument::OnRefreshDynamicStringEnum);
 }
 
 EZ_PLUGIN_ON_LOADED()

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -8,7 +8,7 @@
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetDocument, 14, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetDocument, 15, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
@@ -63,9 +63,10 @@ ezTransformStatus ezMeshAssetDocument::InternalTransformAsset(ezStreamWriter& st
   range.BeginNextStep("Writing Result");
   desc.Save(stream);
 
+  ezMeshImportUtils::RecordMeshTransformInfo(GetTransformInfo(), desc);
+
   return ezStatus(EZ_SUCCESS);
 }
-
 
 void ezMeshAssetDocument::CreateMeshFromGeom(ezMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc)
 {
@@ -262,6 +263,8 @@ ezTransformStatus ezMeshAssetDocument::CreateMeshFromFile(ezMeshAssetProperties*
 
   if (pImporter->Import(opt).Failed())
     return ezStatus("Model importer was unable to read this asset.");
+
+  ezMeshImportUtils::RecordAvailableMeshes(GetTransformInfo(), pImporter.Borrow());
 
   if (desc.GetSubMeshes().IsEmpty() || !desc.GetBounds().IsValid())
     return ezStatus("Imported mesh is empty.");

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -24,6 +24,7 @@ protected:
   virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   void CreateMeshFromGeom(ezMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc);
+
   ezTransformStatus CreateMeshFromFile(ezMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc, bool bAllowMaterialImport);
 
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -128,3 +128,9 @@ void ezMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArra
 {
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
+
+void ezMeshAssetDocumentManager::AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix) const
+{
+  const ezStringView keys[] = {ezAssetInfoFile::Keys::NumTriangles, ezAssetInfoFile::Keys::BoundsHalfExtents};
+  info.AppendValuesToDisplayString(ref_sOut, keys, sLinePrefix);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
@@ -20,6 +20,7 @@ private:
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const override;
 
 private:
   ezAssetDocumentTypeDescriptor m_DocTypeDesc;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkeletonAssetDocument, 11, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkeletonAssetDocument, 12, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
@@ -156,11 +156,16 @@ void ezSkeletonAssetDocument::PropertyMetaStateEventHandler(ezPropertyMetaStateE
   }
 }
 
-ezStatus ezSkeletonAssetDocument::WriteResource(ezStreamWriter& inout_stream, const ezEditableSkeleton& skeleton) const
+ezStatus ezSkeletonAssetDocument::WriteResource(ezStreamWriter& inout_stream, const ezEditableSkeleton& skeleton, ezUInt16* out_pNumBones) const
 {
   ezSkeletonResourceDescriptor desc;
   desc.m_RootTransform = CalculateTransformationMatrix(&skeleton);
   skeleton.FillResourceDescriptor(desc);
+
+  if (out_pNumBones != nullptr)
+  {
+    *out_pNumBones = desc.m_Skeleton.GetJointCount();
+  }
 
   EZ_SUCCEED_OR_RETURN(desc.Serialize(inout_stream));
 
@@ -306,12 +311,14 @@ ezTransformStatus ezSkeletonAssetDocument::InternalTransformAsset(ezStreamWriter
 
     ezEditableSkeleton* pProp = GetProperties();
 
+    ezUInt16 uiNumBones = 0;
+
     ezStringBuilder sAbsFilename = pProp->m_sSourceFile;
 
     if (sAbsFilename.IsEmpty())
     {
       range.BeginNextStep("Writing Result");
-      EZ_SUCCEED_OR_RETURN(WriteResource(stream, *GetProperties()));
+      EZ_SUCCEED_OR_RETURN(WriteResource(stream, *GetProperties(), &uiNumBones));
     }
     else
     {
@@ -344,11 +351,13 @@ ezTransformStatus ezSkeletonAssetDocument::InternalTransformAsset(ezStreamWriter
       const ezEditableSkeleton* pFinalSkeleton = MergeWithNewSkeleton(newSkeleton);
 
       range.BeginNextStep("Writing Result");
-      EZ_SUCCEED_OR_RETURN(WriteResource(stream, *pFinalSkeleton));
+      EZ_SUCCEED_OR_RETURN(WriteResource(stream, *pFinalSkeleton, &uiNumBones));
 
       // merge the new data with the actual asset document
       ApplyNativePropertyChangesToObjectManager(true);
     }
+
+    GetTransformInfo().SetValue(ezAssetInfoFile::Keys::NumBones, uiNumBones);
   }
 
   ezSkeletonAssetEvent e;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -31,7 +31,7 @@ public:
 
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
-  ezStatus WriteResource(ezStreamWriter& inout_stream, const ezEditableSkeleton& skeleton) const;
+  ezStatus WriteResource(ezStreamWriter& inout_stream, const ezEditableSkeleton& skeleton, ezUInt16* out_pNumBones = nullptr) const;
 
   bool m_bIsTransforming = false;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -55,3 +55,9 @@ void ezSkeletonAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamic
 {
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
+
+void ezSkeletonAssetDocumentManager::AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix) const
+{
+  const ezStringView keys[] = {ezAssetInfoFile::Keys::NumBones};
+  info.AppendValuesToDisplayString(ref_sOut, keys, sLinePrefix);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
@@ -19,6 +19,7 @@ private:
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const override;
 
 private:
   ezAssetDocumentTypeDescriptor m_DocTypeDesc;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -6,7 +6,7 @@
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureAssetDocument, 6, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureAssetDocument, 7, ezRTTINoAllocator)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -173,6 +173,13 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
 
   arguments << "-out";
   arguments << szTargetFile;
+
+  // TexConv writes this itself, because only it knows the resolution and format it chose.
+  {
+    const ezStringBuilder sInfoFile = ezAssetInfoFile::GetInfoFilePathForOutput(szTargetFile);
+    arguments << "-assetInfoOut";
+    arguments << sInfoFile.GetData();
+  }
 
   const ezStringBuilder sThumbnail = GetThumbnailFilePath();
   if (bUpdateThumbnail)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -118,3 +118,9 @@ ezString ezTextureAssetDocumentManager::GetRelativeOutputFileName(const ezAssetD
 
   return SUPER::GetRelativeOutputFileName(pTypeDescriptor, sDataDirectory, sDocumentPath, sOutputTag, pAssetProfile);
 }
+
+void ezTextureAssetDocumentManager::AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix) const
+{
+  const ezStringView keys[] = {ezAssetInfoFile::Keys::ImageWidth, ezAssetInfoFile::Keys::Format};
+  info.AppendValuesToDisplayString(ref_sOut, keys, sLinePrefix);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
@@ -31,6 +31,7 @@ private:
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const override;
 
   virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -58,6 +58,12 @@ ezStatus ezTextureCubeAssetDocument::RunTexConv(const char* szTargetFile, const 
   arguments << "-out";
   arguments << szTargetFile;
 
+  {
+    const ezStringBuilder sInfoFile = ezAssetInfoFile::GetInfoFilePathForOutput(szTargetFile);
+    arguments << "-assetInfoOut";
+    arguments << sInfoFile.GetData();
+  }
+
   const ezStringBuilder sThumbnail = GetThumbnailFilePath();
   if (bUpdateThumbnail)
   {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -66,3 +66,9 @@ ezUInt64 ezTextureCubeAssetDocumentManager::ComputeAssetProfileHashImpl(const ez
   // don't have any settings yet, but assets that generate profile specific output must not return 0 here
   return 1;
 }
+
+void ezTextureCubeAssetDocumentManager::AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix) const
+{
+  const ezStringView keys[] = {ezAssetInfoFile::Keys::ImageWidth, ezAssetInfoFile::Keys::Format};
+  info.AppendValuesToDisplayString(ref_sOut, keys, sLinePrefix);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
@@ -21,6 +21,7 @@ private:
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const override;
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
@@ -7,6 +7,7 @@
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/JSONReader.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <Foundation/Utilities/Progress.h>
 #include <ModelImporter2/Importer/Importer.h>
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
@@ -208,6 +209,40 @@ namespace ezMeshImportUtils
     {
       ref_desc.SetMaterial(i, materialSlots[i].m_sResource);
     }
+  }
+
+  void RecordMeshTransformInfo(ezAssetInfoFile& ref_info, const ezMeshResourceDescriptor& desc)
+  {
+    const auto& mbd = desc.MeshBufferDesc();
+
+    ref_info.SetValue(ezAssetInfoFile::Keys::NumVertices, mbd.GetVertexCount());
+    ref_info.SetValue(ezAssetInfoFile::Keys::NumTriangles, mbd.GetPrimitiveCount());
+    ref_info.SetValue(ezAssetInfoFile::Keys::NumSubMeshes, desc.GetSubMeshes().GetCount());
+
+    const ezBoundingBoxSphere& bounds = desc.GetBounds();
+
+    if (bounds.IsValid())
+    {
+      ref_info.SetValue(ezAssetInfoFile::Keys::BoundsCenter, bounds.m_vCenter);
+      ref_info.SetValue(ezAssetInfoFile::Keys::BoundsHalfExtents, bounds.m_vBoxHalfExtents);
+      ref_info.SetValue(ezAssetInfoFile::Keys::BoundsRadius, bounds.m_fSphereRadius);
+    }
+  }
+
+  void RecordAvailableMeshes(ezAssetInfoFile& ref_info, const ezModelImporter2::Importer* pImporter)
+  {
+    if (pImporter == nullptr || pImporter->m_OutputMeshNames.IsEmpty())
+      return;
+
+    ezVariantArray meshNames;
+    meshNames.Reserve(pImporter->m_OutputMeshNames.GetCount());
+
+    for (const auto& sName : pImporter->m_OutputMeshNames)
+    {
+      meshNames.PushBack(ezVariant(sName));
+    }
+
+    ref_info.SetValue(ezAssetInfoFile::Keys::AvailableMeshes, ezVariant(meshNames));
   }
 
   static void ImportMeshAssetMaterialProperties(ezMaterialAssetDocument* pMaterialDoc, const ezModelImporter2::OutputMaterial& material, const char* szImportSourceFolder, const char* szImportTargetFolder, const ezModelImporter2::Importer* pImporter)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.h
@@ -5,6 +5,7 @@
 #include <RendererCore/Meshes/MeshBufferUtils.h>
 
 class ezMeshResourceDescriptor;
+class ezAssetInfoFile;
 
 namespace ezModelImporter2
 {
@@ -19,6 +20,14 @@ namespace ezMeshImportUtils
   EZ_EDITORPLUGINASSETS_DLL void SetMeshAssetMaterialSlots(ezDynamicArray<ezMaterialResourceSlot>& inout_materialSlots, const ezModelImporter2::Importer* pImporter);
   EZ_EDITORPLUGINASSETS_DLL void CopyMeshAssetMaterialSlotToResource(ezMeshResourceDescriptor& ref_desc, const ezArrayPtr<ezMaterialResourceSlot>& materialSlots);
   EZ_EDITORPLUGINASSETS_DLL void ImportMeshAssetMaterials(ezDynamicArray<ezMaterialResourceSlot>& inout_materialSlots, ezStringView sDocumentDirectory, const ezModelImporter2::Importer* pImporter);
+
+  /// Records vertex and triangle counts, sub-mesh count and the bounding box of a transformed mesh.
+  ///
+  /// Call this after the descriptor has been saved, because saving computes the bounds if they were not set explicitly.
+  EZ_EDITORPLUGINASSETS_DLL void RecordMeshTransformInfo(ezAssetInfoFile& ref_info, const ezMeshResourceDescriptor& desc);
+
+  /// Records the names of the meshes that the source file contains.
+  EZ_EDITORPLUGINASSETS_DLL void RecordAvailableMeshes(ezAssetInfoFile& ref_info, const ezModelImporter2::Importer* pImporter);
 
   /// \brief Extracts external buffer file dependencies from a glTF file and adds them to the transform dependencies set.
   ///

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -4,6 +4,7 @@
 #include <EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <Foundation/Utilities/GraphicsUtils.h>
 #include <Foundation/Utilities/Progress.h>
 #include <JoltPlugin/Resources/JoltMeshResourceWriter.h>
@@ -15,9 +16,26 @@
 #endif
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetDocument, 10, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetDocument, 11, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
+
+static ezStringView ezJoltMeshTypeToString(ezJoltMeshDesc::Type type)
+{
+  switch (type)
+  {
+    case ezJoltMeshDesc::Type::Triangle:
+      return "Triangle"_ezsv;
+    case ezJoltMeshDesc::Type::ConvexHull:
+      return "ConvexHull"_ezsv;
+    case ezJoltMeshDesc::Type::ConvexDecomposition:
+      return "ConvexDecomposition"_ezsv;
+    case ezJoltMeshDesc::Type::ConvexHullGroup:
+      return "ConvexHullGroup"_ezsv;
+  }
+
+  return "Unknown"_ezsv;
+}
 
 static ezMat3 CalculateTransformationMatrix(const ezJoltCollisionMeshAssetProperties* pProp)
 {
@@ -163,13 +181,49 @@ ezTransformStatus ezJoltCollisionMeshAssetDocument::InternalTransformAsset(ezStr
     }
   }
 
+  // Surfaces and bounds are properties of the input mesh and do not change during cooking. The vertex
+  // and triangle counts are taken from the cooking statistics below instead. \see ezJoltCookedMeshStats
+  {
+    ezAssetInfoFile& info = GetTransformInfo();
+    info.SetValue(ezAssetInfoFile::Keys::NumSurfaces, meshDesc.m_Surfaces.GetCount());
+    info.SetValue(ezAssetInfoFile::Keys::CollisionMeshType, ezJoltMeshTypeToString(meshDesc.m_Type));
+
+    if (!meshDesc.m_Vertices.IsEmpty())
+    {
+      const ezBoundingBoxSphere bounds = ezBoundingBoxSphere::MakeFromPoints(meshDesc.m_Vertices.GetData(), meshDesc.m_Vertices.GetCount());
+
+      if (bounds.IsValid())
+      {
+        info.SetValue(ezAssetInfoFile::Keys::BoundsCenter, bounds.m_vCenter);
+        info.SetValue(ezAssetInfoFile::Keys::BoundsHalfExtents, bounds.m_vBoxHalfExtents);
+        info.SetValue(ezAssetInfoFile::Keys::BoundsRadius, bounds.m_fSphereRadius);
+      }
+    }
+  }
+
   // Please check that the code here is in sync with ezJoltMeshResourceWriter::WriteMeshResource()
-  EZ_ASSERT_DEV(AssetHeader.GetFileVersion() == 10, "Version change");
+  EZ_ASSERT_DEV(AssetHeader.GetFileVersion() == 11, "Version change");
 
   range.BeginNextStep("Writing Result");
 
   const bool bWriteAssetHeader = false; // already written outside of InternalTransformAsset
-  return ezJoltMeshResourceWriter::WriteMeshResource(std::move(meshDesc), stream, bWriteAssetHeader);
+
+  ezJoltCookedMeshStats stats;
+  EZ_SUCCEED_OR_RETURN(ezJoltMeshResourceWriter::WriteMeshResource(std::move(meshDesc), stream, bWriteAssetHeader, 0, &stats));
+
+  {
+    ezAssetInfoFile& info = GetTransformInfo();
+    info.SetValue(ezAssetInfoFile::Keys::NumVertices, stats.m_uiNumVertices);
+    info.SetValue(ezAssetInfoFile::Keys::NumTriangles, stats.m_uiNumTriangles);
+
+    // Only interesting when the mesh was split into several hulls.
+    if (stats.m_uiNumParts > 1)
+    {
+      info.SetValue(ezAssetInfoFile::Keys::NumConvexParts, stats.m_uiNumParts);
+    }
+  }
+
+  return ezStatus(EZ_SUCCESS);
 }
 
 ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltMeshDesc& outMesh)
@@ -226,6 +280,8 @@ ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltMeshDesc& ou
 
   if (pImporter->Import(opt).Failed())
     return ezStatus("Model importer was unable to read this asset.");
+
+  ezMeshImportUtils::RecordAvailableMeshes(GetTransformInfo(), pImporter.Borrow());
 
   const auto& meshBuffer = meshDesc.MeshBufferDesc();
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.cpp
@@ -79,3 +79,9 @@ ezUInt64 ezJoltCollisionMeshAssetDocumentManager::ComputeAssetProfileHashImpl(co
   // don't have any settings yet, but assets that generate profile specific output must not return 0 here
   return 1;
 }
+
+void ezJoltCollisionMeshAssetDocumentManager::AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix) const
+{
+  const ezStringView keys[] = {ezAssetInfoFile::Keys::CollisionMeshType, ezAssetInfoFile::Keys::NumConvexParts, ezAssetInfoFile::Keys::NumTriangles};
+  info.AppendValuesToDisplayString(ref_sOut, keys, sLinePrefix);
+}

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.h
@@ -19,6 +19,7 @@ private:
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
+  virtual void AppendAssetInfoSummary(ezStringBuilder& ref_sOut, const ezAssetInfoFile& info, ezStringView sLinePrefix = "\n"_ezsv) const override;
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/AssetTool.cpp
@@ -5,6 +5,7 @@
 #include <Mcp/McpJsonWriter.h>
 #include <Mcp/McpTranslation.h>
 
+#include <Core/Configuration/PlatformProfile.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocumentGenerator.h>
 #include <EditorFramework/Assets/AssetProcessor.h>
@@ -410,10 +411,19 @@ void ezMcpAssetTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools)
     desc.m_sDescription = "Returns the details of one asset: its absolute and relative paths, type, transform state, tags, "
                           "sub-assets, its dependencies, a link to the documentation of its type, and - if the last transform "
                           "failed - the log messages explaining why. "
-                          "The log messages are the reason to call this on a broken asset instead of searching the editor log.";
+                          "The log messages are the reason to call this on a broken asset instead of searching the editor log. "
+                          "For some asset types an 'info' object reports what the last transform measured, e.g. 'Triangles', "
+                          "'Vertices' and the bounding box ('Center' and 'Extents', so the full size is twice "
+                          "the extents) for a mesh, or 'Width', 'Height' and 'Format' for a texture. Use this to size a "
+                          "collider to a mesh instead of parsing the source file. It is absent when the asset type records "
+                          "nothing or the asset has not been transformed yet. "
+                          "Some asset types produce different output per asset profile, most notably textures, whose format and "
+                          "resolution are chosen per profile. For those the 'info' object carries an 'assetProfile' field naming "
+                          "the profile the values belong to.";
     desc.m_sInputSchema = R"({"type":"object","properties":{)"
                           R"("asset":{"type":"string","description":"The asset GUID or its path, as returned by asset_find. Either form works."},)"
-                          R"("dependencies":{"type":"boolean","description":"If true, include the transform, thumbnail and package dependency lists. Default true. Set to false on assets with many references to keep the result small."})"
+                          R"("dependencies":{"type":"boolean","description":"If true, include the transform, thumbnail and package dependency lists. Default true. Set to false on assets with many references to keep the result small."},)"
+                          R"("profile":{"type":"string","description":"Name of the asset profile to report the 'info' values for, for asset types that transform differently per profile. Defaults to the editor's active profile. A profile that has never been transformed has no values to report."})"
                           R"(},"required":["asset"]})";
   }
 
@@ -988,6 +998,37 @@ void ezMcpAssetTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpTool
   }
 
   const bool bDependencies = ezMcpJson::GetBool(arguments, "dependencies", true);
+
+  // Null means 'the active profile', which DetermineFinalTargetProfile() resolves it to later.
+  const ezPlatformProfile* pRequestedProfile = nullptr;
+
+  if (const ezStringView sProfile = ezMcpJson::GetString(arguments, "profile"); !sProfile.IsEmpty())
+  {
+    ezStringBuilder sKnownProfiles;
+
+    for (ezUInt32 i = 0; i < pCurator->GetNumAssetProfiles(); ++i)
+    {
+      const ezPlatformProfile* pCandidate = pCurator->GetAssetProfile(i);
+
+      if (pCandidate->GetConfigName().IsEqual_NoCase(sProfile))
+      {
+        pRequestedProfile = pCandidate;
+        break;
+      }
+
+      sKnownProfiles.AppendWithSeparator(", ", pCandidate->GetConfigName());
+    }
+
+    // Falling back to the active profile would look plausible while being about the wrong platform.
+    if (pRequestedProfile == nullptr)
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("There is no asset profile named '{}'. Known profiles: {}.", sProfile, sKnownProfiles);
+      out_result.SetError(sError);
+      return;
+    }
+  }
+
   const ezAssetInfo* pAssetInfo = asset->m_pAssetInfo;
 
   ezMcpJsonWriter writer;
@@ -1022,6 +1063,34 @@ void ezMcpAssetTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpTool
       WriteStringSet(writer, "transformDependencies", pInfo->m_TransformDependencies);
       WriteStringSet(writer, "thumbnailDependencies", pInfo->m_ThumbnailDependencies);
       WriteStringSet(writer, "packageDependencies", pInfo->m_PackageDependencies);
+    }
+  }
+
+  // Facts recorded by the last transform. Most asset types record nothing, so this is frequently absent.
+  if (pAssetInfo->m_pDocumentTypeDescriptor != nullptr && pAssetInfo->m_AssetHash != 0)
+  {
+    if (auto* pManager = static_cast<ezAssetDocumentManager*>(pAssetInfo->m_pDocumentTypeDescriptor->m_pManager))
+    {
+      // Some asset types transform differently per profile, and then these values describe one profile only.
+      const ezPlatformProfile* pProfile = ezAssetDocumentManager::DetermineFinalTargetProfile(pRequestedProfile);
+
+      if (const ezAssetInfoFile* pAssetInfoFile = pAssetInfo->GetTransformInfo({}, pProfile))
+      {
+        writer.BeginObject("info");
+
+        // Named explicitly, so that a profile specific value is not read as if it were the only answer.
+        if (pManager->GeneratesProfileSpecificAssets() && pProfile != nullptr)
+        {
+          writer.AddVariableString("assetProfile", pProfile->GetConfigName());
+        }
+
+        for (auto it = pAssetInfoFile->GetValues().GetIterator(); it.IsValid(); ++it)
+        {
+          writer.AddVariableVariant(it.Key(), it.Value());
+        }
+
+        writer.EndObject();
+      }
     }
   }
 

--- a/Code/Engine/Foundation/Utilities/AssetInfoFile.h
+++ b/Code/Engine/Foundation/Utilities/AssetInfoFile.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <Foundation/Containers/Map.h>
+#include <Foundation/Strings/String.h>
+#include <Foundation/Types/Variant.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
+
+/// Key/value pairs describing the result of an asset transform, e.g. the vertex count of a mesh or the format of a texture.
+///
+/// Written as OpenDDL text next to the transformed output in the AssetCache folder. The file records the hash and type
+/// version of the output it belongs to, so that a stale file can be detected like a stale output.
+///
+/// Most assets record nothing and therefore have no such file at all, so a missing file is not an error.
+///
+/// Values are untyped, because the file is written by several tools (editor, editor processor, TexConv) and consumed
+/// generically. Use the key names below where they apply.
+class EZ_FOUNDATION_DLL ezAssetInfoFile
+{
+public:
+  /// Key names used across multiple asset types. Asset types may add arbitrary further keys.
+  ///
+  /// Must be valid DDL identifiers, because that is what they become in the file. For display they are run through
+  /// ezTranslate, which splits CamelCase into words, so "ConvexParts" shows up as "Convex Parts".
+  struct Keys
+  {
+    static constexpr ezStringView NumVertices = "Vertices"_ezsv;            ///< ezUInt32
+    static constexpr ezStringView NumTriangles = "Triangles"_ezsv;          ///< ezUInt32
+    static constexpr ezStringView NumSubMeshes = "Meshes"_ezsv;             ///< ezUInt32
+    static constexpr ezStringView NumSurfaces = "Surfaces"_ezsv;            ///< ezUInt32
+    static constexpr ezStringView NumBones = "Bones"_ezsv;                  ///< ezUInt32
+    static constexpr ezStringView BoundsCenter = "Center"_ezsv;             ///< ezVec3, shown together with Extents as the resulting range
+    static constexpr ezStringView BoundsHalfExtents = "Extents"_ezsv;       ///< ezVec3, so the full size is twice this
+    static constexpr ezStringView BoundsRadius = "Radius"_ezsv;             ///< float
+    static constexpr ezStringView ImageWidth = "Width"_ezsv;                ///< ezUInt32, shown together with Height as the resolution
+    static constexpr ezStringView ImageHeight = "Height"_ezsv;              ///< ezUInt32
+    static constexpr ezStringView Format = "Format"_ezsv;                   ///< ezString
+    static constexpr ezStringView CollisionMeshType = "CollisionMesh"_ezsv; ///< ezString, e.g. "Triangle" or "ConvexHull"
+    static constexpr ezStringView NumConvexParts = "ConvexParts"_ezsv;      ///< ezUInt32, only recorded when there is more than one
+    static constexpr ezStringView AvailableClips = "Clips"_ezsv;            ///< ezVariantArray of ezString: animation clip names in the source file
+    static constexpr ezStringView AvailableMeshes = "MeshesInSource"_ezsv;  ///< ezVariantArray of ezString: mesh names in the source file
+  };
+
+  /// Adds or overwrites a value. An invalid value removes the key.
+  void SetValue(ezStringView sKey, const ezVariant& value);
+
+  /// Returns an invalid variant if the key does not exist.
+  ezVariant GetValue(ezStringView sKey) const;
+
+  bool IsEmpty() const { return m_Values.IsEmpty(); }
+  void Clear() { m_Values.Clear(); }
+
+  const ezMap<ezString, ezVariant>& GetValues() const { return m_Values; }
+
+  /// Writes the values and the header as OpenDDL.
+  ///
+  /// Always writes, even when the map is empty. Prefer WriteToFile(), which skips empty maps.
+  ezResult Write(ezStreamWriter& inout_stream, const ezAssetFileHeader& header) const;
+
+  /// Discards previous content. Values whose type this build cannot represent are skipped individually.
+  ezResult Read(ezStreamReader& inout_stream, ezAssetFileHeader& out_header);
+
+  /// Writes the file, or deletes any existing one if there is nothing to write.
+  ezResult WriteToFile(ezStringView sAbsolutePath, const ezAssetFileHeader& header) const;
+
+  /// Fails if the file does not exist, or if it was written for a different hash or type version, ie. if it is stale.
+  ezResult ReadFromFile(ezStringView sAbsolutePath, ezUInt64 uiExpectedHash, ezUInt16 uiExpectedTypeVersion);
+
+  /// Returns the path of the info file that belongs to the given transform output.
+  static ezStringBuilder GetInfoFilePathForOutput(ezStringView sAbsoluteOutputPath);
+
+  /// Appends all values, one "Name: value" per line, for display in the UI.
+  ///
+  /// Nothing is appended when there are no values, not even a separator. This shows everything, which is a lot for some
+  /// asset types; for a short summary use ezAssetDocumentManager::AppendAssetInfoSummary() instead.
+  void AppendToDisplayString(ezStringBuilder& ref_sOut, ezStringView sLinePrefix = "\n"_ezsv) const;
+
+  /// Appends only the given keys, in the given order. Keys that have no value are skipped.
+  void AppendValuesToDisplayString(ezStringBuilder& ref_sOut, ezArrayPtr<const ezStringView> keys, ezStringView sLinePrefix = "\n"_ezsv) const;
+
+  /// Appends a single value. Returns false if there is nothing to show for that key.
+  ///
+  /// Some keys are formatted together with another one, e.g. ImageWidth prints the full resolution. The absorbed key
+  /// (here ImageHeight) returns false on its own, so iterating over all keys does not print it twice.
+  bool AppendValueToDisplayString(ezStringBuilder& ref_sOut, ezStringView sKey, ezStringView sLinePrefix = "\n"_ezsv) const;
+
+private:
+  // A map, not a hash table, so that the written files don't change just because the insertion order did.
+  ezMap<ezString, ezVariant> m_Values;
+};

--- a/Code/Engine/Foundation/Utilities/Implementation/AssetInfoFile.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/AssetInfoFile.cpp
@@ -1,0 +1,244 @@
+#include <Foundation/FoundationPCH.h>
+
+#include <Foundation/IO/FileSystem/DeferredFileWriter.h>
+#include <Foundation/IO/FileSystem/FileReader.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/IO/OpenDdlReader.h>
+#include <Foundation/IO/OpenDdlUtils.h>
+#include <Foundation/IO/OpenDdlWriter.h>
+#include <Foundation/Strings/TranslationLookup.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
+
+// Version of the file layout, not of the values inside it.
+static constexpr ezUInt16 s_uiAssetInfoFileVersion = 1;
+
+static constexpr ezStringView s_sRootObject = "AssetInfo"_ezsv;
+static constexpr ezStringView s_sValuesObject = "Values"_ezsv;
+static constexpr ezStringView s_sVersion = "Version"_ezsv;
+static constexpr ezStringView s_sAssetHash = "AssetHash"_ezsv;
+static constexpr ezStringView s_sTypeVersion = "TypeVersion"_ezsv;
+
+void ezAssetInfoFile::SetValue(ezStringView sKey, const ezVariant& value)
+{
+  if (!value.IsValid())
+  {
+    m_Values.Remove(sKey);
+    return;
+  }
+
+  m_Values[sKey] = value;
+}
+
+ezVariant ezAssetInfoFile::GetValue(ezStringView sKey) const
+{
+  auto it = m_Values.Find(sKey);
+
+  if (!it.IsValid())
+    return ezVariant();
+
+  return it.Value();
+}
+
+ezResult ezAssetInfoFile::Write(ezStreamWriter& inout_stream, const ezAssetFileHeader& header) const
+{
+  ezOpenDdlWriter ddl;
+  ddl.SetOutputStream(&inout_stream);
+
+  ddl.SetFloatPrecisionMode(ezOpenDdlWriter::FloatPrecisionMode::Readable);
+
+  ddl.BeginObject(s_sRootObject);
+  {
+    ezOpenDdlUtils::StoreUInt16(ddl, s_uiAssetInfoFileVersion, s_sVersion);
+
+    // Stored here rather than in a binary ezAssetFileHeader, so that the entire file stays readable text.
+    ezOpenDdlUtils::StoreUInt64(ddl, header.GetFileHash(), s_sAssetHash);
+    ezOpenDdlUtils::StoreUInt16(ddl, header.GetFileVersion(), s_sTypeVersion);
+
+    ddl.BeginObject(s_sValuesObject);
+    {
+      for (auto it = m_Values.GetIterator(); it.IsValid(); ++it)
+      {
+        ezOpenDdlUtils::StoreVariant(ddl, it.Value(), it.Key());
+      }
+    }
+    ddl.EndObject();
+  }
+  ddl.EndObject();
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezAssetInfoFile::Read(ezStreamReader& inout_stream, ezAssetFileHeader& out_header)
+{
+  m_Values.Clear();
+
+  ezOpenDdlReader ddl;
+  if (ddl.ParseDocument(inout_stream).Failed())
+    return EZ_FAILURE;
+
+  const ezOpenDdlReaderElement* pRoot = ddl.GetRootElement()->FindChildOfType(s_sRootObject);
+
+  if (pRoot == nullptr)
+    return EZ_FAILURE;
+
+  const ezOpenDdlReaderElement* pVersion = pRoot->FindChildOfType(ezOpenDdlPrimitiveType::UInt16, s_sVersion);
+
+  // A newer version may be structured differently, so it is not read at all.
+  if (pVersion == nullptr || *pVersion->GetPrimitivesUInt16() > s_uiAssetInfoFileVersion)
+    return EZ_FAILURE;
+
+  const ezOpenDdlReaderElement* pHash = pRoot->FindChildOfType(ezOpenDdlPrimitiveType::UInt64, s_sAssetHash);
+  const ezOpenDdlReaderElement* pTypeVersion = pRoot->FindChildOfType(ezOpenDdlPrimitiveType::UInt16, s_sTypeVersion);
+
+  if (pHash == nullptr || pTypeVersion == nullptr)
+    return EZ_FAILURE;
+
+  out_header.SetFileHashAndVersion(*pHash->GetPrimitivesUInt64(), *pTypeVersion->GetPrimitivesUInt16());
+
+  if (const ezOpenDdlReaderElement* pValues = pRoot->FindChildOfType(s_sValuesObject))
+  {
+    for (const ezOpenDdlReaderElement* pChild = pValues->GetFirstChild(); pChild != nullptr; pChild = pChild->GetSibling())
+    {
+      if (pChild->GetName().IsEmpty())
+        continue;
+
+      ezVariant value;
+
+      // Skip a value of a type this build cannot represent, the remaining ones are still useful.
+      if (ezOpenDdlUtils::ConvertToVariant(pChild, value).Failed())
+        continue;
+
+      m_Values[pChild->GetName()] = value;
+    }
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezAssetInfoFile::WriteToFile(ezStringView sAbsolutePath, const ezAssetFileHeader& header) const
+{
+  // Remove a file from an earlier transform, it would be mistaken for current information.
+  if (m_Values.IsEmpty())
+  {
+    ezOSFile::DeleteFile(sAbsolutePath).IgnoreResult();
+    return EZ_SUCCESS;
+  }
+
+  ezDeferredFileWriter file;
+  file.SetOutput(sAbsolutePath);
+
+  if (Write(file, header).Failed())
+  {
+    file.Discard();
+    return EZ_FAILURE;
+  }
+
+  return file.Close();
+}
+
+ezResult ezAssetInfoFile::ReadFromFile(ezStringView sAbsolutePath, ezUInt64 uiExpectedHash, ezUInt16 uiExpectedTypeVersion)
+{
+  m_Values.Clear();
+
+  ezFileReader file;
+  if (file.Open(sAbsolutePath).Failed())
+    return EZ_FAILURE;
+
+  ezAssetFileHeader header;
+  EZ_SUCCEED_OR_RETURN(Read(file, header));
+
+  if (!header.IsFileUpToDate(uiExpectedHash, uiExpectedTypeVersion))
+  {
+    m_Values.Clear();
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezStringBuilder ezAssetInfoFile::GetInfoFilePathForOutput(ezStringView sAbsoluteOutputPath)
+{
+  ezStringBuilder sPath = sAbsoluteOutputPath;
+  sPath.Append(".ezAssetInfo");
+  return sPath;
+}
+
+// Keys that are only ever shown as part of a combined line, and must not also be listed on their own.
+static bool IsPartOfCombinedLine(ezStringView sKey)
+{
+  return sKey == ezAssetInfoFile::Keys::ImageHeight;
+}
+
+bool ezAssetInfoFile::AppendValueToDisplayString(ezStringBuilder& ref_sOut, ezStringView sKey, ezStringView sLinePrefix) const
+{
+  const ezVariant value = GetValue(sKey);
+
+  if (!value.IsValid() || IsPartOfCombinedLine(sKey))
+    return false;
+
+  if (sKey == Keys::ImageWidth)
+  {
+    const ezVariant height = GetValue(Keys::ImageHeight);
+
+    if (!height.IsValid())
+      return false;
+
+    ref_sOut.AppendFormat("{}Resolution: {} x {}", sLinePrefix, value, height);
+    return true;
+  }
+
+  // The size is more useful than the half extents that it is stored as.
+  if (sKey == Keys::BoundsHalfExtents)
+  {
+    if (!value.IsA<ezVec3>())
+      return false;
+
+    const ezVec3 vHalf = value.Get<ezVec3>();
+    ref_sOut.AppendFormat("{}Size: {} x {} x {}", sLinePrefix, ezArgF(vHalf.x * 2, 3), ezArgF(vHalf.y * 2, 3), ezArgF(vHalf.z * 2, 3));
+    return true;
+  }
+
+  // The center is shown as the range it produces, which reveals whether the origin sits inside the object or at its base.
+  if (sKey == Keys::BoundsCenter)
+  {
+    const ezVariant halfExtents = GetValue(Keys::BoundsHalfExtents);
+
+    if (!value.IsA<ezVec3>() || !halfExtents.IsValid() || !halfExtents.IsA<ezVec3>())
+      return false;
+
+    const ezVec3 vCenter = value.Get<ezVec3>();
+    const ezVec3 vHalf = halfExtents.Get<ezVec3>();
+    ref_sOut.AppendFormat("{}Bounds: {} {} {} to {} {} {}", sLinePrefix,
+      ezArgF(vCenter.x - vHalf.x, 3), ezArgF(vCenter.y - vHalf.y, 3), ezArgF(vCenter.z - vHalf.z, 3),
+      ezArgF(vCenter.x + vHalf.x, 3), ezArgF(vCenter.y + vHalf.y, 3), ezArgF(vCenter.z + vHalf.z, 3));
+    return true;
+  }
+
+  const ezStringView sLabel = ezTranslate(sKey);
+
+  // Recorded lists are long enough to swamp everything else, so only the element count is shown.
+  if (value.IsA<ezVariantArray>())
+  {
+    ref_sOut.AppendFormat("{}{}: {}", sLinePrefix, sLabel, value.Get<ezVariantArray>().GetCount());
+    return true;
+  }
+
+  ref_sOut.AppendFormat("{}{}: {}", sLinePrefix, sLabel, value);
+  return true;
+}
+
+void ezAssetInfoFile::AppendToDisplayString(ezStringBuilder& ref_sOut, ezStringView sLinePrefix) const
+{
+  for (auto it = m_Values.GetIterator(); it.IsValid(); ++it)
+  {
+    AppendValueToDisplayString(ref_sOut, it.Key(), sLinePrefix);
+  }
+}
+
+void ezAssetInfoFile::AppendValuesToDisplayString(ezStringBuilder& ref_sOut, ezArrayPtr<const ezStringView> keys, ezStringView sLinePrefix) const
+{
+  for (ezStringView sKey : keys)
+  {
+    AppendValueToDisplayString(ref_sOut, sKey, sLinePrefix);
+  }
+}

--- a/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResourceWriter.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResourceWriter.cpp
@@ -23,8 +23,9 @@ using namespace VHACD;
 static constexpr ezUInt8 uiColliderFileVersion = 4;
 
 // static
-ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, bool bWriteAssetHeader /*= true*/, ezUInt64 uiAssetHash /*= 0*/)
+ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, bool bWriteAssetHeader /*= true*/, ezUInt64 uiAssetHash /*= 0*/, ezJoltCookedMeshStats* out_pStats /*= nullptr*/)
 {
+  ezJoltCookedMeshStats stats;
   if (bWriteAssetHeader)
   {
     ezAssetFileHeader header;
@@ -81,6 +82,10 @@ ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshD
 
       ezStopwatch timer;
       resCooking = CookTriangleMesh(meshDesc, chunk);
+
+      // A triangle mesh is cooked as it is, so the input counts are the output counts.
+      stats.m_uiNumVertices = meshDesc.m_Vertices.GetCount();
+      stats.m_uiNumTriangles = meshDesc.m_TriangleIndices.GetCount() / 3;
       ezLog::Dev("Triangle Mesh Cooking time: {0}s", ezArgF(timer.GetRunningTotal().GetSeconds(), 2));
 
       chunk.EndChunk();
@@ -90,7 +95,7 @@ ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshD
       chunk.BeginChunk("ConvexMesh", 1);
 
       ezStopwatch timer;
-      resCooking = CookConvexMesh(meshDesc, chunk);
+      resCooking = CookConvexMesh(meshDesc, chunk, stats);
       ezLog::Dev("Convex Mesh Cooking time: {0}s", ezArgF(timer.GetRunningTotal().GetSeconds(), 2));
 
       chunk.EndChunk();
@@ -100,7 +105,7 @@ ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshD
       chunk.BeginChunk("ConvexDecompositionMesh", 1);
 
       ezStopwatch timer;
-      resCooking = CookDecomposedConvexMesh(meshDesc, chunk);
+      resCooking = CookDecomposedConvexMesh(meshDesc, chunk, stats);
       ezLog::Dev("Decomposed Convex Mesh Cooking time: {0}s", ezArgF(timer.GetRunningTotal().GetSeconds(), 2));
 
       chunk.EndChunk();
@@ -110,7 +115,7 @@ ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshD
       chunk.BeginChunk("ConvexDecompositionMesh", 1);
 
       ezStopwatch timer;
-      resCooking = CookConvexHullGroup(meshDesc, chunk);
+      resCooking = CookConvexHullGroup(meshDesc, chunk, stats);
       ezLog::Dev("Decomposed Convex Mesh Cooking time: {0}s", ezArgF(timer.GetRunningTotal().GetSeconds(), 2));
 
       chunk.EndChunk();
@@ -124,6 +129,11 @@ ezResult ezJoltMeshResourceWriter::WriteMeshResource(const ezJoltMeshDesc& meshD
   }
 
   chunk.EndStream();
+
+  if (out_pStats != nullptr)
+  {
+    *out_pStats = stats;
+  }
 
 #ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
   if (compressor.FinishCompressedStream().Failed())
@@ -173,7 +183,7 @@ ezResult ezJoltMeshResourceWriter::ComputeConvexHull(const ezDynamicArray<ezVec3
   return EZ_SUCCESS;
 }
 
-ezResult ezJoltMeshResourceWriter::CookSingleConvexJoltMesh(const ezDynamicArray<ezVec3>& vertices, ezStreamWriter& inout_stream)
+ezResult ezJoltMeshResourceWriter::CookSingleConvexJoltMesh(const ezDynamicArray<ezVec3>& vertices, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats)
 {
   if (JPH::Allocate == nullptr)
   {
@@ -213,6 +223,11 @@ ezResult ezJoltMeshResourceWriter::CookSingleConvexJoltMesh(const ezDynamicArray
 
   const ezUInt32 uiNumTriangles = shapeRes.Get()->GetStats().mNumTriangles;
   inout_stream << uiNumTriangles;
+
+  // Summed, because a decomposition or hull group cooks several shapes into one file.
+  ref_stats.m_uiNumVertices += uiNumVertices;
+  ref_stats.m_uiNumTriangles += uiNumTriangles;
+  ref_stats.m_uiNumParts += 1;
 
   return EZ_SUCCESS;
 }
@@ -319,7 +334,7 @@ ezResult ezJoltMeshResourceWriter::CookTriangleMesh(const ezJoltMeshDesc& meshDe
   return EZ_SUCCESS;
 }
 
-ezResult ezJoltMeshResourceWriter::CookConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream)
+ezResult ezJoltMeshResourceWriter::CookConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats)
 {
   ezProgressRange range("Cooking Convex Mesh", 2, false);
 
@@ -330,12 +345,12 @@ ezResult ezJoltMeshResourceWriter::CookConvexMesh(const ezJoltMeshDesc& meshDesc
 
   range.BeginNextStep("Cooking Convex Hull");
 
-  EZ_SUCCEED_OR_RETURN(CookSingleConvexJoltMesh(hullVertices, inout_stream));
+  EZ_SUCCEED_OR_RETURN(CookSingleConvexJoltMesh(hullVertices, inout_stream, ref_stats));
 
   return EZ_SUCCESS;
 }
 
-ezResult ezJoltMeshResourceWriter::CookDecomposedConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream)
+ezResult ezJoltMeshResourceWriter::CookDecomposedConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats)
 {
   EZ_LOG_BLOCK("Decomposing Mesh");
 
@@ -407,13 +422,13 @@ ezResult ezJoltMeshResourceWriter::CookDecomposedConvexMesh(const ezJoltMeshDesc
       hullVertices[v].Set((float)ch.m_points[v].mX, (float)ch.m_points[v].mY, (float)ch.m_points[v].mZ);
     }
 
-    EZ_SUCCEED_OR_RETURN(CookSingleConvexJoltMesh(hullVertices, inout_stream));
+    EZ_SUCCEED_OR_RETURN(CookSingleConvexJoltMesh(hullVertices, inout_stream, ref_stats));
   }
 
   return EZ_SUCCESS;
 }
 
-ezResult ezJoltMeshResourceWriter::CookConvexHullGroup(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream)
+ezResult ezJoltMeshResourceWriter::CookConvexHullGroup(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats)
 {
   ezMap<ezUInt16, ezDynamicArray<ezVec3>> parts;
 
@@ -444,7 +459,7 @@ ezResult ezJoltMeshResourceWriter::CookConvexHullGroup(const ezJoltMeshDesc& mes
     ezTempHybridArray<ezVec3, 256> hullVertices;
     EZ_SUCCEED_OR_RETURN(ComputeConvexHull(meshPartVertices, hullVertices));
 
-    EZ_SUCCEED_OR_RETURN(CookSingleConvexJoltMesh(hullVertices, inout_stream));
+    EZ_SUCCEED_OR_RETURN(CookSingleConvexJoltMesh(hullVertices, inout_stream, ref_stats));
   }
 
   return EZ_SUCCESS;

--- a/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResourceWriter.h
+++ b/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResourceWriter.h
@@ -61,6 +61,14 @@ struct ezJoltMeshDesc
   ezDynamicArray<ezString> m_Surfaces;
 };
 
+/// Stats for the geometry that cooking produced.
+struct ezJoltCookedMeshStats
+{
+  ezUInt32 m_uiNumVertices = 0;  ///< Summed over all parts, for a decomposition or hull group.
+  ezUInt32 m_uiNumTriangles = 0; ///< Summed over all parts, for a decomposition or hull group.
+  ezUInt32 m_uiNumParts = 0;     ///< How many convex pieces were produced. 1 for a single hull, 0 for a triangle mesh.
+};
+
 /// \brief Helper class for writing ezJoltMeshResource and ezJoltHeightfieldResource files.
 class EZ_JOLTPLUGIN_DLL ezJoltMeshResourceWriter
 {
@@ -68,7 +76,7 @@ public:
   /// \brief Writes the given mesh description to the provided stream so that it can be loaded as an ezJoltMeshResource.
   ///
   /// Set bWriteAssetHeader to false if the asset header has already been written to the stream, e.g. in case of an asset transformation.
-  static ezResult WriteMeshResource(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, bool bWriteAssetHeader = true, ezUInt64 uiAssetHash = 0);
+  static ezResult WriteMeshResource(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, bool bWriteAssetHeader = true, ezUInt64 uiAssetHash = 0, ezJoltCookedMeshStats* out_pStats = nullptr);
 
   /// Cooks the Jolt heightfield shape and writes it to the provided stream so that it can be loaded as an ezJoltHeightfieldResource.
   ///
@@ -78,10 +86,10 @@ public:
 private:
   static ezResult ComputeConvexHull(const ezDynamicArray<ezVec3>& vertices, ezDynamicArray<ezVec3>& out_hullVertices);
 
-  static ezResult CookSingleConvexJoltMesh(const ezDynamicArray<ezVec3>& vertices, ezStreamWriter& inout_stream);
+  static ezResult CookSingleConvexJoltMesh(const ezDynamicArray<ezVec3>& vertices, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats);
 
   static ezResult CookTriangleMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream);
-  static ezResult CookConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream);
-  static ezResult CookDecomposedConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream);
-  static ezResult CookConvexHullGroup(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream);
+  static ezResult CookConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats);
+  static ezResult CookDecomposedConvexMesh(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats);
+  static ezResult CookConvexHullGroup(const ezJoltMeshDesc& meshDesc, ezStreamWriter& inout_stream, ezJoltCookedMeshStats& ref_stats);
 };

--- a/Code/Tools/Libs/GuiFoundation/UIServices/DynamicStringEnum.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/DynamicStringEnum.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <Foundation/Communication/Event.h>
 #include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>
 #include <Foundation/Types/Delegate.h>
 #include <Foundation/Types/Variant.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
+
+class ezDocument;
 
 /// \brief Stores the valid values and names for 'dynamic' enums.
 ///
@@ -71,6 +74,21 @@ public:
   ///
   /// Can be used to on-demand load those values, before GetDynamicEnum() returns.
   static ezDelegate<void(ezStringView sEnumName, ezDynamicStringEnum& e)> s_RequestUnknownCallback;
+
+  /// \see s_RefreshValuesEvent
+  struct RefreshValuesEvent
+  {
+    ezStringView m_sEnumName;                ///< Which enum is about to be shown.
+    const ezDocument* m_pDocument = nullptr; ///< The document whose property is being edited. May be null.
+    ezDynamicStringEnum* m_pEnum = nullptr;  ///< Modify this in place.
+  };
+
+  /// Broadcast right before the values are presented to the user, so that they can be brought up to date.
+  ///
+  /// Unlike s_RequestUnknownCallback this fires every time, not just once, which makes it usable for values that are
+  /// derived from the document being edited. The enum is modified in place, so a subscriber can add to values that were
+  /// loaded from a file. An enum whose values depend entirely on the document has to Clear() it first.
+  static ezEvent<RefreshValuesEvent&> s_RefreshValuesEvent;
 
 private:
   ezHybridArray<ezString, 16> m_ValidValues;

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/DynamicStringEnum.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/DynamicStringEnum.cpp
@@ -6,6 +6,7 @@
 
 ezMap<ezString, ezDynamicStringEnum> ezDynamicStringEnum::s_DynamicEnums;
 ezDelegate<void(ezStringView sEnumName, ezDynamicStringEnum& e)> ezDynamicStringEnum::s_RequestUnknownCallback;
+ezEvent<ezDynamicStringEnum::RefreshValuesEvent&> ezDynamicStringEnum::s_RefreshValuesEvent;
 
 // static
 ezDynamicStringEnum& ezDynamicStringEnum::GetDynamicEnum(ezStringView sEnumName)

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -69,6 +69,13 @@ ezCommandLineOptionPath opt_ThumbnailOut("_TexConv", "-thumbnailOut",
 ",
   "");
 
+ezCommandLineOptionPath opt_AssetInfoOut("_TexConv", "-assetInfoOut",
+  "\
+  Path to a file that receives information about the generated texture, such as its final resolution and format.\n\
+  Written only when the output is an ez texture format.\n\
+",
+  "");
+
 ezCommandLineOptionPath opt_LowOut("_TexConv", "-lowOut",
   "\
   Path to low-resolution output file.\n\
@@ -408,6 +415,8 @@ ezResult ezTexConv::ParseOutputFiles()
   {
     m_Processor.m_Descriptor.m_uiThumbnailOutputResolution = opt_ThumbnailRes.GetOptionValue(ezCommandLineOption::LogMode::Always);
   }
+
+  m_sOutputAssetInfoFile = opt_AssetInfoOut.GetOptionValue(ezCommandLineOption::LogMode::Always);
 
   m_sOutputLowResFile = opt_LowOut.GetOptionValue(ezCommandLineOption::LogMode::Always);
 

--- a/Code/Tools/TexConv/TexConv.cpp
+++ b/Code/Tools/TexConv/TexConv.cpp
@@ -2,6 +2,7 @@
 
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
 #include <TexConv/TexConv.h>
 #include <Texture/Image/Formats/DdsFileFormat.h>
 #include <Texture/Image/Formats/StbImageFileFormats.h>
@@ -548,6 +549,29 @@ void ezTexConv::Run()
       }
 
       ezLog::Success("Wrote thumbnail to '{}'", m_sOutputThumbnailFile);
+    }
+
+    if (!m_sOutputAssetInfoFile.IsEmpty() && m_Processor.m_OutputImage.IsValid())
+    {
+      const ezImageHeader& header = m_Processor.m_OutputImage.GetHeader();
+
+      ezAssetInfoFile info;
+      info.SetValue(ezAssetInfoFile::Keys::ImageWidth, header.GetWidth());
+      info.SetValue(ezAssetInfoFile::Keys::ImageHeight, header.GetHeight());
+      info.SetValue(ezAssetInfoFile::Keys::Format, ezImageFormat::GetName(header.GetImageFormat()));
+      info.SetValue("MipLevels", header.GetNumMipLevels());
+
+      ezAssetFileHeader assetHeader;
+      assetHeader.SetFileHashAndVersion(m_Processor.m_Descriptor.m_uiAssetHash, m_Processor.m_Descriptor.m_uiAssetVersion);
+
+      if (info.WriteToFile(m_sOutputAssetInfoFile, assetHeader).Failed())
+      {
+        ezLog::Error("Failed to write asset info to '{}'", m_sOutputAssetInfoFile);
+        QuitApplication();
+        return;
+      }
+
+      ezLog::Success("Wrote asset info to '{}'", m_sOutputAssetInfoFile);
     }
 
     if (!m_sOutputLowResFile.IsEmpty())

--- a/Code/Tools/TexConv/TexConv.h
+++ b/Code/Tools/TexConv/TexConv.h
@@ -81,6 +81,7 @@ public:
 private:
   ezString m_sOutputFile;
   ezString m_sOutputThumbnailFile;
+  ezString m_sOutputAssetInfoFile;
   ezString m_sOutputLowResFile;
   ezString m_sReduceInputFile;
   bool m_bDeleteSource = false;

--- a/Code/UnitTests/FoundationTest/Utility/AssetInfoFileTest.cpp
+++ b/Code/UnitTests/FoundationTest/Utility/AssetInfoFileTest.cpp
@@ -1,0 +1,262 @@
+#include <FoundationTest/FoundationTestPCH.h>
+
+#include <Foundation/IO/MemoryStream.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
+
+EZ_CREATE_SIMPLE_TEST(Utility, AssetInfoFile)
+{
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetValue / GetValue")
+  {
+    ezAssetInfoFile info;
+    EZ_TEST_BOOL(info.IsEmpty());
+
+    info.SetValue(ezAssetInfoFile::Keys::NumTriangles, 1234u);
+    EZ_TEST_BOOL(!info.IsEmpty());
+    EZ_TEST_INT(info.GetValue(ezAssetInfoFile::Keys::NumTriangles).Get<ezUInt32>(), 1234);
+
+    // overwriting replaces the value instead of adding a second entry
+    info.SetValue(ezAssetInfoFile::Keys::NumTriangles, 42u);
+    EZ_TEST_INT(info.GetValue(ezAssetInfoFile::Keys::NumTriangles).Get<ezUInt32>(), 42);
+    EZ_TEST_INT(info.GetValues().GetCount(), 1);
+
+    // an unknown key yields an invalid variant, rather than asserting
+    EZ_TEST_BOOL(!info.GetValue("DoesNotExist").IsValid());
+
+    // an invalid value removes the key again
+    info.SetValue(ezAssetInfoFile::Keys::NumTriangles, ezVariant());
+    EZ_TEST_BOOL(info.IsEmpty());
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Write / Read")
+  {
+    ezAssetInfoFile info;
+    info.SetValue(ezAssetInfoFile::Keys::NumVertices, 100u);
+    info.SetValue(ezAssetInfoFile::Keys::NumTriangles, 50u);
+    // not exactly representable, to cover the writer's readable float mode
+    info.SetValue(ezAssetInfoFile::Keys::BoundsCenter, ezVec3(0.477654f, -1.2345678f, 3));
+    info.SetValue(ezAssetInfoFile::Keys::BoundsHalfExtents, ezVec3(4, 5, 6));
+    info.SetValue(ezAssetInfoFile::Keys::Format, ezString("BC7"));
+    info.SetValue(ezAssetInfoFile::Keys::CollisionMeshType, ezString("ConvexHull"));
+
+    ezAssetFileHeader header;
+    header.SetFileHashAndVersion(0x1234567890ABCDEFull, 7);
+
+    ezDefaultMemoryStreamStorage storage;
+    {
+      ezMemoryStreamWriter writer(&storage);
+      EZ_TEST_BOOL(info.Write(writer, header).Succeeded());
+    }
+
+    ezAssetInfoFile read;
+    ezAssetFileHeader readHeader;
+    {
+      ezMemoryStreamReader reader(&storage);
+      EZ_TEST_BOOL(read.Read(reader, readHeader).Succeeded());
+    }
+
+    EZ_TEST_BOOL(readHeader.IsFileUpToDate(0x1234567890ABCDEFull, 7));
+    EZ_TEST_INT(read.GetValues().GetCount(), 6);
+    EZ_TEST_INT(read.GetValue(ezAssetInfoFile::Keys::NumVertices).Get<ezUInt32>(), 100);
+    EZ_TEST_INT(read.GetValue(ezAssetInfoFile::Keys::NumTriangles).Get<ezUInt32>(), 50);
+    EZ_TEST_VEC3(read.GetValue(ezAssetInfoFile::Keys::BoundsCenter).Get<ezVec3>(), ezVec3(0.477654f, -1.2345678f, 3), 0.001f);
+    EZ_TEST_VEC3(read.GetValue(ezAssetInfoFile::Keys::BoundsHalfExtents).Get<ezVec3>(), ezVec3(4, 5, 6), 0.0f);
+    EZ_TEST_STRING(read.GetValue(ezAssetInfoFile::Keys::Format).Get<ezString>(), "BC7");
+    EZ_TEST_STRING(read.GetValue(ezAssetInfoFile::Keys::CollisionMeshType).Get<ezString>(), "ConvexHull");
+
+    // reading replaces previous content rather than merging into it
+    {
+      ezMemoryStreamReader reader(&storage);
+      EZ_TEST_BOOL(read.Read(reader, readHeader).Succeeded());
+    }
+    EZ_TEST_INT(read.GetValues().GetCount(), 6);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "String array round trip")
+  {
+    ezVariantArray clips;
+    clips.PushBack(ezVariant(ezString("Idle")));
+    clips.PushBack(ezVariant(ezString("Walk")));
+    clips.PushBack(ezVariant(ezString("Run")));
+
+    ezAssetInfoFile info;
+    info.SetValue(ezAssetInfoFile::Keys::AvailableClips, ezVariant(clips));
+
+    ezAssetFileHeader header;
+    header.SetFileHashAndVersion(1, 1);
+
+    ezDefaultMemoryStreamStorage storage;
+    {
+      ezMemoryStreamWriter writer(&storage);
+      EZ_TEST_BOOL(info.Write(writer, header).Succeeded());
+    }
+
+    ezAssetInfoFile read;
+    ezAssetFileHeader readHeader;
+    {
+      ezMemoryStreamReader reader(&storage);
+      EZ_TEST_BOOL(read.Read(reader, readHeader).Succeeded());
+    }
+
+    const ezVariant value = read.GetValue(ezAssetInfoFile::Keys::AvailableClips);
+    EZ_TEST_BOOL(value.IsA<ezVariantArray>());
+
+    const ezVariantArray& readClips = value.Get<ezVariantArray>();
+    EZ_TEST_INT(readClips.GetCount(), 3);
+    EZ_TEST_STRING(readClips[0].ConvertTo<ezString>(), "Idle");
+    EZ_TEST_STRING(readClips[1].ConvertTo<ezString>(), "Walk");
+    EZ_TEST_STRING(readClips[2].ConvertTo<ezString>(), "Run");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "AppendToDisplayString")
+  {
+    // nothing is appended for an empty set, not even a separator
+    {
+      ezAssetInfoFile info;
+      ezStringBuilder s("Existing");
+      info.AppendToDisplayString(s);
+      EZ_TEST_STRING(s, "Existing");
+    }
+
+    // center and half extents collapse into a size and a range, rather than being listed raw
+    {
+      ezAssetInfoFile info;
+      info.SetValue(ezAssetInfoFile::Keys::NumTriangles, 252u);
+      info.SetValue(ezAssetInfoFile::Keys::BoundsCenter, ezVec3(0, 0, 0.5f));
+      info.SetValue(ezAssetInfoFile::Keys::BoundsHalfExtents, ezVec3(0.25f, 0.25f, 0.5f));
+      info.SetValue(ezAssetInfoFile::Keys::BoundsRadius, 0.75f);
+
+      ezStringBuilder s;
+      info.AppendToDisplayString(s, "\n");
+
+      EZ_TEST_BOOL(s.FindSubString("Size: 0.500 x 0.500 x 1.000") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Bounds: -0.250 -0.250 0.000 to 0.250 0.250 1.000") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Triangles: 252") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Radius: 0.75") != nullptr);
+      // the keys folded into the lines above must not also appear on their own
+      EZ_TEST_BOOL(s.FindSubString("Center:") == nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Extents:") == nullptr);
+    }
+
+    // the bounds range needs both halves, so a center on its own prints nothing
+    {
+      ezAssetInfoFile info;
+      info.SetValue(ezAssetInfoFile::Keys::BoundsCenter, ezVec3(1, 2, 3));
+
+      ezStringBuilder s;
+      info.AppendToDisplayString(s);
+      EZ_TEST_BOOL(s.IsEmpty());
+    }
+
+    // width and height collapse into a single resolution line
+    {
+      ezAssetInfoFile info;
+      info.SetValue(ezAssetInfoFile::Keys::ImageWidth, 512u);
+      info.SetValue(ezAssetInfoFile::Keys::ImageHeight, 256u);
+      info.SetValue(ezAssetInfoFile::Keys::Format, ezString("BC7"));
+
+      ezStringBuilder s;
+      info.AppendToDisplayString(s);
+
+      EZ_TEST_BOOL(s.FindSubString("Resolution: 512 x 256") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Format: BC7") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Width:") == nullptr);
+    }
+
+    // a key this code does not know about is still shown, under its raw name
+    {
+      ezAssetInfoFile info;
+      info.SetValue("SomethingNew", 42u);
+
+      ezStringBuilder s;
+      info.AppendToDisplayString(s);
+      EZ_TEST_BOOL(s.FindSubString("SomethingNew: 42") != nullptr);
+    }
+
+    // an array is summarized by its element count, not by listing the elements
+    {
+      ezVariantArray clips;
+      clips.PushBack(ezVariant(ezString("Idle")));
+      clips.PushBack(ezVariant(ezString("Walk")));
+
+      ezAssetInfoFile info;
+      info.SetValue(ezAssetInfoFile::Keys::AvailableClips, ezVariant(clips));
+
+      ezStringBuilder s;
+      info.AppendToDisplayString(s);
+
+      EZ_TEST_BOOL(s.FindSubString("Clips: 2") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Idle") == nullptr);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "AppendValuesToDisplayString")
+  {
+    ezAssetInfoFile info;
+    info.SetValue(ezAssetInfoFile::Keys::NumVertices, 4460u);
+    info.SetValue(ezAssetInfoFile::Keys::NumTriangles, 5238u);
+    info.SetValue(ezAssetInfoFile::Keys::NumSubMeshes, 1u);
+    info.SetValue(ezAssetInfoFile::Keys::BoundsCenter, ezVec3(0, 0, 0.5f));
+    info.SetValue(ezAssetInfoFile::Keys::BoundsHalfExtents, ezVec3(0.25f, 0.25f, 0.5f));
+
+    // only the requested keys appear, so that a caller can keep a tooltip short
+    {
+      const ezStringView keys[] = {ezAssetInfoFile::Keys::NumTriangles, ezAssetInfoFile::Keys::BoundsHalfExtents};
+
+      ezStringBuilder s;
+      info.AppendValuesToDisplayString(s, keys);
+
+      EZ_TEST_BOOL(s.FindSubString("Triangles: 5238") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Size: 0.500 x 0.500 x 1.000") != nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Vertices:") == nullptr);
+      EZ_TEST_BOOL(s.FindSubString("Meshes:") == nullptr);
+      // asking for the size must not also print the full coordinate range
+      EZ_TEST_BOOL(s.FindSubString("Bounds:") == nullptr);
+    }
+
+    // the requested order is kept, rather than the order inside the file
+    {
+      const ezStringView keys[] = {ezAssetInfoFile::Keys::NumSubMeshes, ezAssetInfoFile::Keys::NumVertices};
+
+      ezStringBuilder s;
+      info.AppendValuesToDisplayString(s, keys);
+
+      const char* szSub = s.FindSubString("Meshes:");
+      const char* szVert = s.FindSubString("Vertices:");
+      EZ_TEST_BOOL(szSub != nullptr && szVert != nullptr && szSub < szVert);
+    }
+
+    // a key with no value is skipped instead of printing an empty line
+    {
+      const ezStringView keys[] = {ezAssetInfoFile::Keys::Format, ezAssetInfoFile::Keys::NumTriangles};
+
+      ezStringBuilder s;
+      info.AppendValuesToDisplayString(s, keys);
+
+      EZ_TEST_BOOL(s.FindSubString("Format:") == nullptr);
+      EZ_TEST_STRING(s, "\nTriangles: 5238");
+    }
+
+    // asking for the absorbed half of a combined pair yields nothing on its own
+    {
+      ezAssetInfoFile tex;
+      tex.SetValue(ezAssetInfoFile::Keys::ImageWidth, 512u);
+      tex.SetValue(ezAssetInfoFile::Keys::ImageHeight, 256u);
+
+      ezStringBuilder sHeight;
+      const ezStringView keysHeight[] = {ezAssetInfoFile::Keys::ImageHeight};
+      EZ_TEST_BOOL(!tex.AppendValueToDisplayString(sHeight, ezAssetInfoFile::Keys::ImageHeight));
+      tex.AppendValuesToDisplayString(sHeight, keysHeight);
+      EZ_TEST_BOOL(sHeight.IsEmpty());
+
+      // while the other half prints the whole resolution
+      ezStringBuilder sWidth;
+      EZ_TEST_BOOL(tex.AppendValueToDisplayString(sWidth, ezAssetInfoFile::Keys::ImageWidth));
+      EZ_TEST_BOOL(sWidth.FindSubString("Resolution: 512 x 256") != nullptr);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetInfoFilePathForOutput")
+  {
+    EZ_TEST_STRING(ezAssetInfoFile::GetInfoFilePathForOutput("C:/Foo/Bar.ezMesh"), "C:/Foo/Bar.ezMesh.ezAssetInfo");
+  }
+}


### PR DESCRIPTION
Transforming an asset optionally writes an ezAssetInfo file to disk besides the asset output. This file contains data about the stats of the asset (after the transform).

These stats are shown as tooltips in the asset browser (mesh triangle counts etc), but are also useful for instance in the animation clip asset, where it now properly lets users select which animation clip to import from a file.

In the future this information can be extended and used in more places for validation and user convenience.

<img width="686" height="307" alt="grafik" src="https://github.com/user-attachments/assets/7c8e5cd4-592e-433d-94d6-e650ac8de248" />

<img width="826" height="451" alt="grafik" src="https://github.com/user-attachments/assets/c6e9ef78-8681-442c-97de-ee4312fc5944" />
