### PR TITLE
Editor usabiliy improvements

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
@@ -198,7 +198,7 @@ void ezAssetAction::Execute(const ezVariant& value)
     case ezAssetAction::ButtonType::SelectInAssetBrowser:
     {
       ezQtAssetBrowserPanel::GetSingleton()->AssetBrowserWidget->SetSelectedAsset(m_Context.m_pDocument->GetGuid());
-      ezQtAssetBrowserPanel::GetSingleton()->raise();
+      ezQtAssetBrowserPanel::GetSingleton()->EnsureVisible();
     }
     break;
   }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -10,6 +10,7 @@
 #include <EditorFramework/Assets/AssetProcessor.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Preferences/EditorPreferences.h>
+#include <Foundation/Application/Application.h>
 #include <Foundation/Strings/TranslationLookup.h>
 #include <GuiFoundation/ActionViews/ToolBarActionMapView.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
@@ -801,43 +802,59 @@ void ezQtAssetBrowserWidget::DeleteAndReplaceSelection()
     return;
   }
 
-  // Show warning about number of references
-  // Yes = choose replacement, No = delete without replacement, Cancel = abort
-  QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(
-    ezFmt("This asset is referenced by {} other asset(s).\n\n"
-          "Do you want to choose a replacement asset and update all references before deleting?",
-      uses.GetCount()),
-    QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No | QMessageBox::StandardButton::Cancel,
-    QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
+  // Ask what should happen to the existing references. The three actions are distinct enough that
+  // standard Yes/No/Cancel labels would be ambiguous, so custom button texts are used.
+  enum class RefAction
+  {
+    Abort,
+    Replace,      ///< point all references at another asset
+    Clear,        ///< empty all references, leaving the using assets without one
+    LeaveDangling ///< delete and let the references become invalid
+  };
 
-  if (choice == QMessageBox::StandardButton::Cancel)
+  RefAction refAction = RefAction::Abort;
+
+  ezStringBuilder sQuestion;
+  sQuestion.SetFormat("This asset is referenced by {} other asset(s).\n\n"
+                      "What should happen to those references?",
+    uses.GetCount());
+
+  if (ezQtUiServices::IsUnattended())
+  {
+    // an automated caller must not silently modify other assets
+    ezQtUiServices::ReportSuppressedDialog(ezStringBuilder("Question, answered automatically: ", sQuestion));
+    refAction = RefAction::Abort;
+  }
+  else
+  {
+    QMessageBox box(this);
+    box.setWindowTitle(ezMakeQString(ezApplication::GetApplicationInstance()->GetApplicationName()));
+    box.setText(ezMakeQString(sQuestion));
+    box.setIcon(QMessageBox::Icon::Question);
+
+    QPushButton* pReplaceBtn = box.addButton(QLatin1String("Replace With Other Asset..."), QMessageBox::ButtonRole::AcceptRole);
+    QPushButton* pClearBtn = box.addButton(QLatin1String("Clear References"), QMessageBox::ButtonRole::DestructiveRole);
+    QPushButton* pDeleteBtn = box.addButton(QLatin1String("Delete Anyway"), QMessageBox::ButtonRole::DestructiveRole);
+    box.addButton(QMessageBox::StandardButton::Cancel);
+    box.setDefaultButton(pReplaceBtn);
+
+    box.exec();
+
+    if (box.clickedButton() == pReplaceBtn)
+      refAction = RefAction::Replace;
+    else if (box.clickedButton() == pClearBtn)
+      refAction = RefAction::Clear;
+    else if (box.clickedButton() == pDeleteBtn)
+      refAction = RefAction::LeaveDangling;
+  }
+
+  if (refAction == RefAction::Abort)
     return;
 
-  if (choice == QMessageBox::StandardButton::No)
+  if (refAction == RefAction::LeaveDangling)
   {
-    // Delete without replacement
+    // Delete without touching the references
     DeleteSelection(false);
-    return;
-  }
-
-  // Show asset browser dialog to pick replacement (filtered to same asset type)
-  ezQtAssetBrowserDlg dlg(this, assetGuid, sAssetTypeName, "Select Replacement Asset");
-
-  if (dlg.exec() != QDialog::Accepted)
-    return;
-
-  ezUuid replacementGuid = dlg.GetSelectedAssetGuid();
-
-  // Verify replacement is valid and different
-  if (!replacementGuid.IsValid())
-  {
-    ezQtUiServices::MessageBoxWarning("No replacement asset was selected.");
-    return;
-  }
-
-  if (replacementGuid == assetGuid)
-  {
-    ezQtUiServices::MessageBoxWarning("The replacement asset must be different from the asset being deleted.");
     return;
   }
 
@@ -845,11 +862,40 @@ void ezQtAssetBrowserWidget::DeleteAndReplaceSelection()
   ezStringBuilder sOldReference;
   ezConversionUtils::ToString(assetGuid, sOldReference);
 
+  // An empty string is the 'no asset set' value, so clearing is a replacement with nothing.
   ezStringBuilder sNewReference;
-  ezConversionUtils::ToString(replacementGuid, sNewReference);
+
+  if (refAction == RefAction::Replace)
+  {
+    // Show asset browser dialog to pick replacement (filtered to same asset type)
+    ezQtAssetBrowserDlg dlg(this, assetGuid, sAssetTypeName, "Select Replacement Asset");
+
+    if (dlg.exec() != QDialog::Accepted)
+      return;
+
+    ezUuid replacementGuid = dlg.GetSelectedAssetGuid();
+
+    // Verify replacement is valid and different
+    if (!replacementGuid.IsValid())
+    {
+      ezQtUiServices::MessageBoxWarning("No replacement asset was selected.");
+      return;
+    }
+
+    if (replacementGuid == assetGuid)
+    {
+      ezQtUiServices::MessageBoxWarning("The replacement asset must be different from the asset being deleted.");
+      return;
+    }
+
+    ezConversionUtils::ToString(replacementGuid, sNewReference);
+  }
 
   // Perform replacements in all using documents
   ezAssetCurator::ReplaceAssetResult result = ezAssetCurator::GetSingleton()->ReplaceAssetReferenceInUses(assetGuid, sOldReference, sNewReference);
+
+  const char* szVerbNoun = (refAction == RefAction::Clear) ? "Clearing references" : "Replacement";
+  const char* szVerbPast = (refAction == RefAction::Clear) ? "cleared" : "replaced";
 
   // Build result message
   ezStringBuilder sResultMsg;
@@ -857,15 +903,17 @@ void ezQtAssetBrowserWidget::DeleteAndReplaceSelection()
   if (result.m_uiDocumentsFailed > 0)
   {
     sResultMsg.SetFormat(
-      "Replacement partially completed:\n\n"
+      "{} partially completed:\n\n"
       "- {} document(s) modified successfully\n"
       "- {} document(s) failed\n"
-      "- {} property reference(s) replaced\n\n"
+      "- {} property reference(s) {}\n\n"
       "The original asset was NOT deleted due to errors.\n\n"
       "Errors:\n",
+      szVerbNoun,
       result.m_uiDocumentsModified,
       result.m_uiDocumentsFailed,
-      result.m_uiPropertiesReplaced);
+      result.m_uiPropertiesReplaced,
+      szVerbPast);
 
     for (const ezString& error : result.m_Errors)
     {
@@ -881,13 +929,15 @@ void ezQtAssetBrowserWidget::DeleteAndReplaceSelection()
   if (!QFile::moveToTrash(sQtAbsPath))
   {
     sResultMsg.SetFormat(
-      "Replacements completed successfully:\n"
+      "{} completed successfully:\n"
       "- {} document(s) modified\n"
-      "- {} property reference(s) replaced\n\n"
+      "- {} property reference(s) {}\n\n"
       "However, failed to delete the original file:\n{}\n\n"
       "You may need to delete it manually.",
+      szVerbNoun,
       result.m_uiDocumentsModified,
       result.m_uiPropertiesReplaced,
+      szVerbPast,
       sAbsPath);
 
     ezQtUiServices::MessageBoxWarning(sResultMsg);
@@ -898,12 +948,14 @@ void ezQtAssetBrowserWidget::DeleteAndReplaceSelection()
 
   // Complete success
   sResultMsg.SetFormat(
-    "Delete & Replace completed successfully:\n\n"
+    "{} completed successfully:\n\n"
     "- {} document(s) modified\n"
-    "- {} property reference(s) replaced\n"
+    "- {} property reference(s) {}\n"
     "- Original asset deleted",
+    szVerbNoun,
     result.m_uiDocumentsModified,
-    result.m_uiPropertiesReplaced);
+    result.m_uiPropertiesReplaced,
+    szVerbPast);
 
   ezQtUiServices::MessageBoxInformation(sResultMsg);
 }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
@@ -39,10 +39,15 @@ private Q_SLOTS:
   // note, because of the way we set up the widget, auto-connect doesn't work
   void onListAssetsDoubleClicked(const QModelIndex& index);
   void onCheckIndirectToggled(bool checked);
+  void onListAssetsContextMenuRequested(const QPoint& pos);
 
 private:
   void LogWriter(const ezLoggingEventData& e);
   void UpdateIssueInfo();
+
+  /// Returns the index of the item the context menu should operate on, which is the current
+  /// selection. Returns an invalid index if nothing is selected.
+  QModelIndex GetContextMenuTarget() const;
 
   QSharedPointer<ezQtAssetBrowserModel> m_Model;
   ezQtAssetCuratorFilter* m_pFilter;

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -5,8 +5,8 @@
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetProcessor.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
-#include <EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h>
 #include <EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.moc.h>
+#include <EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h>
 #include <GuiFoundation/Models/LogModel.moc.h>
 #include <QMenu>
 
@@ -187,7 +187,7 @@ void ezQtAssetCuratorPanel::onListAssetsContextMenuRequested(const QPoint& pos)
         return;
 
       ezQtAssetBrowserPanel::GetSingleton()->AssetBrowserWidget->SetSelectedAsset(assetGuid);
-      ezQtAssetBrowserPanel::GetSingleton()->raise(); //
+      ezQtAssetBrowserPanel::GetSingleton()->EnsureVisible(); //
     });
 
   // the double click default action is 'open', so make that the bold default entry as well

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -6,7 +6,9 @@
 #include <EditorFramework/Assets/AssetProcessor.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h>
