### PR TITLE
Fixed issue with differing Windows drive letter casing

### DIFF
--- a/Code/Engine/Foundation/Platform/Win/OSFile_WinAndUWP.cpp
+++ b/Code/Engine/Foundation/Platform/Win/OSFile_WinAndUWP.cpp
@@ -80,7 +80,13 @@ ezStringView ezOSFile::GetApplicationPath()
       EZ_REPORT_FAILURE("GetModuleFileNameW failed: {0}", ezArgErrorCode(error));
     }
 
-    s_sApplicationPath = ezStringUtf8(tmp.GetData()).GetData();
+    // GetModuleFileNameW returns the drive letter exactly as the process was started with,
+    // so launching the same executable through a lower case and an upper case path yields absolute paths
+    // that differ in that one character.
+    ezStringBuilder sPath = ezStringUtf8(tmp.GetData()).GetView();
+    ezPathUtils::NormalizeWindowsDriveLetter(sPath);
+
+    s_sApplicationPath = sPath;
   }
 
   return s_sApplicationPath;

--- a/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
@@ -269,6 +269,23 @@ void ezPathUtils::MakeValidFilename(ezStringView sFilename, ezUInt32 uiReplaceme
   }
 }
 
+void ezPathUtils::NormalizeWindowsDriveLetter(ezStringBuilder& ref_sAbsolutePath)
+{
+  if (ref_sAbsolutePath.GetElementCount() >= 2 && ref_sAbsolutePath.GetData()[1] == ':')
+  {
+    const ezUInt32 uiChar = static_cast<ezUInt8>(ref_sAbsolutePath.GetData()[0]);
+
+    // Only ASCII can be a drive letter, which also guarantees that the replacement is a single byte.
+    if (ezUnicodeUtils::IsASCII(uiChar))
+    {
+      const ezUInt32 uiUpper = ezStringUtils::ToUpperChar(uiChar);
+
+      const char szUpper[2] = {static_cast<char>(uiUpper), '\0'};
+      ref_sAbsolutePath.ReplaceSubString(ref_sAbsolutePath.GetData(), ref_sAbsolutePath.GetData() + 1, szUpper);
+    }
+  }
+}
+
 bool ezPathUtils::IsSubPath(ezStringView sPrefixPath, ezStringView sFullPath0)
 {
   if (sPrefixPath.IsEmpty())

--- a/Code/Engine/Foundation/Strings/PathUtils.h
+++ b/Code/Engine/Foundation/Strings/PathUtils.h
@@ -5,7 +5,7 @@
 
 class ezStringBuilder;
 
-/// \brief Contains Helper functions to work with paths.
+/// Contains Helper functions to work with paths.
 ///
 /// Only functions that require read-only access to a string are provided here
 /// All functions that require to modify the path are provided by ezStringBuilder.
@@ -14,28 +14,28 @@ class ezStringBuilder;
 class EZ_FOUNDATION_DLL ezPathUtils
 {
 public:
-  /// \brief The path separator used by this operating system.
+  /// The path separator used by this operating system.
   static const char OsSpecificPathSeparator;
 
-  /// \brief Returns whether c is any known path separator.
+  /// Returns whether c is any known path separator.
   static bool IsPathSeparator(ezUInt32 c); // [tested]
 
-  /// \brief Checks if a given character is allowed in a filename (not path!)
+  /// Checks if a given character is allowed in a filename (not path!)
   static bool IsValidFilenameChar(ezUInt32 uiCharacter);
 
-  /// \brief Checks every character in the string with IsValidFilenameChar()
+  /// Checks every character in the string with IsValidFilenameChar()
   ///
   /// This is a basic check, only because each character passes the test, it does not guarantee that the full string is a valid path.
   static bool ContainsInvalidFilenameChars(ezStringView sPath);
 
-  /// \brief Searches for the previous path separator before szStartSearchAt. Will return nullptr if it reaches szPathStart before finding
+  /// Searches for the previous path separator before szStartSearchAt. Will return nullptr if it reaches szPathStart before finding
   /// any separator.
   static const char* FindPreviousSeparator(const char* szPathStart, const char* szStartSearchAt); // [tested]
 
-  /// \brief Checks whether the given path has any file extension
+  /// Checks whether the given path has any file extension
   static bool HasAnyExtension(ezStringView sPath); // [tested]
 
-  /// \brief Checks whether the path ends with the given file extension.
+  /// Checks whether the path ends with the given file extension.
   /// szExtension may or may not start with a dot.
   /// The check is case insensitive.
   ///
@@ -47,26 +47,26 @@ public:
   ///   HasExtension("file.a.b", "file.a.b") -> false
   static bool HasExtension(ezStringView sPath, ezStringView sExtension); // [tested]
 
-  /// \brief Returns the file extension of the given path. Will be empty, if the path does not end with a proper extension. The dot (.) is not included.
+  /// Returns the file extension of the given path. Will be empty, if the path does not end with a proper extension. The dot (.) is not included.
   ///
   /// If bFullExtension is false, a file named "file.a.b.c" will return "c".
   /// If bFullExtension is true, a file named "file.a.b.c" will return "a.b.c".
   static ezStringView GetFileExtension(ezStringView sPath, bool bFullExtension = false); // [tested]
 
-  /// \brief Returns the file name of a path, excluding the path and extension.
+  /// Returns the file name of a path, excluding the path and extension.
   ///
   /// If the path already ends with a path separator, the result will be empty.
   static ezStringView GetFileName(ezStringView sPath, bool bRemoveFullExtension = false); // [tested]
 
-  /// \brief Returns the path, excluding the file extension.
+  /// Returns the path, excluding the file extension.
   static ezStringView GetWithoutExtension(ezStringView sPath, bool bRemoveFullExtension = false);
 
-  /// \brief Returns the substring that represents the file name including the file extension.
+  /// Returns the substring that represents the file name including the file extension.
   ///
   /// Returns an empty string, if sPath already ends in a path separator, or is empty itself.
   static ezStringView GetFileNameAndExtension(ezStringView sPath); // [tested]
 
-  /// \brief Returns the directory of the given file, which is the substring up to the last path separator.
+  /// Returns the directory of the given file, which is the substring up to the last path separator.
   ///
   /// If the path already ends in a path separator, and thus points to a folder, instead of a file, the unchanged path is returned.
   /// "path/to/file" -> "path/to/"
@@ -75,17 +75,17 @@ public:
   /// "/file_at_root_level" -> "/"
   static ezStringView GetFileDirectory(ezStringView sPath); // [tested]
 
-  /// \brief Returns true, if the given path represents an absolute path on the current OS.
+  /// Returns true, if the given path represents an absolute path on the current OS.
   static bool IsAbsolutePath(ezStringView sPath); // [tested]
 
-  /// \brief Returns true, if the given path represents a relative path on the current OS.
+  /// Returns true, if the given path represents a relative path on the current OS.
   static bool IsRelativePath(ezStringView sPath); // [tested]
 
-  /// \brief A rooted path starts with a colon and then names a file-system data directory. Rooted paths are used as 'absolute' paths within
+  /// A rooted path starts with a colon and then names a file-system data directory. Rooted paths are used as 'absolute' paths within
   /// the ezFileSystem.
   static bool IsRootedPath(ezStringView sPath); // [tested]
 
-  /// \brief Splits the passed path into its root portion and the relative path
+  /// Splits the passed path into its root portion and the relative path
   ///
   /// ":MyRoot\file.txt" -> root = "MyRoot", relPath="file.txt"
   /// ":MyRoot\folder\file.txt" -> root = "MyRoot", relPath = "folder\file.txt"
@@ -94,19 +94,24 @@ public:
   /// If the path is not rooted, then root will be an empty string and relPath is set to the full input path.
   static void GetRootedPathParts(ezStringView sPath, ezStringView& ref_sRoot, ezStringView& ref_sRelPath); // [tested]
 
-  /// \brief Special case of GetRootedPathParts that returns the root of the input path and discards the relative path
+  /// Special case of GetRootedPathParts that returns the root of the input path and discards the relative path
   static ezStringView GetRootedPathRootName(ezStringView sPath); // [tested]
 
-  /// \brief Creates a valid filename (not path!) using the given string by replacing all disallowed characters.
+  /// Creates a valid filename (not path!) using the given string by replacing all disallowed characters.
   ///
   /// Note that path separators in the given string will be replaced as well!
   /// Asserts that replacementCharacter is an allowed character.
   /// \see IsValidFilenameChar()
   static void MakeValidFilename(ezStringView sFilename, ezUInt32 uiReplacementCharacter, ezStringBuilder& out_sFilename);
 
-  /// \brief Checks whether \a sFullPath starts with \a sPrefixPath.
+  /// Makes the drive letter of an absolute Windows path upper case.
+  ///
+  /// Checks whether this is a Windows-specific absolute path. Does nothing if not.
+  static void NormalizeWindowsDriveLetter(ezStringBuilder& ref_sAbsolutePath); // [tested]
+
+  /// Checks whether \a sFullPath starts with \a sPrefixPath.
   static bool IsSubPath(ezStringView sPrefixPath, ezStringView sFullPath); // [tested]
-  /// \brief Checks whether \a sFullPath starts with \a sPrefixPath. Case insensitive.
+  /// Checks whether \a sFullPath starts with \a sPrefixPath. Case insensitive.
   static bool IsSubPath_NoCase(ezStringView sPrefixPath, ezStringView sFullPath); // [tested]
 };
 

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/DataDirPath_inl.h
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/DataDirPath_inl.h
@@ -5,14 +5,18 @@ inline ezDataDirPath::ezDataDirPath() = default;
 inline ezDataDirPath::ezDataDirPath(ezStringView sAbsPath, ezArrayPtr<ezString> dataDirRoots, ezUInt32 uiLastKnownDataDirIndex /*= 0*/)
 {
   EZ_ASSERT_DEBUG(!sAbsPath.EndsWith_NoCase("/"), "");
-  m_sAbsolutePath = sAbsPath;
+  ezStringBuilder sTmp = sAbsPath;
+  ezPathUtils::NormalizeWindowsDriveLetter(sTmp);
+  m_sAbsolutePath = sTmp;
   UpdateDataDirInfos(dataDirRoots, uiLastKnownDataDirIndex);
 }
 
 inline ezDataDirPath::ezDataDirPath(const ezStringBuilder& sAbsPath, ezArrayPtr<ezString> dataDirRoots, ezUInt32 uiLastKnownDataDirIndex /*= 0*/)
 {
   EZ_ASSERT_DEBUG(!sAbsPath.EndsWith_NoCase("/"), "");
-  m_sAbsolutePath = sAbsPath;
+  ezStringBuilder sTmp = sAbsPath;
+  ezPathUtils::NormalizeWindowsDriveLetter(sTmp);
+  m_sAbsolutePath = sTmp;
   UpdateDataDirInfos(dataDirRoots, uiLastKnownDataDirIndex);
 }
 
@@ -20,6 +24,12 @@ inline ezDataDirPath::ezDataDirPath(ezString&& sAbsPath, ezArrayPtr<ezString> da
 {
   EZ_ASSERT_DEBUG(!sAbsPath.EndsWith_NoCase("/"), "");
   m_sAbsolutePath = std::move(sAbsPath);
+  {
+    ezStringBuilder sTmp = m_sAbsolutePath;
+    ezPathUtils::NormalizeWindowsDriveLetter(sTmp);
+    if (sTmp != m_sAbsolutePath)
+      m_sAbsolutePath = sTmp;
+  }
   UpdateDataDirInfos(dataDirRoots, uiLastKnownDataDirIndex);
 }
 
@@ -94,6 +104,13 @@ inline ezStreamWriter& ezDataDirPath::Write(ezStreamWriter& inout_stream) const
 inline ezStreamReader& ezDataDirPath::Read(ezStreamReader& inout_stream)
 {
   inout_stream >> m_sAbsolutePath;
+  {
+    // Caches written before the drive letter was normalized can still hold the other spelling.
+    ezStringBuilder sTmp = m_sAbsolutePath;
+    ezPathUtils::NormalizeWindowsDriveLetter(sTmp);
+    if (sTmp != m_sAbsolutePath)
+      m_sAbsolutePath = sTmp;
+  }
   inout_stream >> m_uiDataDirParent;
   inout_stream >> m_uiDataDirLength;
   inout_stream >> m_uiDataDirIndex;

--- a/Code/UnitTests/FoundationTest/Strings/PathUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/PathUtilsTest.cpp
@@ -202,6 +202,31 @@ EZ_CREATE_SIMPLE_TEST(Strings, PathUtils)
     EZ_TEST_BOOL(relPath == "");
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "NormalizeWindowsDriveLetter")
+  {
+    auto Normalized = [](const char* szPath) -> ezStringBuilder
+    {
+      ezStringBuilder s = szPath;
+      ezPathUtils::NormalizeWindowsDriveLetter(s);
+      return s;
+    };
+
+    EZ_TEST_STRING(Normalized("c:/DataDir/File.txt"), "C:/DataDir/File.txt");
+    EZ_TEST_STRING(Normalized("C:/DataDir/File.txt"), "C:/DataDir/File.txt");
+    EZ_TEST_STRING(Normalized("z:"), "Z:");
+    EZ_TEST_STRING(Normalized("c:"), "C:");
+
+    // the rest of the path is not touched
+    EZ_TEST_STRING(Normalized("c:/dataDIR/fILE.txt"), "C:/dataDIR/fILE.txt");
+
+    // nothing that looks like a drive letter
+    EZ_TEST_STRING(Normalized(""), "");
+    EZ_TEST_STRING(Normalized("c"), "c");
+    EZ_TEST_STRING(Normalized("/usr/local"), "/usr/local");
+    EZ_TEST_STRING(Normalized("relative/path.txt"), "relative/path.txt");
+    EZ_TEST_STRING(Normalized("1:/foo"), "1:/foo");
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsSubPath")
   {
     EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:/DataDir", "C:/DataDir/SomeFolder"));


### PR DESCRIPTION
Inconsistent path casing could cause the editor to not find assets across data directories.