### PR TITLE
Fixed that editor didn't detect all asset uses

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -316,19 +316,18 @@ public:
   ///   File name (may include a path) to search for. Will be modified both on success and failure to give a 'reasonable' result.
   ezResult FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArrayPtr<ezString> allowedFileExtensions) const;
 
-  /// Finds all uses, either as transform or thumbnail dependencies to a given asset.
-  ///
-  /// Technically this finds all dependencies to this asset but in practice there are no uses of transform dependencies between assets right now so the result is a list of thumbnail dependencies and can be referred to as simply a list of asset references.
+  /// Finds all assets that reference the given asset, as a transform, thumbnail or package dependency.
   ///
   /// \param assetGuid
   ///   The asset to find use cases for.
-  /// \param uses
+  /// \param ref_uses
   ///   List of assets that use 'assetGuid'. Any previous content of the set is not removed.
-  /// \param transitive
+  /// \param bTransitive
   ///   If set, will also find indirect uses of the asset.
   void FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool bTransitive) const;
 
-  /// Returns all assets that use a file for transform. Use this to e.g. figure which assets still reference a .tga file in the project.
+  /// Returns all assets that reference a file, as a transform, thumbnail or package dependency. Use this to e.g. figure out which assets still reference a .tga file in the project.
+  ///
   /// \param sAbsolutePath Absolute path to any file inside a data directory.
   /// \param ref_uses List of assets that use 'sAbsolutePath'. Any previous content of the set is not removed.
   void FindAllUses(ezStringView sAbsolutePath, ezSet<ezUuid>& ref_uses) const;
@@ -489,8 +488,10 @@ private:
   // Derived dependency lookup tables
   ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseTransformDeps; // [Absolute path -> asset Guid]
   ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseThumbnailDeps; // [Absolute path -> asset Guid]
+  ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InversePackageDeps;   // [Absolute path -> asset Guid]
   ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedTransformDeps;      ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
   ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedThumbnailDeps;
+  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedPackageDeps;
 
   // State caches
   ezHashSet<ezUuid> m_TransformState[ezAssetInfo::TransformState::COUNT];

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1175,8 +1175,9 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
     if (pInfo)
     {
       sCurrentAsset = pInfo->m_Path;
-      GatherReferences(m_InverseThumbnailDeps, sCurrentAsset);
       GatherReferences(m_InverseTransformDeps, sCurrentAsset);
+      GatherReferences(m_InverseThumbnailDeps, sCurrentAsset);
+      GatherReferences(m_InversePackageDeps, sCurrentAsset);
     }
   } while (bTransitive && !todoList.IsEmpty());
 }
@@ -1184,13 +1185,21 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
 void ezAssetCurator::FindAllUses(ezStringView sAbsolutePath, ezSet<ezUuid>& ref_uses) const
 {
   EZ_LOCK(m_CuratorMutex);
-  if (auto it = m_InverseTransformDeps.Find(sAbsolutePath); it.IsValid())
+
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker)
   {
-    for (const ezUuid& guid : it.Value())
+    if (auto it = inverseTracker.Find(sAbsolutePath); it.IsValid())
     {
-      ref_uses.Insert(guid);
+      for (const ezUuid& guid : it.Value())
+      {
+        ref_uses.Insert(guid);
+      }
     }
-  }
+  };
+
+  GatherReferences(m_InverseTransformDeps);
+  GatherReferences(m_InverseThumbnailDeps);
+  GatherReferences(m_InversePackageDeps);
 }
 
 bool ezAssetCurator::IsReferenced(ezStringView sAbsolutePath) const

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -293,6 +293,7 @@ void ezAssetCurator::TrackDependencies(ezAssetInfo* pAssetInfo)
 {
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_TransformDependencies, m_InverseTransformDeps, m_UnresolvedTransformDeps, true);
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_ThumbnailDependencies, m_InverseThumbnailDeps, m_UnresolvedThumbnailDeps, true);
+  UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_PackageDependencies, m_InversePackageDeps, m_UnresolvedPackageDeps, true);
 
   const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_pDocumentTypeDescriptor, pAssetInfo->m_Path, "");
   auto it = m_InverseThumbnailDeps.FindOrAdd(sTargetFile);
@@ -308,12 +309,14 @@ void ezAssetCurator::TrackDependencies(ezAssetInfo* pAssetInfo)
   // If pAssetInfo was previously an unresolved dependency, these two calls will update the inverse dep tables now that it can be resolved.
   UpdateUnresolvedTrackedFiles(m_InverseTransformDeps, m_UnresolvedTransformDeps);
   UpdateUnresolvedTrackedFiles(m_InverseThumbnailDeps, m_UnresolvedThumbnailDeps);
+  UpdateUnresolvedTrackedFiles(m_InversePackageDeps, m_UnresolvedPackageDeps);
 }
 
 void ezAssetCurator::UntrackDependencies(ezAssetInfo* pAssetInfo)
 {
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_TransformDependencies, m_InverseTransformDeps, m_UnresolvedTransformDeps, false);
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_ThumbnailDependencies, m_InverseThumbnailDeps, m_UnresolvedThumbnailDeps, false);
+  UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_PackageDependencies, m_InversePackageDeps, m_UnresolvedPackageDeps, false);
 
   const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_pDocumentTypeDescriptor, pAssetInfo->m_Path, "");
   auto it = m_InverseThumbnailDeps.FindOrAdd(sTargetFile);


### PR DESCRIPTION
E.g. when deleting a collision mesh asset, it wouldn't detect that a static actor component was referencing that, since that reference was a package dependency, which wasn't tracked before.