+#include <EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.moc.h>
 #include <GuiFoundation/Models/LogModel.moc.h>
+#include <QMenu>
 
 ezQtAssetCuratorFilter::ezQtAssetCuratorFilter(QObject* pParent)
   : ezQtAssetFilter(pParent)
@@ -81,6 +83,7 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
 
   connect(ListAssets, &QTreeView::doubleClicked, this, &ezQtAssetCuratorPanel::onListAssetsDoubleClicked);
   connect(CheckIndirect, &QCheckBox::toggled, this, &ezQtAssetCuratorPanel::onCheckIndirectToggled);
+  connect(ListAssets, &QWidget::customContextMenuRequested, this, &ezQtAssetCuratorPanel::onListAssetsContextMenuRequested);
 
   ezAssetProcessor::GetSingleton()->AddLogWriter(ezMakeDelegate(&ezQtAssetCuratorPanel::LogWriter, this));
 
@@ -142,6 +145,55 @@ void ezQtAssetCuratorPanel::onListAssetsDoubleClicked(const QModelIndex& index)
   QString sAbsPath = m_Model->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
 
   ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sAbsPath.toUtf8().data());
+}
+
+QModelIndex ezQtAssetCuratorPanel::GetContextMenuTarget() const
+{
+  return ListAssets->selectionModel()->currentIndex();
+}
+
+void ezQtAssetCuratorPanel::onListAssetsContextMenuRequested(const QPoint& pos)
+{
+  // make the item under the cursor the current one, so that the menu always acts on what was clicked
+  const QModelIndex clicked = ListAssets->indexAt(pos);
+  if (clicked.isValid())
+  {
+    ListAssets->selectionModel()->setCurrentIndex(clicked, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+  }
+
+  const QModelIndex index = GetContextMenuTarget();
+  if (!index.isValid())
+    return;
+
+  QMenu menu;
+
+  QAction* pOpen = menu.addAction(ezMakeQString(ezTranslate("AssetCurator.OpenDocument")));
+  connect(pOpen, &QAction::triggered, this, [this]()
+    {
+      const QModelIndex idx = GetContextMenuTarget();
+      if (idx.isValid())
+        onListAssetsDoubleClicked(idx); //
+    });
+
+  QAction* pSelect = menu.addAction(ezMakeQString(ezTranslate("AssetCurator.SelectInAssetBrowser")));
+  connect(pSelect, &QAction::triggered, this, [this]()
+    {
+      const QModelIndex idx = GetContextMenuTarget();
+      if (!idx.isValid())
+        return;
+
+      const ezUuid assetGuid = m_Model->data(idx, ezQtAssetBrowserModel::UserRoles::AssetGuid).value<ezUuid>();
+      if (!assetGuid.IsValid())
+        return;
+
+      ezQtAssetBrowserPanel::GetSingleton()->AssetBrowserWidget->SetSelectedAsset(assetGuid);
+      ezQtAssetBrowserPanel::GetSingleton()->raise(); //
+    });
+
+  // the double click default action is 'open', so make that the bold default entry as well
+  menu.setDefaultAction(pOpen);
+
+  menu.exec(ListAssets->viewport()->mapToGlobal(pos));
 }
 
 void ezQtAssetCuratorPanel::onCheckIndirectToggled(bool checked)

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -327,7 +327,7 @@ void ezQtAssetPropertyWidget::OnOpenAssetDocument()
 void ezQtAssetPropertyWidget::OnSelectInAssetBrowser()
 {
   ezQtAssetBrowserPanel::GetSingleton()->AssetBrowserWidget->SetSelectedAsset(m_AssetGuid);
-  ezQtAssetBrowserPanel::GetSingleton()->raise();
+  ezQtAssetBrowserPanel::GetSingleton()->EnsureVisible();
 }
 
 void ezQtAssetPropertyWidget::OnOpenExplorer()

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -340,6 +340,13 @@ ezTransformStatus ezSkeletonAssetDocument::InternalTransformAsset(ezStreamWriter
 
       range.BeginNextStep("Importing Skeleton Data");
 
+      // merging rewrites the joint hierarchy in this document, which can't be saved back to disk
+      // during background processing, so the asset has to be transformed in the editor instead
+      if (transformFlags.IsSet(ezTransformFlags::BackgroundProcessing) && WouldSkeletonHierarchyChange(newSkeleton))
+      {
+        return ezTransformStatus(ezTransformResult::NeedsImport);
+      }
+
       // synchronize the old data (collision geometry etc.) with the new hierarchy
       const ezEditableSkeleton* pFinalSkeleton = MergeWithNewSkeleton(newSkeleton);
 
@@ -374,6 +381,39 @@ ezTransformStatus ezSkeletonAssetDocument::InternalCreateThumbnail(const Thumbna
 
   ezStatus status = ezAssetDocument::RemoteCreateThumbnail(ThumbnailInfo);
   return status;
+}
+
+bool ezSkeletonAssetDocument::WouldSkeletonHierarchyChange(const ezEditableSkeleton& newSkeleton) const
+{
+  auto CompareJoints = [](const auto& self, const ezEditableSkeletonJoint* pOld, const ezEditableSkeletonJoint* pNew) -> bool
+  {
+    if (!ezStringUtils::IsEqual(pOld->GetName(), pNew->GetName()))
+      return true;
+
+    if (pOld->m_Children.GetCount() != pNew->m_Children.GetCount())
+      return true;
+
+    for (ezUInt32 i = 0; i < pOld->m_Children.GetCount(); ++i)
+    {
+      if (self(self, pOld->m_Children[i], pNew->m_Children[i]))
+        return true;
+    }
+
+    return false;
+  };
+
+  const ezEditableSkeleton* pOldSkeleton = GetProperties();
+
+  if (pOldSkeleton->m_Children.GetCount() != newSkeleton.m_Children.GetCount())
+    return true;
+
+  for (ezUInt32 i = 0; i < pOldSkeleton->m_Children.GetCount(); ++i)
+  {
+    if (CompareJoints(CompareJoints, pOldSkeleton->m_Children[i], newSkeleton.m_Children[i]))
+      return true;
+  }
+
+  return false;
 }
 
 const ezEditableSkeleton* ezSkeletonAssetDocument::MergeWithNewSkeleton(ezEditableSkeleton& newSkeleton)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -68,6 +68,9 @@ protected:
 
   const ezEditableSkeleton* MergeWithNewSkeleton(ezEditableSkeleton& newSkeleton);
 
+  /// Whether merging in newSkeleton would change the joint hierarchy stored in this document.
+  bool WouldSkeletonHierarchyChange(const ezEditableSkeleton& newSkeleton) const;
+
   ezEvent<const ezSkeletonAssetEvent&> m_Events;
   bool m_bRenderBones = true;
   bool m_bRenderColliders = true;

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
@@ -50,11 +50,21 @@ void ezTextureContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
 
     if (pMsg2->m_sWhatToDo == "SetChannelMode")
     {
+      m_iChannelMode = pMsg2->m_iValue;
+      m_fAlphaThreshold = pMsg2->m_fValue;
+
       for (auto& slice : m_SlicePreviews)
       {
         ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-        pMaterial->SetParameter("ShowChannelMode", pMsg2->m_iValue);
-        pMaterial->SetParameter("AlphaThreshold", pMsg2->m_fValue);
+        if (pMaterial.GetAcquireResult() != ezResourceAcquireResult::Final)
+        {
+          // Would modify the loading fallback; retry once the real material is loaded.
+          m_bSliceMaterialsDirty = true;
+          break;
+        }
+
+        pMaterial->SetParameter("ShowChannelMode", m_iChannelMode);
+        pMaterial->SetParameter("AlphaThreshold", m_fAlphaThreshold);
       }
     }
     else if (pMsg2->m_sWhatToDo == "SetLodLevel")
@@ -65,7 +75,13 @@ void ezTextureContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
         for (auto& slice : m_SlicePreviews)
         {
           ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-          pMaterial->SetParameter("LodLevel", pMsg2->m_iValue);
+          if (pMaterial.GetAcquireResult() != ezResourceAcquireResult::Final)
+          {
+            m_bSliceMaterialsDirty = true;
+            break;
+          }
+
+          pMaterial->SetParameter("LodLevel", m_iLodLevel);
         }
       }
     }
@@ -91,6 +107,13 @@ void ezTextureContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
       }
     }
     RebuildPreviewObjects(uiArraySlices);
+
+    // Applying the material parameters can fail while the materials are still loading (a loading
+    // fallback would be modified instead of the real material). In that case retry on the next redraw.
+    if (m_bSliceMaterialsDirty)
+    {
+      ApplySliceMaterialParameters();
+    }
   }
 
   ezEngineProcessDocumentContext::HandleMessage(pMsg);
@@ -152,10 +175,18 @@ void ezTextureContext::RebuildPreviewObjects(ezUInt32 uiNumArraySlices)
   if (uiNumArraySlices == 0)
     uiNumArraySlices = 1;
 
-  if (uiNumArraySlices == m_uiNumArraySlices)
+  if (uiNumArraySlices == m_uiNumArraySlices && !m_bPreviewObjectsDirty)
     return;
 
   m_uiNumArraySlices = uiNumArraySlices;
+  m_bPreviewObjectsDirty = false;
+
+  // The slice materials are created resources, so they have no data loader and can never be reloaded
+  // once their data was unloaded (which happens when the document is closed and the material loses its
+  // last reference). Reusing such a name would yield a material without base material or shader, which
+  // renders as the fallback texture. A process wide counter keeps every batch of materials distinct.
+  static ezAtomicInteger32 s_uiNextMaterialGeneration = 0;
+  m_uiMaterialGeneration = (ezUInt32)s_uiNextMaterialGeneration.Increment();
 
   ezStringBuilder sTextureGuid;
   ezConversionUtils::ToString(GetDocumentGuid(), sTextureGuid);
@@ -176,24 +207,11 @@ void ezTextureContext::RebuildPreviewObjects(ezUInt32 uiNumArraySlices)
   {
     // Per-slice material
     ezStringBuilder sMaterialName;
-    sMaterialName.SetFormat("{} - Texture Preview Slice {}", sTextureGuid, i);
+    sMaterialName.SetFormat("{}-{} - Texture Preview Slice {}", sTextureGuid, m_uiMaterialGeneration, i);
 
-    ezMaterialResourceHandle hMaterial = ezResourceManager::GetExistingResource<ezMaterialResource>(sMaterialName);
-    if (!hMaterial.IsValid())
-    {
-      ezMaterialResourceDescriptor md;
-      md.m_hBaseMaterial = ezResourceManager::LoadResource<ezMaterialResource>("Editor/Materials/TexturePreview.ezMaterial");
-      hMaterial = ezResourceManager::GetOrCreateResource<ezMaterialResource>(sMaterialName, std::move(md));
-    }
-
-    {
-      ezResourceLock<ezMaterialResource> pMaterial(hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-      pMaterial->SetParameter("ArrayIndex", (int)i);
-      pMaterial->SetParameter("LodLevel", m_iLodLevel);
-
-      if (m_hTexture.IsValid())
-        pMaterial->SetTexture2DBinding("BaseTexture", m_hTexture);
-    }
+    ezMaterialResourceDescriptor md;
+    md.m_hBaseMaterial = ezResourceManager::LoadResource<ezMaterialResource>("Editor/Materials/TexturePreview.ezMaterial");
+    ezMaterialResourceHandle hMaterial = ezResourceManager::GetOrCreateResource<ezMaterialResource>(sMaterialName, std::move(md));
 
     // Game object at stacked position
     ezGameObjectDesc obj;
@@ -213,6 +231,42 @@ void ezTextureContext::RebuildPreviewObjects(ezUInt32 uiNumArraySlices)
     slice.m_hMeshComponent = hMeshComp;
     slice.m_hMaterial = hMaterial;
   }
+
+  m_bSliceMaterialsDirty = true;
+  ApplySliceMaterialParameters();
+}
+
+void ezTextureContext::ApplySliceMaterialParameters()
+{
+  ezUInt32 uiArrayIndex = 0;
+
+  for (auto& slice : m_SlicePreviews)
+  {
+    ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+
+    if (pMaterial.GetAcquireResult() != ezResourceAcquireResult::Final)
+      return;
+
+    pMaterial->SetParameter("ArrayIndex", (int)uiArrayIndex);
+    pMaterial->SetParameter("LodLevel", m_iLodLevel);
+    pMaterial->SetParameter("ShowChannelMode", m_iChannelMode);
+    pMaterial->SetParameter("AlphaThreshold", m_fAlphaThreshold);
+
+    if (m_hTexture.IsValid())
+    {
+      pMaterial->SetTexture2DBinding("BaseTexture", m_hTexture);
+
+      ezResourceLock<ezTexture2DResource> pTexture(m_hTexture, ezResourceAcquireMode::PointerOnly);
+      if (pTexture->GetFormat() != ezGALResourceFormat::Invalid)
+      {
+        pMaterial->SetParameter("IsLinear", !ezGALResourceFormat::IsSrgb(pTexture->GetFormat()));
+      }
+    }
+
+    ++uiArrayIndex;
+  }
+
+  m_bSliceMaterialsDirty = false;
 }
 
 void ezTextureContext::SetTexture(ezStringView sTextureFile)
@@ -227,8 +281,8 @@ void ezTextureContext::SetTexture(ezStringView sTextureFile)
     pTexture->m_ResourceEvents.AddEventHandler(ezMakeDelegate(&ezTextureContext::OnResourceEvent, this), m_TextureResourceEventSubscriber);
   }
 
-  // Reset slice count so the next redraw triggers a rebuild with the new texture.
-  m_uiNumArraySlices = 0;
+  m_bPreviewObjectsDirty = true;
+  m_bSliceMaterialsDirty = true;
 }
 
 void ezTextureContext::OnResourceEvent(const ezResourceEvent& e)
@@ -238,15 +292,8 @@ void ezTextureContext::OnResourceEvent(const ezResourceEvent& e)
     const ezTexture2DResource* pTexture = static_cast<const ezTexture2DResource*>(e.m_pResource);
     if (pTexture->GetFormat() != ezGALResourceFormat::Invalid)
     {
-      const bool bIsLinear = !ezGALResourceFormat::IsSrgb(pTexture->GetFormat());
-      for (auto& slice : m_SlicePreviews)
-      {
-        ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::BlockTillLoaded);
-        pMaterial->SetParameter("IsLinear", bIsLinear);
-      }
-
-      // Force a rebuild on the next redraw in case the array size changed.
-      m_uiNumArraySlices = 0;
+      m_bPreviewObjectsDirty = true;
+      m_bSliceMaterialsDirty = true;
     }
   }
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.h
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.h
@@ -32,6 +32,10 @@ protected:
 
 private:
   void SetTexture(ezStringView sTextureFile);
+
+  /// Applies all preview parameters to the slice materials. Does nothing and leaves
+  /// m_bSliceMaterialsDirty set if the materials are not loaded yet, so that it gets retried.
+  void ApplySliceMaterialParameters();
   void OnResourceEvent(const ezResourceEvent& e);
   void RebuildPreviewObjects(ezUInt32 uiNumArraySlices);
 
@@ -49,5 +53,10 @@ private:
   ezEvent<const ezResourceEvent&, ezMutex>::Unsubscriber m_TextureResourceEventSubscriber;
 
   ezUInt32 m_uiNumArraySlices = 0;
+  ezUInt32 m_uiMaterialGeneration = 0;
+  bool m_bPreviewObjectsDirty = true;
+  bool m_bSliceMaterialsDirty = true;
   int m_iLodLevel = -1;
+  int m_iChannelMode = 0;
+  float m_fAlphaThreshold = 0.0f;
 };

--- a/Code/Tools/Libs/GuiFoundation/Action/DocumentActions.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/DocumentActions.h
@@ -24,6 +24,7 @@ public:
   static ezActionDescriptorHandle s_hCloseAllButThis;
 
   static ezActionDescriptorHandle s_hOpenContainingFolder;
+  static ezActionDescriptorHandle s_hCopyDocumentPath;
 
   static ezActionDescriptorHandle s_hUpdatePrefabs;
 };
@@ -44,6 +45,7 @@ public:
     CloseAll,
     CloseAllButThis,
     OpenContainingFolder,
+    CopyDocumentPath,
     UpdatePrefabs,
   };
   ezDocumentAction(const ezActionContext& context, const char* szName, ButtonType button);

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
@@ -29,6 +29,7 @@ ezActionDescriptorHandle ezDocumentActions::s_hClose;
 ezActionDescriptorHandle ezDocumentActions::s_hCloseAll;
 ezActionDescriptorHandle ezDocumentActions::s_hCloseAllButThis;
 ezActionDescriptorHandle ezDocumentActions::s_hOpenContainingFolder;
+ezActionDescriptorHandle ezDocumentActions::s_hCopyDocumentPath;
 ezActionDescriptorHandle ezDocumentActions::s_hUpdatePrefabs;
 
 void ezDocumentActions::RegisterActions()
@@ -41,6 +42,7 @@ void ezDocumentActions::RegisterActions()
   s_hCloseAll = EZ_REGISTER_ACTION_1("Document.CloseAll", ezActionScope::Document, "Document", "Ctrl+Shift+W", ezDocumentAction, ezDocumentAction::ButtonType::CloseAll);
   s_hCloseAllButThis = EZ_REGISTER_ACTION_1("Document.CloseAllButThis", ezActionScope::Document, "Document", "Shift+Alt+W", ezDocumentAction, ezDocumentAction::ButtonType::CloseAllButThis);
   s_hOpenContainingFolder = EZ_REGISTER_ACTION_1("Document.OpenContainingFolder", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::OpenContainingFolder);
+  s_hCopyDocumentPath = EZ_REGISTER_ACTION_1("Document.CopyDocumentPath", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::CopyDocumentPath);
   s_hUpdatePrefabs = EZ_REGISTER_ACTION_1("Prefabs.UpdateAll", ezActionScope::Document, "Scene", "Ctrl+Shift+P", ezDocumentAction, ezDocumentAction::ButtonType::UpdatePrefabs);
 }
 
@@ -54,6 +56,7 @@ void ezDocumentActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hCloseAll);
   ezActionManager::UnregisterAction(s_hCloseAllButThis);
   ezActionManager::UnregisterAction(s_hOpenContainingFolder);
+  ezActionManager::UnregisterAction(s_hCopyDocumentPath);
   ezActionManager::UnregisterAction(s_hUpdatePrefabs);
 }
 
@@ -69,6 +72,7 @@ void ezDocumentActions::MapMenuActions(ezStringView sMapping, ezStringView sTarg
   pMap->MapAction(s_hCloseAll, sTargetMenu, 9.0f);
   pMap->MapAction(s_hCloseAllButThis, sTargetMenu, 10.0f);
   pMap->MapAction(s_hOpenContainingFolder, sTargetMenu, 11.0f);
+  pMap->MapAction(s_hCopyDocumentPath, sTargetMenu, 12.0f);
 }
 
 void ezDocumentActions::MapToolbarActions(ezStringView sMapping)
@@ -123,6 +127,9 @@ ezDocumentAction::ezDocumentAction(const ezActionContext& context, const char* s
       break;
     case ezDocumentAction::ButtonType::OpenContainingFolder:
       SetIconPath(":/GuiFoundation/Icons/OpenFolder.svg");
+      break;
+    case ezDocumentAction::ButtonType::CopyDocumentPath:
+      SetIconPath("");
       break;
     case ezDocumentAction::ButtonType::UpdatePrefabs:
       SetIconPath(":/EditorPluginScene/Icons/PrefabUpdate.svg");
@@ -294,6 +301,22 @@ void ezDocumentAction::Execute(const ezVariant& value)
         sPath = m_Context.m_pDocument->GetDocumentPath();
 
       ezQtUiServices::OpenInExplorer(sPath, true);
+    }
+    break;
+
+    case ezDocumentAction::ButtonType::CopyDocumentPath:
+    {
+      if (m_Context.m_pDocument == nullptr)
+        return;
+
+      ezStringBuilder sPath = m_Context.m_pDocument->GetDocumentPath();
+      sPath.MakePathSeparatorsNative();
+
+      QMimeData* pMimeData = new QMimeData();
+      pMimeData->setText(ezMakeQString(sPath));
+      QApplication::clipboard()->setMimeData(pMimeData);
+
+      ezQtUiServices::ShowAllDocumentsTemporaryStatusBarMessage(ezFmt("Copied path: {}", sPath), ezTime::MakeFromSeconds(5));
     }
     break;
 

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -81,6 +81,7 @@ Document.Close;Close
 Document.CloseAll;Close All
 Document.CloseAllButThis;Close All But This
 Document.OpenContainingFolder;Open in Explorer
+Document.CopyDocumentPath;Copy Path;Stores the absolute path of the document in the clipboard.
 Document.MoveWindow;Move to Container Window
 Document.NewWindow;New Container Window
 Document.Undo;Undo
@@ -103,6 +104,8 @@ Asset.WriteLookupTable;Write Lookup Table
 Asset.Help;Open Asset Documentation;Open online documentation for this asset type
 Asset.CopyAssetGuid;Copy Asset Guid;Stores the assets GUID in the clipboard.
 Asset.SelectInAssetBrowser;Select in Asset Browser
+AssetCurator.OpenDocument;Open Document
+AssetCurator.SelectInAssetBrowser;Select in Asset Browser
 Asset.CameraMode;Camera Mode
 
 # Prefabs


### PR DESCRIPTION
* "Select in Asset Browser" now always brings the browser to the foreground
* Added "Copy Path" option to document tabs
* Added context menu to document list in the Asset Curator, to allow to "Select in Asset Browser" (and not only open) the document.
  
  <img width="555" height="162" alt="grafik" src="https://github.com/user-attachments/assets/093cda01-bc58-41d9-a80b-7b78945b4a35" />

* Improved asset "Delete & Replace" option to also allow to just clear existing references. Also the dialog button names are now much clearer.

  <img width="743" height="382" alt="grafik" src="https://github.com/user-attachments/assets/4379c2bc-e7fe-47e1-b99c-a917a9f5e24e" />

* Fixed an issue in the texture preview that sometimes resulted in different textures getting displayed.