### PR TITLE
Added asset browser actions to create LODs, colliders and prefabs from meshes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserContext.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserContext.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Types/Uuid.h>
+#include <GuiFoundation/Action/ActionManager.h>
+
+/// The asset browser selection that an action from the "AssetBrowserContextMenu" action map operates on.
+///
+/// ezActionContext carries no selection, and the actions behind the menu entries are cached and reused,
+/// so they must read the selection here from ezAction::RefreshState() and Execute() rather than
+/// capture it in their constructor.
+///
+/// Empty except while that context menu is being built or is open, which actions have to handle.
+struct EZ_EDITORFRAMEWORK_DLL ezAssetBrowserSelection
+{
+  /// Guids of the selected sub-assets. For assets that have no sub-assets this is the asset guid.
+  ezDynamicArray<ezUuid> m_SubAssetGuids;
+
+  /// Guids of the owning (main) assets, with duplicates removed. Can be shorter than m_SubAssetGuids.
+  ezDynamicArray<ezUuid> m_AssetGuids;
+
+  /// Absolute paths of all selected items, including plain files and folders that are not assets.
+  ezDynamicArray<ezString> m_AbsolutePaths;
+
+  static const ezAssetBrowserSelection& GetCurrent();
+
+  /// Called by the asset browser before it shows its context menu, and again with an empty selection
+  /// once the menu is closed.
+  static void SetCurrent(ezAssetBrowserSelection&& ref_selection);
+};
+
+/// The sub-menu of the "AssetBrowserContextMenu" action map that holds operations specific to the
+/// type of the selected asset, e.g. creating a prefab or a collision mesh from a mesh.
+///
+/// Registered here rather than by any one plugin, because several plugins map into it. Pass the name
+/// to ezActionMap::MapAction() as the sub-path.
+struct EZ_EDITORFRAMEWORK_DLL ezAssetBrowserContextMenu
+{
+  /// The name to map into, and the action name that the localization files give a display name to.
+  static constexpr ezStringView s_sAssetMenu = "AssetBrowser.AssetMenu"_ezsv;
+
+  /// Called once during editor startup, before any plugin maps into the menu.
+  static void RegisterActions();
+  static void UnregisterActions();
+
+  /// Puts the sub-menu into the "AssetBrowserContextMenu" map. Must have happened before a plugin
+  /// maps anything into it, so this is called during editor startup as well.
+  static void MapActions();
+
+  static ezActionDescriptorHandle s_hAssetMenu;
+};

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserContext.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserContext.h
@@ -27,7 +27,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetBrowserSelection
 
   /// Called by the asset browser before it shows its context menu, and again with an empty selection
   /// once the menu is closed.
-  static void SetCurrent(ezAssetBrowserSelection&& ref_selection);
+  static void SetCurrent(ezAssetBrowserSelection&& selection);
 };
 
 /// The sub-menu of the "AssetBrowserContextMenu" action map that holds operations specific to the

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <EditorFramework/Assets/AssetBrowserContext.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_AssetBrowserWidget.h>
 #include <ToolsFoundation/FileSystem/FileSystemModel.h>
@@ -109,6 +110,7 @@ private:
   void AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedAsset);
   void AddImportedViaMenu(QMenu* pMenu);
   void GetSelectedImportableFiles(ezDynamicArray<ezString>& out_Files) const;
+  ezAssetBrowserSelection GetCurrentSelectionForActions() const;
 
   Mode m_Mode = Mode::Browser;
   ezQtToolBarActionMapView* m_pToolbar = nullptr;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserContext.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserContext.cpp
@@ -14,9 +14,9 @@ const ezAssetBrowserSelection& ezAssetBrowserSelection::GetCurrent()
   return s_CurrentAssetBrowserSelection;
 }
 
-void ezAssetBrowserSelection::SetCurrent(ezAssetBrowserSelection&& ref_selection)
+void ezAssetBrowserSelection::SetCurrent(ezAssetBrowserSelection&& selection)
 {
-  s_CurrentAssetBrowserSelection = std::move(ref_selection);
+  s_CurrentAssetBrowserSelection = std::move(selection);
 }
 
 ezActionDescriptorHandle ezAssetBrowserContextMenu::s_hAssetMenu;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserContext.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserContext.cpp
@@ -1,0 +1,40 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetBrowserContext.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+#include <GuiFoundation/Action/BaseActions.h>
+
+namespace
+{
+  ezAssetBrowserSelection s_CurrentAssetBrowserSelection;
+} // namespace
+
+const ezAssetBrowserSelection& ezAssetBrowserSelection::GetCurrent()
+{
+  return s_CurrentAssetBrowserSelection;
+}
+
+void ezAssetBrowserSelection::SetCurrent(ezAssetBrowserSelection&& ref_selection)
+{
+  s_CurrentAssetBrowserSelection = std::move(ref_selection);
+}
+
+ezActionDescriptorHandle ezAssetBrowserContextMenu::s_hAssetMenu;
+
+void ezAssetBrowserContextMenu::RegisterActions()
+{
+  s_hAssetMenu = EZ_REGISTER_MENU_WITH_ICON("AssetBrowser.AssetMenu", ":/GuiFoundation/Icons/Document.svg");
+}
+
+void ezAssetBrowserContextMenu::MapActions()
+{
+  ezActionMap* pMap = ezActionMapManager::GetActionMap("AssetBrowserContextMenu");
+  EZ_ASSERT_DEV(pMap != nullptr, "The action map 'AssetBrowserContextMenu' does not exist.");
+
+  pMap->MapAction(s_hAssetMenu, "", 1.0f);
+}
+
+void ezAssetBrowserContextMenu::UnregisterActions()
+{
+  ezActionManager::UnregisterAction(s_hAssetMenu);
+}

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -1,5 +1,6 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
+#include <EditorFramework/Assets/AssetBrowserContext.h>
 #include <EditorFramework/Assets/AssetBrowserDlg.moc.h>
 #include <EditorFramework/Assets/AssetBrowserFilter.moc.h>
 #include <EditorFramework/Assets/AssetBrowserFolderView.moc.h>
@@ -12,6 +13,9 @@
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <Foundation/Application/Application.h>
 #include <Foundation/Strings/TranslationLookup.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+#include <GuiFoundation/ActionViews/MenuActionMapView.moc.h>
+#include <GuiFoundation/ActionViews/QtProxy.moc.h>
 #include <GuiFoundation/ActionViews/ToolBarActionMapView.moc.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <QFile>
@@ -471,6 +475,35 @@ void ezQtAssetBrowserWidget::GetSelectedImportableFiles(ezDynamicArray<ezString>
       out_Files.PushBack(qtToEzString(id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString()));
     }
   }
+}
+
+ezAssetBrowserSelection ezQtAssetBrowserWidget::GetCurrentSelectionForActions() const
+{
+  ezAssetBrowserSelection res;
+
+  QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
+  for (const QModelIndex& id : selection)
+  {
+    res.m_AbsolutePaths.PushBack(qtToEzString(id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString()));
+
+    const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)id.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+    if (!itemType.IsAnySet(ezAssetBrowserItemFlags::Asset | ezAssetBrowserItemFlags::SubAsset))
+      continue;
+
+    const ezUuid subAssetGuid = id.data(ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>();
+    if (subAssetGuid.IsValid())
+    {
+      res.m_SubAssetGuids.PushBack(subAssetGuid);
+    }
+
+    const ezUuid assetGuid = id.data(ezQtAssetBrowserModel::UserRoles::AssetGuid).value<ezUuid>();
+    if (assetGuid.IsValid() && !res.m_AssetGuids.Contains(assetGuid))
+    {
+      res.m_AssetGuids.PushBack(assetGuid);
+    }
+  }
+
+  return res;
 }
 
 void ezQtAssetBrowserWidget::on_ListAssets_clicked(const QModelIndex& index)
@@ -1199,6 +1232,11 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
   QMenu m;
   m.setToolTipsVisible(true);
 
+  ezAssetBrowserSelection::SetCurrent(GetCurrentSelectionForActions());
+
+  // the actions below read the selection from here, so it has to stay valid until the menu is closed
+  EZ_SCOPE_EXIT(ezAssetBrowserSelection::SetCurrent(ezAssetBrowserSelection()));
+
   if (ListAssets->selectionModel()->hasSelection())
   {
     bool bShowDocumentActions = false;
@@ -1255,6 +1293,68 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
     }
   }
 
+  // actions that plugins contributed for specific asset types.
+  // Holds the references to the proxies, so it has to outlive m.exec() below.
+  ezHashTable<ezUuid, QSharedPointer<ezQtProxy>> contextMenuProxies;
+  {
+    ezActionContext context;
+    context.m_sMapping = "AssetBrowserContextMenu";
+    context.m_pWindow = this;
+
+    if (ezActionMap* pActionMap = ezActionMapManager::GetActionMap(context.m_sMapping))
+    {
+      const int iActionsBefore = m.actions().count();
+      ezQtMenuActionMapView::AddDocumentObjectToMenu(contextMenuProxies, context, pActionMap, &m, pActionMap->BuildActionTree());
+
+      // the proxies are cached and reused, so they still reflect the selection they were built with
+      for (auto it : contextMenuProxies)
+      {
+        if (ezAction* pAction = it.Value()->GetAction())
+        {
+          pAction->RefreshState();
+        }
+
+        it.Value()->Update();
+      }
+
+      // a sub-menu has no state of its own, so it stays visible even when every entry in it hid itself
+      for (QAction* pAction : m.actions())
+      {
+        QMenu* pSubMenu = pAction->menu();
+        if (pSubMenu == nullptr)
+          continue;
+
+        bool bAnyEntryVisible = false;
+        for (QAction* pEntry : pSubMenu->actions())
+        {
+          if (pEntry->isVisible() && !pEntry->isSeparator())
+          {
+            bAnyEntryVisible = true;
+            break;
+          }
+        }
+
+        pAction->setVisible(bAnyEntryVisible);
+      }
+
+      // Only separate when something is actually shown: the action map adds its own separators around
+      // each category, and an action that hid itself still counts towards actions().
+      bool bAnyVisible = false;
+      for (int i = iActionsBefore; i < m.actions().count(); ++i)
+      {
+        if (m.actions()[i]->isVisible() && !m.actions()[i]->isSeparator())
+        {
+          bAnyVisible = true;
+          break;
+        }
+      }
+
+      if (bAnyVisible)
+      {
+        m.addSeparator();
+      }
+    }
+  }
 
   if (m_Mode == Mode::Browser && ListAssets->selectionModel()->hasSelection())
   {

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -12,6 +12,7 @@
 #include <EditorFramework/Actions/ViewActions.h>
 #include <EditorFramework/Actions/ViewLightActions.h>
 #include <EditorFramework/Actions/WindowLayoutActions.h>
+#include <EditorFramework/Assets/AssetBrowserContext.h>
 #include <EditorFramework/CodeGen/CodeEditorPreferencesWidget.moc.h>
 #include <EditorFramework/CodeGen/CompilerPreferencesWidget.moc.h>
 #include <EditorFramework/CodeGen/CppProject.h>
@@ -99,6 +100,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezDefaultState::RegisterDefaultStateProvider(ezDynamicDefaultStateProvider::CreateProvider);
     ezProjectActions::RegisterActions();
     ezAssetActions::RegisterActions();
+    ezAssetBrowserContextMenu::RegisterActions();
     ezViewActions::RegisterActions();
     ezViewLightActions::RegisterActions();
     ezGameObjectContextActions::RegisterActions();
@@ -152,6 +154,11 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezActionMapManager::RegisterActionMap("AssetBrowserToolBar");
     ezAssetActions::MapToolBarActions("AssetBrowserToolBar", false);
 
+    // Plugins map actions here to offer operations on the asset types they own.
+    // The selection is not part of the action context, it has to be read from ezAssetBrowserSelection.
+    ezActionMapManager::RegisterActionMap("AssetBrowserContextMenu");
+    ezAssetBrowserContextMenu::MapActions();
+
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezFileBrowserAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtFilePropertyWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezExternalFileBrowserAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtExternalFilePropertyWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezAssetBrowserAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtAssetPropertyWidget(); });
@@ -196,6 +203,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezDefaultState::UnregisterDefaultStateProvider(ezDynamicDefaultStateProvider::CreateProvider);
     ezProjectActions::UnregisterActions();
     ezAssetActions::UnregisterActions();
+    ezAssetBrowserContextMenu::UnregisterActions();
     ezViewActions::UnregisterActions();
     ezViewLightActions::UnregisterActions();
     ezGameObjectContextActions::UnregisterActions();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Actions/MeshLodActions.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Actions/MeshLodActions.cpp
@@ -1,0 +1,155 @@
+#include <EditorPluginAssets/EditorPluginAssetsPCH.h>
+
+#include <EditorFramework/Assets/AssetBrowserContext.h>
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorPluginAssets/Actions/MeshLodActions.h>
+#include <EditorPluginAssets/Dialogs/CreateMeshLodsDlg.moc.h>
+#include <GuiFoundation/Action/ActionManager.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshLodAction, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezActionDescriptorHandle ezMeshLodActions::s_hCategory;
+ezActionDescriptorHandle ezMeshLodActions::s_hCreateLods;
+ezActionDescriptorHandle ezMeshLodActions::s_hCreateLodsDoc;
+
+void ezMeshLodActions::RegisterActions()
+{
+  s_hCategory = EZ_REGISTER_CATEGORY("MeshLodCategory");
+
+  s_hCreateLods = EZ_REGISTER_ACTION_0("Meshes.CreateLods", ezActionScope::Global, "Meshes", "", ezMeshLodAction);
+  s_hCreateLodsDoc = EZ_REGISTER_ACTION_0("Meshes.CreateLodsDocument", ezActionScope::Document, "Meshes", "", ezMeshLodAction);
+}
+
+void ezMeshLodActions::UnregisterActions()
+{
+  ezActionManager::UnregisterAction(s_hCategory);
+  ezActionManager::UnregisterAction(s_hCreateLods);
+  ezActionManager::UnregisterAction(s_hCreateLodsDoc);
+}
+
+ezResult ezMeshLodActions::MapActions(ezStringView sActionMap, ezStringView sSubPath, bool bDocumentScope)
+{
+  ezActionMap* pMap = ezActionMapManager::GetActionMap(sActionMap);
+  if (pMap == nullptr)
+    return EZ_FAILURE;
+
+  // 9.0f, so that creating LODs sits above creating a prefab (10.0f) and a collider (11.0f)
+  pMap->MapAction(s_hCategory, sSubPath, 9.0f);
+  pMap->MapAction(bDocumentScope ? s_hCreateLodsDoc : s_hCreateLods, "MeshLodCategory", 1.0f);
+  return EZ_SUCCESS;
+}
+
+bool ezMeshLodAction::IsLodAsset(const ezUuid& assetGuid)
+{
+  auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(assetGuid);
+  if (!pSubAsset.isValid() || pSubAsset->m_pAssetInfo == nullptr)
+    return false;
+
+  return ezPathUtils::GetFileName(pSubAsset->m_pAssetInfo->m_Path.GetAbsolutePath()).StartsWith_NoCase("LOD-");
+}
+
+void ezMeshLodAction::GetTargetAssets(ezDynamicArray<ezUuid>& out_assets) const
+{
+  out_assets.Clear();
+
+  if (const ezAssetDocument* pAssetDoc = ezDynamicCast<const ezAssetDocument*>(m_Context.m_pDocument))
+  {
+    if (ezMeshLodCreator::IsMeshAsset(pAssetDoc->GetGuid()) && !IsLodAsset(pAssetDoc->GetGuid()))
+    {
+      out_assets.PushBack(pAssetDoc->GetGuid());
+    }
+
+    return;
+  }
+
+  for (const ezUuid& guid : ezAssetBrowserSelection::GetCurrent().m_AssetGuids)
+  {
+    if (ezMeshLodCreator::IsMeshAsset(guid) && !IsLodAsset(guid))
+    {
+      out_assets.PushBack(guid);
+    }
+  }
+}
+
+ezMeshLodAction::ezMeshLodAction(const ezActionContext& context, const char* szName)
+  : ezButtonAction(context, szName, false, "")
+{
+  SetIconPath(":/AssetIcons/Mesh.svg");
+
+  RefreshState();
+}
+
+void ezMeshLodAction::RefreshState()
+{
+  ezHybridArray<ezUuid, 16> assets;
+  GetTargetAssets(assets);
+
+  SetVisible(!assets.IsEmpty(), false);
+  SetEnabled(!assets.IsEmpty(), false);
+}
+
+void ezMeshLodAction::Execute(const ezVariant& value)
+{
+  ezHybridArray<ezUuid, 16> assets;
+  GetTargetAssets(assets);
+
+  if (assets.IsEmpty())
+    return;
+
+  if (assets.GetCount() == 1)
+  {
+    ezMeshLodSource source;
+    if (ezMeshLodCreator::GatherMeshLodSource(assets[0], source).Failed())
+    {
+      ezQtUiServices::MessageBoxWarning("The selected asset is not a mesh asset.");
+      return;
+    }
+
+    ezQtCreateMeshLodsDlg dlg(source, nullptr);
+    if (dlg.exec() != QDialog::Accepted)
+      return;
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    const ezStatus res = ezMeshLodCreator::CreateMeshLods(source, dlg.GetOptions(), uiCreated, uiSkipped);
+
+    if (res.Failed())
+    {
+      ezQtUiServices::MessageBoxStatus(res, "Failed to create the LOD assets.", "", true);
+      return;
+    }
+
+    if (uiSkipped > 0)
+    {
+      ezQtUiServices::MessageBoxInformation(ezFmt("Created {} LOD asset(s), skipped {}.", uiCreated, uiSkipped));
+    }
+
+    return;
+  }
+
+  ezQtCreateMeshLodsDlg dlg(assets.GetCount(), nullptr);
+  if (dlg.exec() != QDialog::Accepted)
+    return;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  const ezStatus res = ezMeshLodCreator::CreateMeshLodsForAll(assets, dlg.GetOptions(), uiCreated, uiSkipped);
+
+  if (res.Failed())
+  {
+    ezQtUiServices::MessageBoxStatus(res, "Failed to create the LOD assets.", "", true);
+    return;
+  }
+
+  // which meshes were skipped and why is in the log
+  if (uiSkipped > 0)
+  {
+    ezQtUiServices::MessageBoxInformation(ezFmt("Created {} LOD asset(s), skipped {}.\n\nSee the log for details.", uiCreated, uiSkipped));
+  }
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Actions/MeshLodActions.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Actions/MeshLodActions.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <EditorPluginAssets/EditorPluginAssetsDLL.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Types/Uuid.h>
+#include <GuiFoundation/Action/BaseActions.h>
+
+/// Creates LOD mesh assets from mesh assets. Hides itself unless the target is one or more mesh
+/// assets that are not themselves LODs.
+class ezMeshLodActions
+{
+public:
+  static void RegisterActions();
+  static void UnregisterActions();
+
+  /// Pass bDocumentScope for a map belonging to a document window, so that the action is given that
+  /// document; leave it off for the asset browser, which has none and uses ezAssetBrowserSelection.
+  ///
+  /// Fails if the action map does not exist, i.e. the plugin that owns it is not loaded.
+  static ezResult MapActions(ezStringView sActionMap, ezStringView sSubPath, bool bDocumentScope = false);
+
+  static ezActionDescriptorHandle s_hCategory;
+  static ezActionDescriptorHandle s_hCreateLods;
+  static ezActionDescriptorHandle s_hCreateLodsDoc;
+};
+
+class ezMeshLodAction : public ezButtonAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMeshLodAction, ezButtonAction);
+
+public:
+  ezMeshLodAction(const ezActionContext& context, const char* szName);
+
+  virtual void Execute(const ezVariant& value) override;
+  virtual void RefreshState() override;
+
+private:
+  /// The action's own document, or else every mesh asset in the asset browser selection. Empty when
+  /// neither names a mesh asset.
+  ///
+  /// Non-mesh assets in the selection are dropped rather than disabling the action.
+  void GetTargetAssets(ezDynamicArray<ezUuid>& out_assets) const;
+
+  /// A LOD asset must not get LODs of its own, or the _data folders nest without end.
+  static bool IsLodAsset(const ezUuid& assetGuid);
+};

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/CreateMeshLodsDlg.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/CreateMeshLodsDlg.cpp
@@ -1,0 +1,167 @@
+#include <EditorPluginAssets/EditorPluginAssetsPCH.h>
+
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginAssets/Dialogs/CreateMeshLodsDlg.moc.h>
+#include <QPushButton>
+
+ezInt32 ezQtCreateMeshLodsDlg::s_iLodCount = 2;
+bool ezQtCreateMeshLodsDlg::s_bOpenAfterCreate = false;
+
+ezQtCreateMeshLodsDlg::ezQtCreateMeshLodsDlg(const ezMeshLodSource& source, QWidget* pParent)
+  : ezQtDialog(pParent)
+  , m_pSource(&source)
+{
+  Setup();
+
+  {
+    // not editable: the prefab tool finds LODs by this exact name
+    ezStringBuilder sFolder = m_pSource->m_sLodFolder;
+    ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sFolder);
+    LodFolder->setText(ezMakeQString(sFolder));
+  }
+
+  UpdateInfo();
+}
+
+ezQtCreateMeshLodsDlg::ezQtCreateMeshLodsDlg(ezUInt32 uiMeshCount, QWidget* pParent)
+  : ezQtDialog(pParent)
+  , m_uiMeshCount(uiMeshCount)
+{
+  Setup();
+
+  LodFolder->setText(QLatin1String("<next to each mesh asset>"));
+
+  // Each mesh gets several LODs, so the document count grows faster than the mesh count. The box
+  // stays available, it is only unticked by default for a large selection.
+  OpenAfterCreate->setText(QString("Open all %1 LOD meshes after creating them").arg(uiMeshCount * s_iLodCount));
+  OpenAfterCreate->setChecked(s_bOpenAfterCreate && uiMeshCount <= s_uiMaxAutoOpen);
+
+  UpdateInfo();
+}
+
+void ezQtCreateMeshLodsDlg::Setup()
+{
+  setupUi(this);
+
+  LodCount->setMaximum((int)ezMeshLodCreator::s_uiMaxLods);
+  LodCount->setValue(s_iLodCount);
+  OpenAfterCreate->setChecked(s_bOpenAfterCreate);
+}
+
+void ezQtCreateMeshLodsDlg::UpdateInfo()
+{
+  const ezUInt32 uiLodCount = (ezUInt32)LodCount->value();
+  const bool bOverwrite = OverwriteExisting->isChecked();
+
+  {
+    // how far each level goes depends on the mesh's own simplification, which isn't visible otherwise
+    const ezUInt8 uiBase = (m_pSource != nullptr) ? m_pSource->m_uiBaseSimplification : 0;
+
+    // the percent signs are appended: a literal '%' in a format string is consumed as a format spec
+    ezStringBuilder sLadder;
+    sLadder.SetFormat("LOD 0 (the mesh itself): {}", (ezUInt32)uiBase);
+    sLadder.Append("% simplified.");
+
+    for (ezUInt32 uiLod = 1; uiLod <= uiLodCount; ++uiLod)
+    {
+      sLadder.AppendFormat("\nLOD {}: {}", uiLod, (ezUInt32)ezMeshLodCreator::GetLodSimplification(uiBase, uiLod));
+      sLadder.Append("% simplified.");
+    }
+
+    LadderInfo->setText(ezMakeQString(sLadder));
+  }
+
+  ezStringBuilder sWarning;
+
+  // not every message blocks: that some LODs are kept still leaves something to create
+  bool bCanCreate = true;
+
+  if (m_pSource == nullptr)
+  {
+    // nothing mesh specific to check, the per mesh cases are handled while creating
+  }
+  else if (m_pSource->m_bIsPrimitive)
+  {
+    sWarning = "This mesh asset uses a procedural primitive, not a model file, so no LODs can be generated from it.";
+    bCanCreate = false;
+  }
+  else if (m_pSource->m_sMeshFile.IsEmpty())
+  {
+    sWarning = "The source file of this mesh asset could not be read, so no LODs can be generated from it.";
+    bCanCreate = false;
+  }
+  else
+  {
+    ezHybridArray<ezUInt32, 4> existing;
+    for (ezUInt32 uiLod = 1; uiLod <= uiLodCount; ++uiLod)
+    {
+      if (m_pSource->HasLod(uiLod))
+      {
+        existing.PushBack(uiLod);
+      }
+    }
+
+    // with the overwrite box ticked, its own label already says what happens
+    if (!existing.IsEmpty() && !bOverwrite)
+    {
+      ezStringBuilder sList;
+      for (ezUInt32 uiLod : existing)
+      {
+        if (!sList.IsEmpty())
+          sList.Append(", ");
+
+        sList.AppendFormat("LOD-{}", uiLod);
+      }
+
+      // every requested level already there means there is nothing to do
+      if (existing.GetCount() == uiLodCount)
+      {
+        sWarning = "All of the requested LODs already exist. Raise the count, or tick the box above to overwrite them.";
+        bCanCreate = false;
+      }
+      else
+      {
+        sWarning.SetFormat("{} already exist and are kept.", sList);
+      }
+    }
+  }
+
+  WarningLabel->setText(ezMakeQString(sWarning));
+
+  if (QPushButton* pOk = ButtonBox->button(QDialogButtonBox::Ok))
+  {
+    pOk->setEnabled(bCanCreate);
+  }
+}
+
+void ezQtCreateMeshLodsDlg::on_LodCount_valueChanged(int value)
+{
+  UpdateInfo();
+}
+
+void ezQtCreateMeshLodsDlg::on_OverwriteExisting_toggled(bool checked)
+{
+  UpdateInfo();
+}
+
+void ezQtCreateMeshLodsDlg::on_ButtonBox_accepted()
+{
+  s_iLodCount = LodCount->value();
+
+  // Not remembered for a large selection, where the box was unticked by us rather than by the user.
+  if (m_uiMeshCount <= s_uiMaxAutoOpen)
+  {
+    s_bOpenAfterCreate = OpenAfterCreate->isChecked();
+  }
+
+  m_Options.m_uiLodCount = (ezUInt32)s_iLodCount;
+  m_Options.m_bOverwriteExisting = OverwriteExisting->isChecked();
+  m_Options.m_bOpenAfterCreate = OpenAfterCreate->isChecked();
+
+  accept();
+}
+
+void ezQtCreateMeshLodsDlg::on_ButtonBox_rejected()
+{
+  reject();
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/CreateMeshLodsDlg.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/CreateMeshLodsDlg.moc.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <EditorPluginAssets/EditorPluginAssetsDLL.h>
+#include <EditorPluginAssets/Util/MeshLodCreator.h>
+#include <EditorPluginAssets/ui_CreateMeshLodsDlg.h>
+
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
+
+/// Configures what ezMeshLodCreator::CreateMeshLods() should generate.
+///
+/// Also used for several meshes at once, in which case the folder and the resulting simplification
+/// are decided per mesh and only the number of LODs is shown.
+class ezQtCreateMeshLodsDlg : public ezQtDialog, public Ui_CreateMeshLodsDlg
+{
+  Q_OBJECT
+
+public:
+  /// For a single mesh, whose folder and simplification ladder are shown.
+  ezQtCreateMeshLodsDlg(const ezMeshLodSource& source, QWidget* pParent);
+
+  /// For several meshes.
+  ezQtCreateMeshLodsDlg(ezUInt32 uiMeshCount, QWidget* pParent);
+
+  const ezMeshLodOptions& GetOptions() const { return m_Options; }
+
+private Q_SLOTS:
+  void on_LodCount_valueChanged(int value);
+  void on_OverwriteExisting_toggled(bool checked);
+  void on_ButtonBox_accepted();
+  void on_ButtonBox_rejected();
+
+private:
+  /// Everything both constructors do, before either fills in what is specific to its case.
+  void Setup();
+
+  /// Spells out the simplification each LOD will get, which depends on the mesh's own simplification.
+  void UpdateInfo();
+
+  /// Null when several meshes were selected, as none of them speaks for the others.
+  const ezMeshLodSource* m_pSource = nullptr;
+
+  /// 1 unless several meshes were selected.
+  ezUInt32 m_uiMeshCount = 1;
+
+  ezMeshLodOptions m_Options;
+
+  /// Above this many meshes the "open after creation" box starts out unticked. It stays available.
+  static constexpr ezUInt32 s_uiMaxAutoOpen = 5;
+
+  // remembered across invocations
+  static ezInt32 s_iLodCount;
+  static bool s_bOpenAfterCreate;
+};

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/CreateMeshLodsDlg.ui
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/CreateMeshLodsDlg.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateMeshLodsDlg</class>
+ <widget class="QDialog" name="CreateMeshLodsDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>520</width>
+    <height>340</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create LODs from Mesh</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+    <normaloff>:/GuiFoundation/EZ-logo.svg</normaloff>:/GuiFoundation/EZ-logo.svg</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCount">
+       <property name="text">
+        <string>Number of LODs:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="LodCount">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>4</number>
+       </property>
+       <property name="value">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelFolder">
+       <property name="text">
+        <string>Folder:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="LodFolder">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="LadderInfo">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="OverwriteExisting">
+     <property name="text">
+      <string>Overwrite LOD assets that already exist</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="WarningLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>13</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="OpenAfterCreate">
+     <property name="text">
+      <string>Open the LOD assets after creating them</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../QtResources/resources.qrc"/>
+  <include location="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc"/>
+  <include location="../../../../Editor/EditorFramework/QtResources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -11,6 +11,8 @@
 #include <EditorFramework/Actions/TransformGizmoActions.h>
 #include <EditorFramework/Actions/ViewActions.h>
 #include <EditorFramework/Actions/ViewLightActions.h>
+#include <EditorFramework/Assets/AssetBrowserContext.h>
+#include <EditorPluginAssets/Actions/MeshLodActions.h>
 #include <EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.h>
 #include <EditorPluginAssets/AnimationClipAsset/AnimationClipActions.h>
 #include <EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h>
@@ -452,11 +454,23 @@ void OnLoadPlugin()
   ConfigureBlackboardTemplateAsset();
   ConfigureCustomDataAsset();
 
+  // Creating LOD meshes from mesh assets.
+  {
+    ezMeshLodActions::RegisterActions();
+
+    ezMeshLodActions::MapActions("AssetBrowserContextMenu", ezAssetBrowserContextMenu::s_sAssetMenu).IgnoreResult();
+    ezMeshLodActions::MapActions("MeshAssetMenuBar", "G.Asset", true).IgnoreResult();
+    ezMeshLodActions::MapActions("AnimatedMeshAssetMenuBar", "G.Asset", true).IgnoreResult();
+    ezMeshLodActions::MapActions("MeshAssetToolBar", "", true).IgnoreResult();
+    ezMeshLodActions::MapActions("AnimatedMeshAssetToolBar", "", true).IgnoreResult();
+  }
+
   ezDocumentManager::s_CustomActions["CustomAction_CreateShaderFromTemplate"] = CustomAction_CreateShaderFromTemplate;
 }
 
 void OnUnloadPlugin()
 {
+  ezMeshLodActions::UnregisterActions();
   ezTextureAssetActions::UnregisterActions();
   ezLUTAssetActions::UnregisterActions();
   ezVisualShaderActions::UnregisterActions();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshColliderUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshColliderUtils.cpp
@@ -61,6 +61,11 @@ namespace
 
 bool ezMeshColliderUtils::IsMeshAsset(const ezUuid& assetGuid)
 {
+  // The actions that call this refresh their state whenever a menu is built, which also happens
+  // in the headless ezEditorProcessor, where no asset curator exists.
+  if (ezAssetCurator::GetSingleton() == nullptr)
+    return false;
+
   auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(assetGuid);
   if (!pSubAsset.isValid() || pSubAsset->m_pAssetInfo == nullptr || pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor == nullptr)
     return false;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshColliderUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshColliderUtils.cpp
@@ -1,0 +1,321 @@
+#include <EditorPluginAssets/EditorPluginAssetsPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocumentInfo.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginAssets/Util/MeshColliderUtils.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Strings/PathUtils.h>
+#include <ToolsFoundation/Command/TreeCommands.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+
+namespace
+{
+  constexpr ezStringView s_sMeshIncludeTags = "MeshIncludeTags"_ezsv;
+  constexpr ezStringView s_sMeshExcludeTags = "MeshExcludeTags"_ezsv;
+
+  constexpr ezStringView s_ColliderSubMeshProperties[] = {s_sMeshIncludeTags, s_sMeshExcludeTags};
+
+  constexpr ezStringView s_ColliderImportProperties[] = {
+    "MeshFile"_ezsv,
+    s_sMeshIncludeTags,
+    s_sMeshExcludeTags,
+    "ImportTransform"_ezsv,
+    "RightDir"_ezsv,
+    "UpDir"_ezsv,
+    "FlipForwardDir"_ezsv,
+    "PositionOffset"_ezsv,
+    "UniformScaling"_ezsv,
+  };
+
+  constexpr ezStringView s_ColliderSimplificationProperties[] = {
+    "SimplifyMesh"_ezsv,
+    "MeshSimplification"_ezsv,
+    "MaxSimplificationError"_ezsv,
+    "NormalWeight"_ezsv,
+    "AggressiveSimplification"_ezsv,
+  };
+
+  /// An unwritten property and one set to an empty string mean the same thing here.
+  ezString GetTagValue(const ezVariantDictionary& properties, ezStringView sProperty)
+  {
+    ezVariant value;
+    if (!properties.TryGetValue(sProperty, value) || !value.IsA<ezString>())
+      return {};
+
+    return value.Get<ezString>();
+  }
+
+  /// Equivalent of ezSimpleAssetDocument::GetPropertyObject(), which can't be called without knowing
+  /// the concrete asset type.
+  const ezDocumentObject* GetColliderTopLevelObject(const ezDocument* pDoc)
+  {
+    const ezDocumentObject* pRoot = pDoc->GetObjectManager()->GetRootObject();
+    if (pRoot == nullptr || pRoot->GetChildren().GetCount() != 1)
+      return nullptr;
+
+    return pRoot->GetChildren()[0];
+  }
+} // namespace
+
+bool ezMeshColliderUtils::IsMeshAsset(const ezUuid& assetGuid)
+{
+  auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(assetGuid);
+  if (!pSubAsset.isValid() || pSubAsset->m_pAssetInfo == nullptr || pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor == nullptr)
+    return false;
+
+  const ezStringView sType = pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName;
+  return sType == s_sMeshDocType || sType == s_sAnimatedMeshDocType;
+}
+
+ezArrayPtr<const ezStringView> ezMeshColliderUtils::GetImportPropertyNames()
+{
+  return ezMakeArrayPtr(s_ColliderImportProperties);
+}
+
+ezArrayPtr<const ezStringView> ezMeshColliderUtils::GetSimplificationPropertyNames()
+{
+  return ezMakeArrayPtr(s_ColliderSimplificationProperties);
+}
+
+ezArrayPtr<const ezStringView> ezMeshColliderUtils::GetSubMeshPropertyNames()
+{
+  return ezMakeArrayPtr(s_ColliderSubMeshProperties);
+}
+
+ezStringView ezMeshColliderUtils::GetDocumentType(ezEnum<ezCollisionMeshKind> kind)
+{
+  return (kind == ezCollisionMeshKind::ConvexHull) ? "Jolt_Colmesh_Convex"_ezsv : "Jolt_Colmesh_Triangle"_ezsv;
+}
+
+ezStringView ezMeshColliderUtils::GetExtension(ezEnum<ezCollisionMeshKind> kind)
+{
+  return (kind == ezCollisionMeshKind::ConvexHull) ? "ezJoltConvexCollisionMeshAsset"_ezsv : "ezJoltCollisionMeshAsset"_ezsv;
+}
+
+ezUuid ezMeshColliderUtils::FindExisting(ezEnum<ezCollisionMeshKind> kind, ezStringView sMeshFile, const ezVariantDictionary& meshImportProperties, ezStringView sMeshAssetPath)
+{
+  if (sMeshFile.IsEmpty())
+    return {};
+
+  const ezStringView sDocType = GetDocumentType(kind);
+
+  struct Candidate
+  {
+    ezUuid m_Guid;
+    ezString m_sPath;
+  };
+
+  ezHybridArray<Candidate, 8> candidates;
+
+  auto pAssets = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
+  for (auto it : *pAssets)
+  {
+    const ezSubAsset& subAsset = it.Value();
+    if (!subAsset.m_bMainAsset || subAsset.m_pAssetInfo == nullptr || subAsset.m_pAssetInfo->m_pDocumentTypeDescriptor == nullptr)
+      continue;
+
+    if (subAsset.m_pAssetInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName != sDocType)
+      continue;
+
+    const ezAssetDocumentInfo* pInfo = subAsset.m_pAssetInfo->m_Info.Borrow();
+    if (pInfo != nullptr && pInfo->m_TransformDependencies.Contains(sMeshFile))
+    {
+      candidates.PushBack({subAsset.m_Data.m_Guid, subAsset.m_pAssetInfo->m_Path.GetAbsolutePath()});
+    }
+  }
+
+  if (candidates.IsEmpty())
+    return {};
+
+  // Which sub-mesh a candidate selects is only stored inside its document, so every candidate has to
+  // be read, even a single one: it may belong to a different mesh asset importing a different
+  // sub-mesh out of the same model file.
+  const ezString sMeshInclude = GetTagValue(meshImportProperties, s_sMeshIncludeTags);
+  const ezString sMeshExclude = GetTagValue(meshImportProperties, s_sMeshExcludeTags);
+
+  const ezStringBuilder sMeshStem = ezPathUtils::GetFileName(sMeshAssetPath);
+
+  ezUuid nameMatch;
+  ezUuid subMeshMatch;
+
+  for (const Candidate& candidate : candidates)
+  {
+    ezVariantDictionary colliderProperties;
+    if (ReadMeshProperties(candidate.m_sPath, GetSubMeshPropertyNames(), colliderProperties).Failed())
+      continue;
+
+    // a collider built from a different sub-mesh is the wrong geometry, not a worse match
+    if (GetTagValue(colliderProperties, s_sMeshIncludeTags) != sMeshInclude || GetTagValue(colliderProperties, s_sMeshExcludeTags) != sMeshExclude)
+      continue;
+
+    if (!subMeshMatch.IsValid())
+      subMeshMatch = candidate.m_Guid;
+
+    // Several colliders can share a sub-mesh, e.g. one simplified and one not. The one named after
+    // the mesh asset is then the one generated for it.
+    if (!sMeshStem.IsEmpty() && !nameMatch.IsValid() && sMeshStem.IsEqual_NoCase(ezPathUtils::GetFileName(candidate.m_sPath)))
+      nameMatch = candidate.m_Guid;
+  }
+
+  if (nameMatch.IsValid())
+    return nameMatch;
+
+  return subMeshMatch;
+}
+
+ezResult ezMeshColliderUtils::ReadMeshProperties(ezStringView sAbsMeshAssetPath, ezArrayPtr<const ezStringView> properties, ezVariantDictionary& out_values)
+{
+  bool bWasOpen = false;
+  ezDocument* pDoc = nullptr;
+
+  const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+  if (ezDocumentManager::FindDocumentTypeFromPath(sAbsMeshAssetPath, false, pTypeDesc).Succeeded())
+  {
+    pDoc = pTypeDesc->m_pManager->GetDocumentByPath(sAbsMeshAssetPath);
+    bWasOpen = (pDoc != nullptr);
+  }
+
+  if (pDoc == nullptr)
+    pDoc = ezQtEditorApp::GetSingleton()->OpenDocument(sAbsMeshAssetPath, ezDocumentFlags::None);
+
+  if (pDoc == nullptr)
+    return EZ_FAILURE;
+
+  ezResult res = EZ_FAILURE;
+
+  if (const ezDocumentObject* pPropObj = GetColliderTopLevelObject(pDoc))
+  {
+    const ezIReflectedTypeAccessor& accessor = pPropObj->GetTypeAccessor();
+
+    for (ezStringView sProperty : properties)
+    {
+      const ezVariant value = accessor.GetValue(sProperty);
+      if (value.IsValid())
+      {
+        out_values.Insert(sProperty, value);
+      }
+    }
+
+    res = EZ_SUCCESS;
+  }
+
+  if (!bWasOpen && !pDoc->HasWindowBeenRequested())
+  {
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+  }
+
+  return res;
+}
+
+ezStatus ezMeshColliderUtils::CreateCollisionMesh(ezStringView sAbsColliderPath, ezEnum<ezCollisionMeshKind> kind, const ezVariantDictionary& importProperties, ezStringView sSurface, bool bOverwriteExisting, ezUuid& out_guid)
+{
+  out_guid = ezUuid();
+
+  if (sAbsColliderPath.IsEmpty())
+    return ezStatus("No path for the collision mesh asset was given.");
+
+  const bool bExists = ezOSFile::ExistsFile(sAbsColliderPath);
+
+  // CreateDocument reports an already open document through a modal message box, which would hang an
+  // automated caller. Refuse here instead.
+  if (bExists && !bOverwriteExisting)
+    return ezStatus(ezFmt("'{}' already exists. Delete it first, or choose a different name.", sAbsColliderPath));
+
+  // An existing collider is rewritten in place rather than deleted and created again, so that it
+  // keeps its guid and anything referencing it keeps working.
+  ezDocument* pDoc = bExists ? ezQtEditorApp::GetSingleton()->OpenDocument(sAbsColliderPath, ezDocumentFlags::None)
+                             : ezQtEditorApp::GetSingleton()->CreateDocument(sAbsColliderPath, ezDocumentFlags::None);
+
+  if (pDoc == nullptr)
+    return ezStatus(ezFmt("Failed to {} collision mesh asset '{}'. Is the Jolt plugin enabled?", bExists ? "open" : "create", sAbsColliderPath));
+
+  ezStatus result = ezStatus(EZ_SUCCESS);
+
+  {
+    auto pHistory = pDoc->GetCommandHistory();
+    pHistory->StartTransaction("Create Collision Mesh from Mesh");
+
+    // in a lambda, so that every failure path below cancels the transaction
+    auto ApplyProperties = [&]() -> ezStatus
+    {
+      const ezDocumentObject* pPropObj = GetColliderTopLevelObject(pDoc);
+      if (pPropObj == nullptr)
+        return ezStatus("The collision mesh asset has an unexpected structure.");
+
+      const ezRTTI* pType = pPropObj->GetTypeAccessor().GetType();
+
+      ezHybridArray<ezStringView, 24> toWrite;
+      toWrite = ezMakeArrayPtr(s_ColliderImportProperties);
+
+      if (kind == ezCollisionMeshKind::TriangleMesh)
+      {
+        toWrite.PushBackRange(ezMakeArrayPtr(s_ColliderSimplificationProperties));
+      }
+
+      for (ezStringView sProperty : toWrite)
+      {
+        ezVariant value;
+        if (!importProperties.TryGetValue(sProperty, value))
+          continue;
+
+        // the two types are matched by name, so one of them may not have this property
+        if (pType->FindPropertyByName(sProperty) == nullptr)
+          continue;
+
+        ezSetObjectPropertyCommand cmd;
+        cmd.m_Object = pPropObj->GetGuid();
+        cmd.m_sProperty = sProperty;
+        cmd.m_NewValue = value;
+        EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(cmd));
+      }
+
+      // "Surface" is the convex mesh's single surface. A triangle mesh has the "Surfaces" array
+      // instead, which is filled from the model's material slots at transform time.
+      if (!sSurface.IsEmpty() && kind == ezCollisionMeshKind::ConvexHull && pType->FindPropertyByName("Surface") != nullptr)
+      {
+        ezSetObjectPropertyCommand cmd;
+        cmd.m_Object = pPropObj->GetGuid();
+        cmd.m_sProperty = "Surface";
+        cmd.m_NewValue = ezString(sSurface);
+        EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(cmd));
+      }
+
+      return ezStatus(EZ_SUCCESS);
+    };
+
+    result = ApplyProperties();
+
+    if (result.Succeeded())
+    {
+      pHistory->FinishTransaction();
+    }
+    else
+    {
+      pHistory->CancelTransaction();
+    }
+  }
+
+  if (result.Failed())
+  {
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    return result;
+  }
+
+  if (pDoc->SaveDocument(true).Failed())
+  {
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    return ezStatus(ezFmt("Failed to save collision mesh asset '{}'.", sAbsColliderPath));
+  }
+
+  out_guid = pDoc->GetGuid();
+
+  const ezString sPath = pDoc->GetDocumentPath();
+  pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+  // without this the asset is only picked up by the next file system scan
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sPath);
+
+  return ezStatus(EZ_SUCCESS);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshColliderUtils.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshColliderUtils.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <EditorPluginAssets/EditorPluginAssetsDLL.h>
+#include <Foundation/Types/Status.h>
+#include <Foundation/Types/Uuid.h>
+#include <Foundation/Types/Variant.h>
+
+/// Which kind of collision mesh asset to build from a mesh asset.
+///
+/// The values name Jolt document types, but nothing here links against the Jolt plugin: the asset is
+/// built by document type name and by writing properties by name.
+struct ezCollisionMeshKind
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    /// ezJoltCollisionMeshAsset. Concave, but only usable for static geometry.
+    TriangleMesh,
+
+    /// ezJoltConvexCollisionMeshAsset. Required for dynamic actors.
+    ConvexHull,
+
+    Default = TriangleMesh
+  };
+};
+
+/// Builds Jolt collision mesh assets out of mesh assets.
+///
+/// Shared by the "Create Collider" dialog and by prefab creation, so that both build the collision
+/// mesh the same way.
+///
+/// The Jolt plugin does not have to be loaded to find or read collision mesh assets, but it does have
+/// to be loaded to create one, as it registers the document type.
+struct EZ_EDITORPLUGINASSETS_DLL ezMeshColliderUtils
+{
+  /// The document types that a mesh asset can have.
+  static constexpr ezStringView s_sMeshDocType = "Mesh"_ezsv;
+  static constexpr ezStringView s_sAnimatedMeshDocType = "Animated Mesh"_ezsv;
+
+  /// Whether the given guid refers to a mesh or animated mesh asset.
+  static bool IsMeshAsset(const ezUuid& assetGuid);
+
+  /// The mesh asset properties that a collision mesh asset has as well, under the same name.
+  ///
+  /// Pass these to ReadMeshProperties(). An animated mesh asset only has some of them; the rest come
+  /// back as invalid variants and are then not written.
+  static ezArrayPtr<const ezStringView> GetImportPropertyNames();
+
+  /// Written on top of GetImportPropertyNames(), but only to a triangle mesh: a convex hull is built
+  /// from the hull of the vertices, so simplifying the source geometry first changes nothing about it.
+  static ezArrayPtr<const ezStringView> GetSimplificationPropertyNames();
+
+  /// The subset of GetImportPropertyNames() that selects which part of the model file is used.
+  /// FindExisting() needs at least these in the dictionary it is given.
+  static ezArrayPtr<const ezStringView> GetSubMeshPropertyNames();
+
+  /// The document type name of a collision mesh asset of that kind, e.g. for FindExisting().
+  static ezStringView GetDocumentType(ezEnum<ezCollisionMeshKind> kind);
+
+  /// The file extension of a collision mesh asset of that kind, without a dot.
+  static ezStringView GetExtension(ezEnum<ezCollisionMeshKind> kind);
+
+  /// Finds the collision mesh asset of that kind that belongs to a specific mesh asset, wherever it
+  /// sits in the project. A collider inside a mesh's "_data" folder is found just as one next to it.
+  ///
+  /// Candidates come from the transform dependencies the curator already holds. The model file alone
+  /// is not enough to identify one: several mesh assets commonly import different sub-meshes out of
+  /// one model file, and their colliders then all depend on that same file. Those candidates are told
+  /// apart by which sub-mesh they select, and only then by their file name.
+  ///
+  /// \param meshImportProperties
+  ///   The mesh asset's properties, as read by ReadMeshProperties(). A candidate that selects a
+  ///   different sub-mesh is not a match at all, so passing an empty dictionary here means any
+  ///   collider built from the model file is accepted - which is only correct if the model file is
+  ///   known to hold a single mesh.
+  /// \param sMeshAssetPath
+  ///   Used to prefer a collider whose file name matches the mesh asset's, for the case that several
+  ///   colliders select the same sub-mesh. May be empty.
+  ///
+  /// Returns an invalid uuid if there is no match, or if sMeshFile is empty.
+  static ezUuid FindExisting(ezEnum<ezCollisionMeshKind> kind, ezStringView sMeshFile, const ezVariantDictionary& meshImportProperties, ezStringView sMeshAssetPath = {});
+
+  /// Reads the given properties from a mesh asset document, for passing to CreateCollisionMesh().
+  ///
+  /// Opens the document if it is not open already, and closes it again unless someone else was
+  /// working with it. Properties the document does not have are not added to the dictionary.
+  static ezResult ReadMeshProperties(ezStringView sAbsMeshAssetPath, ezArrayPtr<const ezStringView> properties, ezVariantDictionary& out_values);
+
+  /// Creates or rewrites the collision mesh asset at that path and saves it.
+  ///
+  /// importProperties is what ReadMeshProperties() returned; only the entries that this kind of
+  /// collision mesh actually has are written.
+  ///
+  /// sSurface is only used for a convex mesh, which has a single surface. A triangle mesh gets one
+  /// per material slot when it is transformed, so it is ignored there.
+  ///
+  /// Fails if the file exists and bOverwriteExisting is not set. An existing asset is rewritten in
+  /// place, so it keeps its guid and references to it still resolve.
+  ///
+  /// The document is closed again afterwards; opening it is left to the caller.
+  static ezStatus CreateCollisionMesh(ezStringView sAbsColliderPath, ezEnum<ezCollisionMeshKind> kind, const ezVariantDictionary& importProperties, ezStringView sSurface, bool bOverwriteExisting, ezUuid& out_guid);
+};

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshLodCreator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshLodCreator.cpp
@@ -1,0 +1,508 @@
+#include <EditorPluginAssets/EditorPluginAssetsPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginAssets/MeshAsset/MeshAssetObjects.h>
+#include <EditorPluginAssets/Util/MeshColliderUtils.h>
+#include <EditorPluginAssets/Util/MeshLodCreator.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Logging/Log.h>
+#include <ToolsFoundation/Command/TreeCommands.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+
+namespace
+{
+  /// The mesh asset properties that a LOD asset has to share with the mesh it is a LOD of, so that
+  /// it describes the same geometry in the same place, only with fewer triangles.
+  constexpr ezStringView s_ImportProperties[] = {
+    "MeshFile"_ezsv,
+    "MeshIncludeTags"_ezsv,
+    "MeshExcludeTags"_ezsv,
+    "ImportTransform"_ezsv,
+    "RightDir"_ezsv,
+    "UpDir"_ezsv,
+    "FlipForwardDir"_ezsv,
+    "PositionOffset"_ezsv,
+    "UniformScaling"_ezsv,
+    "RecalculateNormals"_ezsv,
+    "RecalculateTangents"_ezsv,
+    "HighPrecision"_ezsv,
+    "VertexColorConversion"_ezsv,
+    "ImportMaterials"_ezsv,
+    "NormalWeight"_ezsv,
+    "AggressiveSimplification"_ezsv,
+  };
+
+  /// Read alongside the import properties, but handled separately: they decide whether LODs can be
+  /// made at all and where the ladder starts.
+  constexpr ezStringView s_sPrimitiveType = "PrimitiveType"_ezsv;
+  constexpr ezStringView s_sSimplifyMesh = "SimplifyMesh"_ezsv;
+  constexpr ezStringView s_sMeshSimplification = "MeshSimplification"_ezsv;
+
+  /// Equivalent of ezSimpleAssetDocument::GetPropertyObject(), which can't be called without knowing
+  /// the concrete asset type.
+  const ezDocumentObject* GetTopLevelObject(const ezDocument* pDoc)
+  {
+    const ezDocumentObject* pRoot = pDoc->GetObjectManager()->GetRootObject();
+    if (pRoot == nullptr || pRoot->GetChildren().GetCount() != 1)
+      return nullptr;
+
+    return pRoot->GetChildren()[0];
+  }
+
+  /// Reads the mesh asset's import settings and material slots without knowing its C++ type.
+  ///
+  /// Only closes the document again if it had to be opened here and nothing has claimed a window for
+  /// it, so that a document someone else is working with is left alone.
+  ezResult ReadMeshAsset(ezStringView sAbsDocumentPath, ezMeshLodSource& ref_source)
+  {
+    bool bWasOpen = false;
+    ezDocument* pDoc = nullptr;
+
+    const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+    if (ezDocumentManager::FindDocumentTypeFromPath(sAbsDocumentPath, false, pTypeDesc).Succeeded())
+    {
+      pDoc = pTypeDesc->m_pManager->GetDocumentByPath(sAbsDocumentPath);
+      bWasOpen = (pDoc != nullptr);
+    }
+
+    if (pDoc == nullptr)
+      pDoc = ezQtEditorApp::GetSingleton()->OpenDocument(sAbsDocumentPath, ezDocumentFlags::None);
+
+    if (pDoc == nullptr)
+      return EZ_FAILURE;
+
+    ezResult res = EZ_FAILURE;
+
+    if (const ezDocumentObject* pPropObj = GetTopLevelObject(pDoc))
+    {
+      const ezIReflectedTypeAccessor& accessor = pPropObj->GetTypeAccessor();
+
+      for (ezStringView sProperty : s_ImportProperties)
+      {
+        const ezVariant value = accessor.GetValue(sProperty);
+        if (value.IsValid())
+        {
+          ref_source.m_ImportProperties.Insert(sProperty, value);
+        }
+      }
+
+      // a primitive is generated procedurally, there is no geometry to simplify
+      const ezVariant primitiveType = accessor.GetValue(s_sPrimitiveType);
+      ref_source.m_bIsPrimitive = primitiveType.IsValid() && primitiveType.ConvertTo<ezInt64>() != 0; // 0 is ezMeshPrimitive::File
+
+      const ezVariant meshFile = accessor.GetValue("MeshFile"_ezsv);
+      if (!ref_source.m_bIsPrimitive && meshFile.IsA<ezString>())
+      {
+        ref_source.m_sMeshFile = meshFile.Get<ezString>();
+      }
+
+      // Where the LOD ladder starts. A mesh that does not simplify at all starts from the full model,
+      // no matter what value the (then unused) property happens to hold.
+      const ezVariant bSimplify = accessor.GetValue(s_sSimplifyMesh);
+      const ezVariant uiSimplification = accessor.GetValue(s_sMeshSimplification);
+
+      if (bSimplify.IsValid() && bSimplify.ConvertTo<bool>() && uiSimplification.IsValid())
+      {
+        ref_source.m_uiBaseSimplification = (ezUInt8)ezMath::Clamp<ezInt64>(uiSimplification.ConvertTo<ezInt64>(), 0, 99);
+      }
+
+      // the LODs render with the same materials as the mesh, so the slots are copied rather than re-imported
+      const ezInt32 iSlots = accessor.GetCount("Materials"_ezsv);
+      for (ezInt32 i = 0; i < iSlots; ++i)
+      {
+        const ezVariant slotGuid = accessor.GetValue("Materials"_ezsv, i);
+        if (!slotGuid.IsA<ezUuid>())
+          continue;
+
+        const ezDocumentObject* pSlot = pDoc->GetObjectManager()->GetObject(slotGuid.Get<ezUuid>());
+        if (pSlot == nullptr)
+          continue;
+
+        ezVariantDictionary& slot = ref_source.m_MaterialSlots.ExpandAndGetRef();
+        slot.Insert("Label", pSlot->GetTypeAccessor().GetValue("Label"_ezsv));
+        slot.Insert("Resource", pSlot->GetTypeAccessor().GetValue("Resource"_ezsv));
+      }
+
+      res = EZ_SUCCESS;
+    }
+
+    if (!bWasOpen && !pDoc->HasWindowBeenRequested())
+    {
+      pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    }
+
+    return res;
+  }
+
+  /// An existing folder is preferred over inventing a second one next to it, so that a mesh that was
+  /// renamed after its import keeps writing into the folder its LODs are already in.
+  ezString DetermineLodFolder(ezStringView sMeshAssetPath, ezStringView sMeshFile)
+  {
+    ezHybridArray<ezString, 2> candidates;
+    ezMeshLodCreator::GetLodFolderCandidates(sMeshAssetPath, sMeshFile, candidates);
+
+    for (const ezString& sPath : candidates)
+    {
+      if (ezOSFile::ExistsDirectory(sPath))
+        return sPath;
+    }
+
+    // none exists yet, so the mesh asset's own name decides - which is what a fresh import would use
+    return candidates.IsEmpty() ? ezString() : candidates[0];
+  }
+} // namespace
+
+void ezMeshLodCreator::GetLodFolderCandidates(ezStringView sMeshAssetPath, ezStringView sMeshFile, ezDynamicArray<ezString>& out_folders)
+{
+  out_folders.Clear();
+
+  ezStringBuilder sDir = sMeshAssetPath;
+  sDir.PathParentDirectory();
+
+  ezHybridArray<ezStringView, 2> names;
+  names.PushBack(ezPathUtils::GetFileName(sMeshAssetPath));
+
+  if (!sMeshFile.IsEmpty())
+  {
+    const ezStringView sSourceName = ezPathUtils::GetFileName(sMeshFile);
+    if (sSourceName != names[0])
+    {
+      names.PushBack(sSourceName);
+    }
+  }
+
+  for (ezStringView sName : names)
+  {
+    ezStringBuilder sFolderName;
+    sFolderName.SetFormat("{}_data", sName);
+
+    ezStringBuilder sPath = sDir;
+    sPath.AppendPath(sFolderName);
+
+    out_folders.PushBack(sPath);
+  }
+}
+
+bool ezMeshLodSource::HasLod(ezUInt32 uiLod) const
+{
+  if (uiLod == 0 || uiLod > m_ExistingLods.GetCount())
+    return false;
+
+  return m_ExistingLods[uiLod - 1].IsValid();
+}
+
+bool ezMeshLodCreator::IsMeshAsset(const ezUuid& assetGuid)
+{
+  return ezMeshColliderUtils::IsMeshAsset(assetGuid);
+}
+
+ezUInt8 ezMeshLodCreator::GetLodSimplification(ezUInt8 uiBaseSimplification, ezUInt32 uiLod)
+{
+  // the value is the percentage of triangles removed, so halving what is left each time is the
+  // midpoint between the previous level and 100
+  float fSimplification = ezMath::Clamp<float>(uiBaseSimplification, 0.0f, 99.0f);
+
+  for (ezUInt32 i = 0; i < uiLod; ++i)
+  {
+    fSimplification += (100.0f - fSimplification) * 0.5f;
+  }
+
+  // 100 would remove the whole mesh, and the importer clamps to 99 anyway
+  return (ezUInt8)ezMath::Clamp<ezInt32>((ezInt32)(fSimplification + 0.5f), 1, 99);
+}
+
+ezUInt8 ezMeshLodCreator::GetLodSimplificationError(ezUInt32 uiLod)
+{
+  // What the mesh import uses for its own LODs. A more distant mesh can afford a coarser silhouette,
+  // and the last entry repeats for levels past the table.
+  constexpr ezUInt8 uiErrors[] = {5, 5, 10, 15};
+
+  if (uiLod == 0)
+    return uiErrors[0];
+
+  return uiErrors[ezMath::Min<ezUInt32>(uiLod - 1, EZ_ARRAY_SIZE(uiErrors) - 1)];
+}
+
+ezString ezMeshLodCreator::GetLodPath(const ezMeshLodSource& source, ezUInt32 uiLod)
+{
+  ezStringBuilder sName;
+  sName.SetFormat("LOD-{}.ezMeshAsset", uiLod);
+
+  ezStringBuilder sPath = source.m_sLodFolder;
+  sPath.AppendPath(sName);
+  return sPath;
+}
+
+ezResult ezMeshLodCreator::GatherMeshLodSource(const ezUuid& meshAssetGuid, ezMeshLodSource& out_source)
+{
+  out_source = ezMeshLodSource();
+  out_source.m_MeshAssetGuid = meshAssetGuid;
+
+  ezStringBuilder sMeshAssetPath;
+
+  // the curator lock must not be held while documents are opened further below
+  {
+    auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(meshAssetGuid);
+    if (!pSubAsset.isValid() || pSubAsset->m_pAssetInfo == nullptr)
+      return EZ_FAILURE;
+
+    const ezAssetInfo* pAssetInfo = pSubAsset->m_pAssetInfo;
+    if (pAssetInfo->m_pDocumentTypeDescriptor == nullptr)
+      return EZ_FAILURE;
+
+    const ezStringView sDocType = pAssetInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName;
+    if (sDocType != ezMeshColliderUtils::s_sMeshDocType && sDocType != ezMeshColliderUtils::s_sAnimatedMeshDocType)
+      return EZ_FAILURE;
+
+    out_source.m_bAnimated = (sDocType == ezMeshColliderUtils::s_sAnimatedMeshDocType);
+    sMeshAssetPath = pAssetInfo->m_Path.GetAbsolutePath();
+    out_source.m_sMeshAssetPath = sMeshAssetPath;
+  }
+
+  // a mesh asset that cannot be read leaves the source without a mesh file, which the caller reports
+  ReadMeshAsset(sMeshAssetPath, out_source).IgnoreResult();
+
+  out_source.m_sLodFolder = DetermineLodFolder(sMeshAssetPath, out_source.m_sMeshFile);
+
+  for (ezUInt32 uiLod = 1; uiLod <= s_uiMaxLods; ++uiLod)
+  {
+    const ezString sPath = GetLodPath(out_source, uiLod);
+
+    auto pLod = ezAssetCurator::GetSingleton()->FindSubAsset(sPath);
+    out_source.m_ExistingLods.PushBack(pLod.isValid() ? pLod->m_Data.m_Guid : ezUuid());
+  }
+
+  // trailing gaps say nothing, only the ones between existing LODs matter
+  while (!out_source.m_ExistingLods.IsEmpty() && !out_source.m_ExistingLods.PeekBack().IsValid())
+  {
+    out_source.m_ExistingLods.PopBack();
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezStatus ezMeshLodCreator::CreateMeshLods(const ezMeshLodSource& source, const ezMeshLodOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped)
+{
+  out_uiCreated = 0;
+  out_uiSkipped = 0;
+
+  if (source.m_bIsPrimitive)
+    return ezStatus("This mesh asset uses a procedural primitive, not a model file, so no LODs can be generated from it.");
+
+  if (source.m_sMeshFile.IsEmpty())
+    return ezStatus("The source file of this mesh asset could not be read, so no LODs can be generated from it.");
+
+  if (source.m_sLodFolder.IsEmpty())
+    return ezStatus("The folder for the LOD assets could not be determined.");
+
+  const ezUInt32 uiLodCount = ezMath::Min(options.m_uiLodCount, s_uiMaxLods);
+  if (uiLodCount == 0)
+    return ezStatus("No LODs were requested.");
+
+  // The LOD sub-folder usually does not exist yet. Creating a document below a missing folder fails
+  // through a modal message box, which would hang an automated caller.
+  if (ezOSFile::CreateDirectoryStructure(source.m_sLodFolder).Failed())
+    return ezStatus(ezFmt("Failed to create the folder '{}'.", source.m_sLodFolder));
+
+  ezHybridArray<ezString, 4> created;
+
+  for (ezUInt32 uiLod = 1; uiLod <= uiLodCount; ++uiLod)
+  {
+    const ezString sPath = GetLodPath(source, uiLod);
+
+    const bool bExists = ezOSFile::ExistsFile(sPath);
+
+    // An existing LOD may have been tuned by hand, so replacing it has to be asked for.
+    if (bExists && !options.m_bOverwriteExisting)
+    {
+      ezLog::Info("Skipping '{}': it already exists.", sPath);
+      ++out_uiSkipped;
+      continue;
+    }
+
+    // An existing LOD is rewritten in place rather than deleted and created again, so that it keeps
+    // its guid and anything referencing it keeps working.
+    ezDocument* pDoc = bExists ? ezQtEditorApp::GetSingleton()->OpenDocument(sPath, ezDocumentFlags::None)
+                               : ezQtEditorApp::GetSingleton()->CreateDocument(sPath, ezDocumentFlags::None);
+
+    if (pDoc == nullptr)
+      return ezStatus(ezFmt("Failed to {} LOD asset '{}'.", bExists ? "open" : "create", sPath));
+
+    ezStatus result = ezStatus(EZ_SUCCESS);
+
+    {
+      auto pHistory = pDoc->GetCommandHistory();
+      pHistory->StartTransaction("Create LOD from Mesh");
+
+      // in a lambda, so that every failure path below cancels the transaction
+      auto ApplyProperties = [&]() -> ezStatus
+      {
+        const ezDocumentObject* pPropObj = GetTopLevelObject(pDoc);
+        if (pPropObj == nullptr)
+          return ezStatus("The mesh asset has an unexpected structure.");
+
+        const ezRTTI* pType = pPropObj->GetTypeAccessor().GetType();
+
+        auto SetProperty = [&](ezStringView sProperty, const ezVariant& value) -> ezStatus
+        {
+          ezSetObjectPropertyCommand cmd;
+          cmd.m_Object = pPropObj->GetGuid();
+          cmd.m_sProperty = sProperty;
+          cmd.m_NewValue = value;
+          return pHistory->AddCommand(cmd);
+        };
+
+        for (ezStringView sProperty : s_ImportProperties)
+        {
+          ezVariant value;
+          if (!source.m_ImportProperties.TryGetValue(sProperty, value))
+            continue;
+
+          // a mesh and an animated mesh asset do not have exactly the same properties
+          if (pType->FindPropertyByName(sProperty) == nullptr)
+            continue;
+
+          EZ_SUCCEED_OR_RETURN(SetProperty(sProperty, value));
+        }
+
+        // what makes this a LOD rather than a copy of the mesh
+        EZ_SUCCEED_OR_RETURN(SetProperty(s_sSimplifyMesh, true));
+        EZ_SUCCEED_OR_RETURN(SetProperty(s_sMeshSimplification, GetLodSimplification(source.m_uiBaseSimplification, uiLod)));
+        EZ_SUCCEED_OR_RETURN(SetProperty("MaxSimplificationError"_ezsv, GetLodSimplificationError(uiLod)));
+
+        // The LODs share the mesh's materials rather than importing their own, which would create a
+        // second set of material assets for the same model.
+        EZ_SUCCEED_OR_RETURN(SetProperty("ImportMaterials"_ezsv, false));
+
+        // a LOD that is being rewritten still holds the slots it had
+        for (ezInt32 i = pPropObj->GetTypeAccessor().GetCount("Materials"_ezsv) - 1; i >= 0; --i)
+        {
+          const ezVariant slotGuid = pPropObj->GetTypeAccessor().GetValue("Materials"_ezsv, i);
+          if (!slotGuid.IsA<ezUuid>())
+            continue;
+
+          ezRemoveObjectCommand remove;
+          remove.m_Object = slotGuid.Get<ezUuid>();
+          EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(remove));
+        }
+
+        for (ezUInt32 i = 0; i < source.m_MaterialSlots.GetCount(); ++i)
+        {
+          ezAddObjectCommand add;
+          add.m_Index = (ezInt32)i;
+          add.m_pType = ezGetStaticRTTI<ezMaterialResourceSlot>();
+          add.m_Parent = pPropObj->GetGuid();
+          add.m_sParentProperty = "Materials";
+          EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(add));
+
+          for (auto it : source.m_MaterialSlots[i])
+          {
+            ezSetObjectPropertyCommand cmd;
+            cmd.m_Object = add.m_NewObjectGuid;
+            cmd.m_sProperty = it.Key();
+            cmd.m_NewValue = it.Value();
+            EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(cmd));
+          }
+        }
+
+        return ezStatus(EZ_SUCCESS);
+      };
+
+      result = ApplyProperties();
+
+      if (result.Succeeded())
+      {
+        pHistory->FinishTransaction();
+      }
+      else
+      {
+        pHistory->CancelTransaction();
+      }
+    }
+
+    if (result.Failed())
+    {
+      pDoc->GetDocumentManager()->CloseDocument(pDoc);
+      return result;
+    }
+
+    if (pDoc->SaveDocument(true).Failed())
+    {
+      pDoc->GetDocumentManager()->CloseDocument(pDoc);
+      return ezStatus(ezFmt("Failed to save LOD asset '{}'.", sPath));
+    }
+
+    const ezString sSavedPath = pDoc->GetDocumentPath();
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+    // no '%' sign: a literal percent in an ezLog format string is consumed as a format spec
+    ezLog::Success("Created '{}' at {} percent simplification.", sSavedPath, (ezUInt32)GetLodSimplification(source.m_uiBaseSimplification, uiLod));
+    created.PushBack(sSavedPath);
+    ++out_uiCreated;
+  }
+
+  // Only once every document is written and closed: notifying the curator makes it look at the
+  // folder, which would re-enter this code between two LODs of the same mesh.
+  for (const ezString& sPath : created)
+  {
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sPath);
+  }
+
+  if (options.m_bOpenAfterCreate)
+  {
+    for (const ezString& sPath : created)
+    {
+      ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sPath);
+    }
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}
+
+ezStatus ezMeshLodCreator::CreateMeshLodsForAll(ezArrayPtr<const ezUuid> meshAssetGuids, const ezMeshLodOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped)
+{
+  out_uiCreated = 0;
+  out_uiSkipped = 0;
+
+  // opening the created documents is left to the caller, which may not want that many tabs
+  ezMeshLodOptions perMesh = options;
+
+  for (const ezUuid& meshGuid : meshAssetGuids)
+  {
+    ezMeshLodSource source;
+    if (GatherMeshLodSource(meshGuid, source).Failed())
+    {
+      // not a mesh asset - with a mixed selection this is the normal case, not a problem
+      ++out_uiSkipped;
+      continue;
+    }
+
+    // A mesh that is already a LOD must not get LODs of its own, or the folders nest without end.
+    if (ezPathUtils::GetFileName(source.m_sMeshAssetPath).StartsWith_NoCase("LOD-"))
+    {
+      ezLog::Info("Skipping '{}': it is itself a LOD.", source.m_sMeshAssetPath);
+      ++out_uiSkipped;
+      continue;
+    }
+
+    if (source.m_bIsPrimitive || source.m_sMeshFile.IsEmpty())
+    {
+      ezLog::Info("Skipping '{}': it has no model file to build LODs from.", source.m_sMeshAssetPath);
+      ++out_uiSkipped;
+      continue;
+    }
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+
+    // "nothing to do here" was handled above, so what is left is a real failure and stops the run
+    EZ_SUCCEED_OR_RETURN(CreateMeshLods(source, perMesh, uiCreated, uiSkipped));
+
+    out_uiCreated += uiCreated;
+    out_uiSkipped += uiSkipped;
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshLodCreator.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshLodCreator.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <EditorPluginAssets/EditorPluginAssetsDLL.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Types/ArrayPtr.h>
+#include <Foundation/Types/Status.h>
+#include <Foundation/Types/Uuid.h>
+
+/// \see ezMeshLodCreator::CreateMeshLods()
+struct ezMeshLodOptions
+{
+  /// How many LOD assets to create, starting at LOD-1. LOD 0 is the mesh asset itself, which is not
+  /// touched. Clamped to ezMeshLodCreator::s_uiMaxLods.
+  ezUInt32 m_uiLodCount = 2;
+
+  /// Overwrites LOD assets that already exist instead of leaving them alone.
+  bool m_bOverwriteExisting = false;
+
+  bool m_bOpenAfterCreate = false;
+};
+
+/// What a mesh asset offers for LOD creation. Filled by GatherMeshLodSource().
+struct EZ_EDITORPLUGINASSETS_DLL ezMeshLodSource
+{
+  ezUuid m_MeshAssetGuid;
+  ezString m_sMeshAssetPath;
+
+  /// The mesh asset's "MeshFile". Empty for a procedural primitive, which cannot get LODs.
+  ezString m_sMeshFile;
+
+  bool m_bIsPrimitive = false;
+  bool m_bAnimated = false;
+
+  /// The folder the LOD assets belong in, absolute. This is the folder the prefab tool looks in, so
+  /// that a prefab created afterwards picks the LODs up by itself.
+  ezString m_sLodFolder;
+
+  /// How much the mesh asset itself is already simplified, as the percentage of triangles removed.
+  /// 0 when it does not simplify at all. The generated LODs continue past this.
+  ezUInt8 m_uiBaseSimplification = 0;
+
+  /// The import settings every LOD has to share with the mesh asset, keyed by property name.
+  ezVariantDictionary m_ImportProperties;
+
+  /// The mesh asset's material slots, so that the LODs render with the same materials. Each entry
+  /// holds the "Label" and "Resource" of one slot.
+  ezDynamicArray<ezVariantDictionary> m_MaterialSlots;
+
+  /// Guids of LOD-1..N that already exist, in order, with an invalid uuid for each gap. Shorter than
+  /// the requested count when the trailing LODs do not exist.
+  ezDynamicArray<ezUuid> m_ExistingLods;
+
+  /// Whether LOD-N already exists. uiLod is 1 based.
+  bool HasLod(ezUInt32 uiLod) const;
+};
+
+/// Creates the LOD mesh assets that sit next to a mesh asset.
+///
+/// The LODs are the same model imported again with progressively stronger mesh simplification, the
+/// same way ezMeshAssetDocumentGenerator does it for a model that is imported with LODs enabled.
+///
+/// Names and locations match what ezMeshPrefabCreator looks for, so that a prefab created from the
+/// mesh afterwards finds the LODs and builds an ezLodMeshComponent.
+class EZ_EDITORPLUGINASSETS_DLL ezMeshLodCreator
+{
+public:
+  /// The most LODs the mesh import generates, and therefore the most the prefab tool looks for.
+  static constexpr ezUInt32 s_uiMaxLods = 4;
+
+  /// Fails if the guid does not belong to a mesh asset.
+  ///
+  /// Opens the mesh asset document to read its properties, if it is not open already.
+  static ezResult GatherMeshLodSource(const ezUuid& meshAssetGuid, ezMeshLodSource& out_source);
+
+  /// Creates and saves the LOD documents.
+  ///
+  /// Existing LOD assets are left alone unless ezMeshLodOptions::m_bOverwriteExisting is set.
+  static ezStatus CreateMeshLods(const ezMeshLodSource& source, const ezMeshLodOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped);
+
+  /// Creates LODs for each of the given mesh assets.
+  ///
+  /// Meshes that cannot get LODs are skipped with a log message rather than failing the whole run.
+  static ezStatus CreateMeshLodsForAll(ezArrayPtr<const ezUuid> meshAssetGuids, const ezMeshLodOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped);
+
+  /// Whether the given guid refers to a mesh or animated mesh asset.
+  static bool IsMeshAsset(const ezUuid& assetGuid);
+
+  /// The simplification for LOD uiLod (1 based), as the percentage of triangles removed.
+  ///
+  /// Each level takes the midpoint between the level before it and 100: from an unsimplified mesh
+  /// that is 50, 75, 88, 94; from a base of 50 it is 75, 88, 94. Never reaches 100, which would
+  /// remove the whole mesh.
+  static ezUInt8 GetLodSimplification(ezUInt8 uiBaseSimplification, ezUInt32 uiLod);
+
+  /// The tolerated error for LOD uiLod (1 based), as a percentage. Grows with the level. Mirrors
+  /// what the mesh import uses.
+  static ezUInt8 GetLodSimplificationError(ezUInt32 uiLod);
+
+  /// The absolute path of LOD uiLod (1 based) for that source.
+  static ezString GetLodPath(const ezMeshLodSource& source, ezUInt32 uiLod);
+
+  /// The folders that LODs of that mesh asset can sit in, most likely first.
+  ///
+  /// The mesh import writes them to "<Name>_data", using the mesh asset's name at import time. After
+  /// a rename that folder still has the old name, which was derived from the source model file, hence
+  /// the second candidate. sMeshFile may be empty, which yields one candidate.
+  static void GetLodFolderCandidates(ezStringView sMeshAssetPath, ezStringView sMeshFile, ezDynamicArray<ezString>& out_folders);
+};

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Actions/MeshColliderActions.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Actions/MeshColliderActions.cpp
@@ -1,0 +1,135 @@
+#include <EditorPluginJolt/EditorPluginJoltPCH.h>
+
+#include <EditorFramework/Assets/AssetBrowserContext.h>
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorPluginJolt/Actions/MeshColliderActions.h>
+#include <EditorPluginJolt/Dialogs/CreateMeshColliderDlg.moc.h>
+#include <GuiFoundation/Action/ActionManager.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshColliderAction, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezActionDescriptorHandle ezMeshColliderActions::s_hCategory;
+ezActionDescriptorHandle ezMeshColliderActions::s_hCreateCollider;
+ezActionDescriptorHandle ezMeshColliderActions::s_hCreateColliderDoc;
+
+void ezMeshColliderActions::RegisterActions()
+{
+  s_hCategory = EZ_REGISTER_CATEGORY("MeshColliderCategory");
+
+  // Two descriptors, because the scope decides both the action's context and how its proxy is cached:
+  // Global once overall for the asset browser, Document once per mesh document.
+  s_hCreateCollider = EZ_REGISTER_ACTION_0("Jolt.CreateColliderFromMesh", ezActionScope::Global, "Jolt", "", ezMeshColliderAction);
+  s_hCreateColliderDoc = EZ_REGISTER_ACTION_0("Jolt.CreateColliderFromMeshDocument", ezActionScope::Document, "Jolt", "", ezMeshColliderAction);
+}
+
+void ezMeshColliderActions::UnregisterActions()
+{
+  ezActionManager::UnregisterAction(s_hCategory);
+  ezActionManager::UnregisterAction(s_hCreateCollider);
+  ezActionManager::UnregisterAction(s_hCreateColliderDoc);
+}
+
+ezResult ezMeshColliderActions::MapActions(ezStringView sActionMap, ezStringView sSubPath, bool bDocumentScope)
+{
+  // Not an assert: the mesh document's action maps belong to EditorPluginAssets, which is not
+  // guaranteed to have been loaded first.
+  ezActionMap* pMap = ezActionMapManager::GetActionMap(sActionMap);
+  if (pMap == nullptr)
+    return EZ_FAILURE;
+
+  pMap->MapAction(s_hCategory, sSubPath, 11.0f);
+  pMap->MapAction(bDocumentScope ? s_hCreateColliderDoc : s_hCreateCollider, "MeshColliderCategory", 1.0f);
+  return EZ_SUCCESS;
+}
+
+void ezMeshColliderAction::GetTargetAssets(ezDynamicArray<ezUuid>& out_assets) const
+{
+  out_assets.Clear();
+
+  if (const ezAssetDocument* pAssetDoc = ezDynamicCast<const ezAssetDocument*>(m_Context.m_pDocument))
+  {
+    if (ezMeshColliderCreator::IsMeshAsset(pAssetDoc->GetGuid()))
+    {
+      out_assets.PushBack(pAssetDoc->GetGuid());
+    }
+
+    return;
+  }
+
+  for (const ezUuid& guid : ezAssetBrowserSelection::GetCurrent().m_AssetGuids)
+  {
+    if (ezMeshColliderCreator::IsMeshAsset(guid))
+    {
+      out_assets.PushBack(guid);
+    }
+  }
+}
+
+ezMeshColliderAction::ezMeshColliderAction(const ezActionContext& context, const char* szName)
+  : ezButtonAction(context, szName, false, "")
+{
+  SetIconPath(":/AssetIcons/Jolt_Collision_Mesh.svg");
+
+  RefreshState();
+}
+
+void ezMeshColliderAction::RefreshState()
+{
+  ezHybridArray<ezUuid, 16> assets;
+  GetTargetAssets(assets);
+
+  SetVisible(!assets.IsEmpty(), false);
+  SetEnabled(!assets.IsEmpty(), false);
+}
+
+void ezMeshColliderAction::Execute(const ezVariant& value)
+{
+  ezHybridArray<ezUuid, 16> assets;
+  GetTargetAssets(assets);
+
+  if (assets.IsEmpty())
+    return;
+
+  if (assets.GetCount() == 1)
+  {
+    ezMeshColliderSource source;
+    if (ezMeshColliderCreator::GatherMeshColliderSource(assets[0], source).Failed())
+    {
+      ezQtUiServices::MessageBoxWarning("The selected asset is not a mesh asset.");
+      return;
+    }
+
+    ezQtCreateMeshColliderDlg dlg(source, nullptr);
+    if (dlg.exec() != QDialog::Accepted)
+      return;
+
+    const ezStatus res = ezMeshColliderCreator::CreateMeshCollider(source, dlg.GetOptions());
+    ezQtUiServices::MessageBoxStatus(res, "Failed to create the collision mesh asset.", "", true);
+    return;
+  }
+
+  ezQtCreateMeshColliderDlg dlg(assets.GetCount(), nullptr);
+  if (dlg.exec() != QDialog::Accepted)
+    return;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  const ezStatus res = ezMeshColliderCreator::CreateMeshColliders(assets, dlg.GetOptions(), uiCreated, uiSkipped);
+
+  if (res.Failed())
+  {
+    ezQtUiServices::MessageBoxStatus(res, "Failed to create the collision mesh assets.", "", true);
+    return;
+  }
+
+  if (uiSkipped > 0)
+  {
+    // which meshes were skipped and why is in the log
+    ezQtUiServices::MessageBoxInformation(ezFmt("Created {} collision mesh asset(s), skipped {}.\n\nSee the log for details.", uiCreated, uiSkipped));
+  }
+}

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Actions/MeshColliderActions.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Actions/MeshColliderActions.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <EditorPluginJolt/EditorPluginJoltDLL.h>
+#include <EditorPluginJolt/Utils/MeshColliderCreator.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Types/Uuid.h>
+#include <GuiFoundation/Action/BaseActions.h>
+
+/// Creates Jolt collision mesh assets from mesh assets. Hides itself unless the target is one or
+/// more mesh assets.
+class ezMeshColliderActions
+{
+public:
+  static void RegisterActions();
+  static void UnregisterActions();
+
+  /// Pass bDocumentScope for a map belonging to a document window, so that the action is given that
+  /// document; leave it off for the asset browser, which has none and uses ezAssetBrowserSelection.
+  ///
+  /// Fails if the action map does not exist, i.e. the plugin that owns it is not loaded.
+  static ezResult MapActions(ezStringView sActionMap, ezStringView sSubPath, bool bDocumentScope = false);
+
+  static ezActionDescriptorHandle s_hCategory;
+  static ezActionDescriptorHandle s_hCreateCollider;
+  static ezActionDescriptorHandle s_hCreateColliderDoc;
+};
+
+class ezMeshColliderAction : public ezButtonAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMeshColliderAction, ezButtonAction);
+
+public:
+  ezMeshColliderAction(const ezActionContext& context, const char* szName);
+
+  virtual void Execute(const ezVariant& value) override;
+  virtual void RefreshState() override;
+
+private:
+  /// The action's own document, or else every mesh asset in the asset browser selection. Empty when
+  /// neither names a mesh asset.
+  ///
+  /// Non-mesh assets in the selection are dropped rather than disabling the action.
+  void GetTargetAssets(ezDynamicArray<ezUuid>& out_assets) const;
+};

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/CreateMeshColliderDlg.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/CreateMeshColliderDlg.cpp
@@ -1,0 +1,223 @@
+#include <EditorPluginJolt/EditorPluginJoltPCH.h>
+
+#include <EditorFramework/Assets/AssetBrowserDlg.moc.h>
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginJolt/Dialogs/CreateMeshColliderDlg.moc.h>
+#include <Foundation/IO/OSFile.h>
+#include <QFileDialog>
+#include <QPushButton>
+#include <ToolsFoundation/Project/ToolsProject.h>
+
+bool ezQtCreateMeshColliderDlg::s_bOpenAfterCreate = true;
+ezEnum<ezMeshColliderKind> ezQtCreateMeshColliderDlg::s_LastKind = ezMeshColliderKind::Default;
+
+ezQtCreateMeshColliderDlg::ezQtCreateMeshColliderDlg(const ezMeshColliderSource& source, QWidget* pParent)
+  : ezQtDialog(pParent)
+  , m_pSource(&source)
+{
+  Setup();
+
+  UpdateSuggestedPath();
+  UpdateInfo();
+}
+
+ezQtCreateMeshColliderDlg::ezQtCreateMeshColliderDlg(ezUInt32 uiMeshCount, QWidget* pParent)
+  : ezQtDialog(pParent)
+  , m_uiMeshCount(uiMeshCount)
+{
+  Setup();
+
+  // with several meshes there is no one path to pick, each collider goes next to its own mesh
+  ColliderPath->setEnabled(false);
+  BrowseButton->setEnabled(false);
+  m_bSettingPath = true;
+  ColliderPath->setText(QLatin1String("<next to each mesh asset>"));
+  m_bSettingPath = false;
+
+  // the box stays available, it is only unticked by default for a large selection
+  OpenAfterCreate->setText(QString("Open all %1 collision meshes after creating them").arg(uiMeshCount));
+  OpenAfterCreate->setChecked(s_bOpenAfterCreate && uiMeshCount <= s_uiMaxAutoOpen);
+
+  UpdateInfo();
+}
+
+void ezQtCreateMeshColliderDlg::Setup()
+{
+  setupUi(this);
+
+  ColliderType->addItem("Convex Hull", QVariant((int)ezMeshColliderKind::ConvexHull));
+  ColliderType->addItem("Triangle Mesh", QVariant((int)ezMeshColliderKind::TriangleMesh));
+  ColliderType->setCurrentIndex(ColliderType->findData(QVariant((int)s_LastKind.GetValue())));
+
+  OpenAfterCreate->setChecked(s_bOpenAfterCreate);
+}
+
+ezEnum<ezMeshColliderKind> ezQtCreateMeshColliderDlg::GetSelectedKind() const
+{
+  return (ezMeshColliderKind::Enum)ColliderType->currentData().toInt();
+}
+
+void ezQtCreateMeshColliderDlg::UpdateSuggestedPath()
+{
+  if (m_pSource == nullptr || !m_bPathIsSuggestion)
+    return;
+
+  const ezString sPath = ezMeshColliderCreator::MakeDisplayPath(
+    ezMeshColliderCreator::SuggestColliderPath(*m_pSource, GetSelectedKind(), OverwriteExisting->isChecked()));
+
+  // the change is our own, so the text handler must not treat it as the user typing a path
+  m_bSettingPath = true;
+  ColliderPath->setText(ezMakeQString(sPath));
+  m_bSettingPath = false;
+}
+
+void ezQtCreateMeshColliderDlg::UpdateInfo()
+{
+  // Only a convex mesh has a single surface. A triangle mesh gets one per material slot of the
+  // model, filled in by the asset transform.
+  const bool bHasSurface = GetSelectedKind() == ezMeshColliderKind::ConvexHull;
+  labelSurface->setVisible(bHasSurface);
+  SurfaceAsset->setVisible(bHasSurface);
+  SurfaceButton->setVisible(bHasSurface);
+  SurfaceClearButton->setVisible(bHasSurface);
+
+  ezStringBuilder sWarning;
+
+  if (m_pSource == nullptr)
+  {
+    // nothing to validate: the paths are decided per mesh, and every problem with one mesh is a skip
+  }
+  else if (m_pSource->m_bIsPrimitive)
+  {
+    sWarning = "This mesh asset uses a procedural primitive, not a model file, so no collision mesh can be generated from it.";
+  }
+  else if (m_pSource->m_sMeshFile.IsEmpty())
+  {
+    sWarning = "The source file of this mesh asset could not be read, so no collision mesh can be generated from it.";
+  }
+  else
+  {
+    const ezString sTyped = qtToEzString(ColliderPath->text());
+
+    ezStringBuilder sAbsolute;
+    if (sTyped.IsEmpty())
+    {
+      sWarning = "Enter a path for the collision mesh asset.";
+    }
+    else if (ezMeshColliderCreator::ResolveDisplayPath(sTyped, sAbsolute).Failed())
+    {
+      sWarning = "This path does not start with the name of a data directory.";
+    }
+    else if (ezOSFile::ExistsFile(sAbsolute) && !OverwriteExisting->isChecked())
+    {
+      sWarning = "This file already exists. Tick the box below to overwrite it, or choose a different name.";
+    }
+  }
+
+  WarningLabel->setText(ezMakeQString(sWarning));
+
+  if (QPushButton* pOk = ButtonBox->button(QDialogButtonBox::Ok))
+  {
+    pOk->setEnabled(sWarning.IsEmpty());
+  }
+}
+
+void ezQtCreateMeshColliderDlg::on_ColliderType_currentIndexChanged(int index)
+{
+  UpdateSuggestedPath();
+  UpdateInfo();
+}
+
+void ezQtCreateMeshColliderDlg::on_OverwriteExisting_toggled(bool checked)
+{
+  // the suggestion dodges an existing file by appending a number, which overwriting no longer wants
+  UpdateSuggestedPath();
+  UpdateInfo();
+}
+
+void ezQtCreateMeshColliderDlg::on_ColliderPath_textChanged(const QString& text)
+{
+  if (!m_bSettingPath)
+  {
+    m_bPathIsSuggestion = false;
+  }
+
+  UpdateInfo();
+}
+
+void ezQtCreateMeshColliderDlg::on_BrowseButton_clicked()
+{
+  const bool bConvex = GetSelectedKind() == ezMeshColliderKind::ConvexHull;
+
+  const QString sFilter = bConvex ? QLatin1String("Convex Collision Mesh (*.ezJoltConvexCollisionMeshAsset)")
+                                  : QLatin1String("Collision Mesh (*.ezJoltCollisionMeshAsset)");
+
+  // the file dialog needs a real path, the line edit holds a data directory relative one
+  ezStringBuilder sStart;
+  if (ezMeshColliderCreator::ResolveDisplayPath(qtToEzString(ColliderPath->text()), sStart).Failed() && m_pSource != nullptr)
+  {
+    sStart = ezMeshColliderCreator::SuggestColliderPath(*m_pSource, GetSelectedKind());
+  }
+
+  QString sFile = QFileDialog::getSaveFileName(this, QLatin1String("Create Collision Mesh"), ezMakeQString(sStart), sFilter,
+    nullptr, QFileDialog::Option::DontResolveSymlinks);
+
+  if (sFile.isEmpty())
+    return;
+
+  // a path the user browsed to must survive a change of the collider type
+  m_bPathIsSuggestion = false;
+  ColliderPath->setText(ezMakeQString(ezMeshColliderCreator::MakeDisplayPath(qtToEzString(sFile))));
+}
+
+void ezQtCreateMeshColliderDlg::on_SurfaceButton_clicked()
+{
+  const ezUuid current = ezConversionUtils::ConvertStringToUuid(m_sSurface);
+
+  ezQtAssetBrowserDlg dlg(this, current, "CompatibleAsset_Surface");
+  if (dlg.exec() == 0)
+    return;
+
+  const ezUuid selected = dlg.GetSelectedAssetGuid();
+  if (!selected.IsValid())
+    return;
+
+  // The guid is what goes into the asset, the path is only shown.
+  ezStringBuilder sGuid;
+  ezConversionUtils::ToString(selected, sGuid);
+  m_sSurface = sGuid;
+
+  SurfaceAsset->setText(ezMakeQString(dlg.GetSelectedAssetPathRelative()));
+}
+
+void ezQtCreateMeshColliderDlg::on_SurfaceClearButton_clicked()
+{
+  m_sSurface.Clear();
+  SurfaceAsset->clear();
+}
+
+void ezQtCreateMeshColliderDlg::on_ButtonBox_accepted()
+{
+  // Left empty for several meshes, which is what makes the creator use each mesh's default path.
+  m_Options.m_sColliderPath = (m_pSource != nullptr) ? qtToEzString(ColliderPath->text()) : ezString();
+  m_Options.m_Kind = GetSelectedKind();
+  s_LastKind = m_Options.m_Kind;
+  m_Options.m_sSurface = (GetSelectedKind() == ezMeshColliderKind::ConvexHull) ? m_sSurface : ezString();
+  m_Options.m_bOverwriteExisting = OverwriteExisting->isChecked();
+
+  // Not remembered for a large selection, where the box was unticked by us rather than by the user.
+  if (m_uiMeshCount <= s_uiMaxAutoOpen)
+  {
+    s_bOpenAfterCreate = OpenAfterCreate->isChecked();
+  }
+
+  m_Options.m_bOpenAfterCreate = OpenAfterCreate->isChecked();
+
+  accept();
+}
+
+void ezQtCreateMeshColliderDlg::on_ButtonBox_rejected()
+{
+  reject();
+}

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/CreateMeshColliderDlg.moc.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/CreateMeshColliderDlg.moc.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <EditorPluginJolt/EditorPluginJoltDLL.h>
+#include <EditorPluginJolt/Utils/MeshColliderCreator.h>
+#include <EditorPluginJolt/ui_CreateMeshColliderDlg.h>
+
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
+
+/// Configures what ezMeshColliderCreator::CreateMeshCollider() should generate.
+///
+/// Also used for several meshes at once, in which case there is no single output path to configure:
+/// each collider goes next to its own mesh, and the path field only says so.
+/// \see ezMeshColliderCreator::CreateMeshColliders()
+class ezQtCreateMeshColliderDlg : public ezQtDialog, public Ui_CreateMeshColliderDlg
+{
+  Q_OBJECT
+
+public:
+  /// For a single mesh, whose settings are shown and whose path can be edited.
+  ezQtCreateMeshColliderDlg(const ezMeshColliderSource& source, QWidget* pParent);
+
+  /// For several meshes. Nothing mesh specific is shown, and the path is fixed to the default.
+  ezQtCreateMeshColliderDlg(ezUInt32 uiMeshCount, QWidget* pParent);
+
+  /// The path is empty for the multi-mesh case, which is what tells the creator to use the default.
+  const ezMeshColliderOptions& GetOptions() const { return m_Options; }
+
+private Q_SLOTS:
+  void on_BrowseButton_clicked();
+  void on_ColliderPath_textChanged(const QString& text);
+  void on_ColliderType_currentIndexChanged(int index);
+  void on_OverwriteExisting_toggled(bool checked);
+  void on_SurfaceButton_clicked();
+  void on_SurfaceClearButton_clicked();
+  void on_ButtonBox_accepted();
+  void on_ButtonBox_rejected();
+
+private:
+  /// Everything both constructors do, before either fills in what is specific to its case.
+  ///
+  /// The collider kind starts on what was picked last.
+  void Setup();
+
+  ezEnum<ezMeshColliderKind> GetSelectedKind() const;
+
+  /// Puts the suggested path for the currently selected collider type into the line edit, unless
+  /// the user has typed their own path. Does nothing without a single source mesh.
+  void UpdateSuggestedPath();
+  void UpdateInfo();
+
+  /// Null when several meshes were selected, as none of them speaks for the others.
+  const ezMeshColliderSource* m_pSource = nullptr;
+
+  /// 1 unless several meshes were selected.
+  ezUInt32 m_uiMeshCount = 1;
+
+  ezMeshColliderOptions m_Options;
+
+  /// The surface asset, as a guid string. Kept separately because the line edit shows its path.
+  ezString m_sSurface;
+
+  /// False once the path was edited by hand, which stops the type combo from overwriting it.
+  bool m_bPathIsSuggestion = true;
+
+  /// Set while the path is filled in from code, so that this is not mistaken for the user typing.
+  bool m_bSettingPath = false;
+
+  /// Above this many meshes the "open after creation" box starts out unticked. It stays available.
+  static constexpr ezUInt32 s_uiMaxAutoOpen = 5;
+
+  // remembered across invocations
+  static bool s_bOpenAfterCreate;
+  static ezEnum<ezMeshColliderKind> s_LastKind;
+};

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/CreateMeshColliderDlg.ui
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/CreateMeshColliderDlg.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateMeshColliderDlg</class>
+ <widget class="QDialog" name="CreateMeshColliderDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>320</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Collider from Mesh</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+    <normaloff>:/GuiFoundation/EZ-logo.svg</normaloff>:/GuiFoundation/EZ-logo.svg</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelType">
+       <property name="text">
+        <string>Collider Type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="ColliderType"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelSurface">
+       <property name="text">
+        <string>Surface:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayoutSurface">
+       <item>
+        <widget class="QLineEdit" name="SurfaceAsset">
+         <property name="placeholderText">
+          <string>&lt;none&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="SurfaceButton">
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="SurfaceClearButton">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelPath">
+       <property name="text">
+        <string>Asset File:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayoutPath">
+       <item>
+        <widget class="QLineEdit" name="ColliderPath"/>
+       </item>
+       <item>
+        <widget class="QToolButton" name="BrowseButton">
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="WarningLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>13</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="OverwriteExisting">
+     <property name="text">
+      <string>Overwrite the collision mesh asset if it already exists</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="OpenAfterCreate">
+     <property name="text">
+      <string>Open collision meshes after creation</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../QtResources/resources.qrc"/>
+  <include location="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc"/>
+  <include location="../../../../Editor/EditorFramework/QtResources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
@@ -4,7 +4,9 @@
 #include <EditorFramework/Actions/CameraModeSwitchActions.h>
 #include <EditorFramework/Actions/CommonAssetActions.h>
 #include <EditorFramework/Actions/ProjectActions.h>
+#include <EditorFramework/Assets/AssetBrowserContext.h>
 #include <EditorPluginJolt/Actions/JoltActions.h>
+#include <EditorPluginJolt/Actions/MeshColliderActions.h>
 #include <EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h>
 #include <EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.moc.h>
 #include <GameEngine/Physics/CollisionFilter.h>
@@ -54,6 +56,15 @@ void OnLoadPlugin()
     }
   }
 
+  // Creating collision meshes from mesh assets
+  {
+    ezMeshColliderActions::RegisterActions();
+
+    ezMeshColliderActions::MapActions("AssetBrowserContextMenu", ezAssetBrowserContextMenu::s_sAssetMenu).IgnoreResult();
+    ezMeshColliderActions::MapActions("MeshAssetMenuBar", "G.Asset", true).IgnoreResult();
+    ezMeshColliderActions::MapActions("AnimatedMeshAssetMenuBar", "G.Asset", true).IgnoreResult();
+  }
+
   // Scene
   {
     // Menu Bar
@@ -84,6 +95,7 @@ void OnUnloadPlugin()
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezClothSheetComponent_PropertyMetaStateEventHandler);
 
   ezJoltActions::UnregisterActions();
+  ezMeshColliderActions::UnregisterActions();
   ezToolsProject::GetSingleton()->s_Events.RemoveEventHandler(ToolsProjectEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler);
 }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Utils/MeshColliderCreator.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Utils/MeshColliderCreator.cpp
@@ -1,0 +1,221 @@
+#include <EditorPluginJolt/EditorPluginJoltPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginAssets/Util/MeshColliderUtils.h>
+#include <EditorPluginJolt/Utils/MeshColliderCreator.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Logging/Log.h>
+
+namespace
+{
+  constexpr ezStringView s_sTriangleExtension = "ezJoltCollisionMeshAsset"_ezsv;
+  constexpr ezStringView s_sConvexExtension = "ezJoltConvexCollisionMeshAsset"_ezsv;
+
+  /// Read alongside the import properties, but not transferred: the collision mesh asset has no
+  /// equivalent, it only tells us whether there is a source file at all.
+  constexpr ezStringView s_sPrimitiveType = "PrimitiveType"_ezsv;
+
+} // namespace
+
+ezUuid ezMeshColliderSource::GetExisting(ezEnum<ezMeshColliderKind> kind) const
+{
+  return (kind == ezMeshColliderKind::ConvexHull) ? m_ExistingConvexColMesh : m_ExistingTriangleColMesh;
+}
+
+bool ezMeshColliderCreator::IsMeshAsset(const ezUuid& assetGuid)
+{
+  return ezMeshColliderUtils::IsMeshAsset(assetGuid);
+}
+
+ezResult ezMeshColliderCreator::GatherMeshColliderSource(const ezUuid& meshAssetGuid, ezMeshColliderSource& out_source)
+{
+  out_source = ezMeshColliderSource();
+  out_source.m_MeshAssetGuid = meshAssetGuid;
+
+  ezStringBuilder sMeshAssetPath;
+
+  // the curator lock must not be held while documents are opened further below
+  {
+    auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(meshAssetGuid);
+    if (!pSubAsset.isValid() || pSubAsset->m_pAssetInfo == nullptr)
+      return EZ_FAILURE;
+
+    const ezAssetInfo* pAssetInfo = pSubAsset->m_pAssetInfo;
+    if (pAssetInfo->m_pDocumentTypeDescriptor == nullptr)
+      return EZ_FAILURE;
+
+    const ezStringView sDocType = pAssetInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName;
+    if (sDocType != ezMeshColliderUtils::s_sMeshDocType && sDocType != ezMeshColliderUtils::s_sAnimatedMeshDocType)
+      return EZ_FAILURE;
+
+    out_source.m_bAnimated = (sDocType == ezMeshColliderUtils::s_sAnimatedMeshDocType);
+    sMeshAssetPath = pAssetInfo->m_Path.GetAbsolutePath();
+    out_source.m_sMeshAssetPath = sMeshAssetPath;
+  }
+
+  ezHybridArray<ezStringView, 24> toRead;
+  toRead = ezMeshColliderUtils::GetImportPropertyNames();
+  toRead.PushBackRange(ezMeshColliderUtils::GetSimplificationPropertyNames());
+  toRead.PushBack(s_sPrimitiveType);
+
+  // failing to read the properties leaves the source without a mesh file, which the caller reports
+  ezMeshColliderUtils::ReadMeshProperties(sMeshAssetPath, toRead, out_source.m_ImportProperties).IgnoreResult();
+
+  // a primitive mesh is generated procedurally, there is no model file for the collision mesh asset
+  ezVariant primitiveType;
+  if (out_source.m_ImportProperties.TryGetValue(s_sPrimitiveType, primitiveType))
+  {
+    out_source.m_bIsPrimitive = primitiveType.ConvertTo<ezInt64>() != 0; // 0 is ezMeshPrimitive::File
+    out_source.m_ImportProperties.Remove(s_sPrimitiveType);
+  }
+
+  ezVariant meshFile;
+  if (!out_source.m_bIsPrimitive && out_source.m_ImportProperties.TryGetValue("MeshFile"_ezsv, meshFile) && meshFile.IsA<ezString>())
+  {
+    out_source.m_sMeshFile = meshFile.Get<ezString>();
+  }
+
+  out_source.m_ExistingTriangleColMesh = ezMeshColliderUtils::FindExisting(ezCollisionMeshKind::TriangleMesh, out_source.m_sMeshFile, out_source.m_ImportProperties, out_source.m_sMeshAssetPath);
+  out_source.m_ExistingConvexColMesh = ezMeshColliderUtils::FindExisting(ezCollisionMeshKind::ConvexHull, out_source.m_sMeshFile, out_source.m_ImportProperties, out_source.m_sMeshAssetPath);
+
+  return EZ_SUCCESS;
+}
+
+ezString ezMeshColliderCreator::SuggestColliderPath(const ezMeshColliderSource& source, ezEnum<ezMeshColliderKind> kind, bool bAllowExisting)
+{
+  const ezStringView sExtension = (kind == ezMeshColliderKind::ConvexHull) ? s_sConvexExtension : s_sTriangleExtension;
+
+  ezStringBuilder sPath = source.m_sMeshAssetPath;
+  sPath.ChangeFileExtension(sExtension);
+
+  if (bAllowExisting || !ezOSFile::ExistsFile(sPath))
+    return sPath;
+
+  const ezString sBaseName = ezPathUtils::GetFileName(sPath);
+
+  for (ezUInt32 i = 2; i < 100; ++i)
+  {
+    ezStringBuilder sCandidateName;
+    sCandidateName.SetFormat("{}{}", sBaseName, i);
+
+    ezStringBuilder sCandidate = sPath;
+    sCandidate.ChangeFileName(sCandidateName);
+
+    if (!ezOSFile::ExistsFile(sCandidate))
+      return sCandidate;
+  }
+
+  return sPath;
+}
+
+ezString ezMeshColliderCreator::MakeDisplayPath(ezStringView sAbsolutePath)
+{
+  ezStringBuilder sPath = sAbsolutePath;
+  ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sPath);
+  return sPath;
+}
+
+ezResult ezMeshColliderCreator::ResolveDisplayPath(ezStringView sPath, ezStringBuilder& out_sAbsolutePath)
+{
+  out_sAbsolutePath = sPath;
+
+  if (out_sAbsolutePath.IsEmpty())
+    return EZ_FAILURE;
+
+  // the file is about to be created, so it does not exist yet
+  return ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(out_sAbsolutePath, false) ? EZ_SUCCESS : EZ_FAILURE;
+}
+
+ezStatus ezMeshColliderCreator::CreateMeshCollider(const ezMeshColliderSource& source, const ezMeshColliderOptions& options)
+{
+  // An empty path means "wherever this collider belongs", which is what creating several at once uses.
+  ezStringBuilder sColliderPath;
+  if (options.m_sColliderPath.IsEmpty())
+  {
+    sColliderPath = SuggestColliderPath(source, options.m_Kind);
+  }
+  else if (ResolveDisplayPath(options.m_sColliderPath, sColliderPath).Failed())
+  {
+    return ezStatus(ezFmt("'{}' does not name a known data directory.", options.m_sColliderPath));
+  }
+
+  if (sColliderPath.IsEmpty())
+    return ezStatus("No path for the collision mesh asset was given.");
+
+  if (source.m_bIsPrimitive)
+    return ezStatus("This mesh asset uses a procedural primitive, not a model file, so no collision mesh can be generated from it.");
+
+  if (source.m_sMeshFile.IsEmpty())
+    return ezStatus("The source file of this mesh asset could not be read, so no collision mesh can be generated from it.");
+
+  const ezEnum<ezCollisionMeshKind> kind = (options.m_Kind == ezMeshColliderKind::ConvexHull) ? ezCollisionMeshKind::ConvexHull : ezCollisionMeshKind::TriangleMesh;
+
+  ezUuid colliderGuid;
+  EZ_SUCCEED_OR_RETURN(ezMeshColliderUtils::CreateCollisionMesh(sColliderPath, kind, source.m_ImportProperties, options.m_sSurface, options.m_bOverwriteExisting, colliderGuid));
+
+  if (options.m_bOpenAfterCreate)
+  {
+    ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sColliderPath);
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}
+
+ezStatus ezMeshColliderCreator::CreateMeshColliders(ezArrayPtr<const ezUuid> meshAssetGuids, const ezMeshColliderOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped)
+{
+  out_uiCreated = 0;
+  out_uiSkipped = 0;
+
+  // The path is decided per mesh below, so a path meant for a single collider must not leak in.
+  ezMeshColliderOptions perMesh = options;
+  perMesh.m_sColliderPath.Clear();
+
+  for (const ezUuid& meshGuid : meshAssetGuids)
+  {
+    ezMeshColliderSource source;
+    if (GatherMeshColliderSource(meshGuid, source).Failed())
+    {
+      // not a mesh asset - with a mixed selection this is the normal case, not a problem
+      ++out_uiSkipped;
+      continue;
+    }
+
+    // a collider built from the same model file counts wherever it sits, unlike the path check below
+    if (!options.m_bOverwriteExisting && source.GetExisting(options.m_Kind).IsValid())
+    {
+      ezLog::Info("Skipping '{}': a collision mesh built from the same model file already exists.", MakeDisplayPath(source.m_sMeshAssetPath));
+      ++out_uiSkipped;
+      continue;
+    }
+
+    if (source.m_bIsPrimitive || source.m_sMeshFile.IsEmpty())
+    {
+      ezLog::Info("Skipping '{}': it has no model file to build a collision mesh from.", MakeDisplayPath(source.m_sMeshAssetPath));
+      ++out_uiSkipped;
+      continue;
+    }
+
+    // SuggestColliderPath() dodges an existing file by appending a number, which is wrong here: a
+    // mesh that already has a collider is done, it should not get a second, numbered one.
+    ezStringBuilder sPath = source.m_sMeshAssetPath;
+    sPath.ChangeFileExtension((options.m_Kind == ezMeshColliderKind::ConvexHull) ? s_sConvexExtension : s_sTriangleExtension);
+
+    if (!options.m_bOverwriteExisting && ezOSFile::ExistsFile(sPath))
+    {
+      ezLog::Info("Skipping '{}': '{}' already exists.", MakeDisplayPath(source.m_sMeshAssetPath), MakeDisplayPath(sPath));
+      ++out_uiSkipped;
+      continue;
+    }
+
+    perMesh.m_sColliderPath = sPath;
+
+    // "nothing to do here" was handled above, so what is left is a real failure and stops the run
+    EZ_SUCCEED_OR_RETURN(CreateMeshCollider(source, perMesh));
+
+    ezLog::Success("Created '{}'.", MakeDisplayPath(sPath));
+    ++out_uiCreated;
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Utils/MeshColliderCreator.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Utils/MeshColliderCreator.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <EditorPluginJolt/EditorPluginJoltDLL.h>
+#include <Foundation/Strings/String.h>
+#include <Foundation/Types/ArrayPtr.h>
+#include <Foundation/Types/Status.h>
+#include <Foundation/Types/Uuid.h>
+#include <Foundation/Types/Variant.h>
+
+/// Which kind of collision mesh asset to generate from a mesh asset.
+struct ezMeshColliderKind
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    /// ezJoltConvexCollisionMeshAsset. Required for dynamic actors.
+    ConvexHull,
+
+    /// ezJoltCollisionMeshAsset. Concave, but only usable for static geometry.
+    TriangleMesh,
+
+    Default = ConvexHull
+  };
+};
+
+/// \see ezMeshColliderCreator::CreateMeshCollider()
+struct ezMeshColliderOptions
+{
+  /// Where to write the asset. Absolute, or relative to the parent of a data directory
+  /// ("Testing Chambers/Objects/Barrel.ezJoltCollisionMeshAsset"). Empty means the suggested path,
+  /// which is what creating colliders for several meshes at once uses.
+  /// \see ezMeshColliderCreator::SuggestColliderPath()
+  ezString m_sColliderPath;
+
+  ezEnum<ezMeshColliderKind> m_Kind;
+
+  /// The surface asset to assign, as a guid or an asset path. Only convex meshes have a single
+  /// surface; a triangle mesh gets one per material slot at transform time, so this is ignored there.
+  ezString m_sSurface;
+
+  /// Overwrites a collision mesh asset that already exists instead of refusing.
+  ///
+  /// The contents are rewritten in place, so the asset keeps its guid and references to it still
+  /// resolve. Hand-tuned values on it are lost.
+  bool m_bOverwriteExisting = false;
+
+  bool m_bOpenAfterCreate = false;
+};
+
+/// The import settings of a mesh asset, as far as a collision mesh asset can reproduce them.
+///
+/// Every value is stored as a variant that is written to the collision mesh asset property of the
+/// same name, so that neither side's C++ type has to be known here. Values that the mesh asset does
+/// not have (an animated mesh has no transform options) are invalid variants and are then left at
+/// the collision mesh asset's own default.
+struct EZ_EDITORPLUGINJOLT_DLL ezMeshColliderSource
+{
+  ezUuid m_MeshAssetGuid;
+  ezString m_sMeshAssetPath;
+
+  /// The mesh asset's "MeshFile". Empty if it could not be read or the mesh is a primitive rather
+  /// than an imported file, in which case no collision mesh can be generated from it.
+  ezString m_sMeshFile;
+
+  /// True for a primitive mesh (ezMeshPrimitive other than File), which has no source file to import.
+  /// Kept separate from an empty m_sMeshFile so that the reason can be reported.
+  bool m_bIsPrimitive = false;
+
+  bool m_bAnimated = false;
+
+  /// The import options shared with the collision mesh asset, keyed by property name.
+  ezVariantDictionary m_ImportProperties;
+
+  /// An existing collision mesh asset of that kind built from the same source file, if there is one.
+  ezUuid m_ExistingTriangleColMesh;
+  ezUuid m_ExistingConvexColMesh;
+
+  /// The existing collision mesh asset of the given kind, or an invalid uuid.
+  ezUuid GetExisting(ezEnum<ezMeshColliderKind> kind) const;
+};
+
+/// Creates Jolt collision mesh assets from mesh assets. \see ezMeshColliderUtils
+///
+/// Only settings that both asset types have are transferred, everything else stays at the collision
+/// mesh asset's default.
+class EZ_EDITORPLUGINJOLT_DLL ezMeshColliderCreator
+{
+public:
+  /// Fails if the guid does not belong to a mesh asset.
+  ///
+  /// Opens the mesh asset document to read its properties, if it is not open already.
+  static ezResult GatherMeshColliderSource(const ezUuid& meshAssetGuid, ezMeshColliderSource& out_source);
+
+  /// Creates and saves the collision mesh asset document.
+  ///
+  /// Fails if a file already exists at the target path, unless ezMeshColliderOptions::m_bOverwriteExisting
+  /// is set. Reusing an existing collider is otherwise up to the caller.
+  /// \see ezMeshColliderSource::GetExisting()
+  static ezStatus CreateMeshCollider(const ezMeshColliderSource& source, const ezMeshColliderOptions& options);
+
+  /// Creates a collider for each of the given mesh assets, each at its suggested path.
+  ///
+  /// Meshes that already have a collider at that path, and ones no collider can be built from, are
+  /// skipped with a log message rather than failing the whole run. Only an outright error, such as a
+  /// document that cannot be written, is reported back.
+  static ezStatus CreateMeshColliders(ezArrayPtr<const ezUuid> meshAssetGuids, const ezMeshColliderOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped);
+
+  /// Whether the given guid refers to a mesh or animated mesh asset.
+  static bool IsMeshAsset(const ezUuid& assetGuid);
+
+  /// The default absolute path for a collider of that kind, next to the mesh asset.
+  ///
+  /// Appends a number if that file is already taken, unless bAllowExisting is set.
+  static ezString SuggestColliderPath(const ezMeshColliderSource& source, ezEnum<ezMeshColliderKind> kind, bool bAllowExisting = false);
+
+  /// Turns an absolute path into one relative to the parent of its data directory, for display.
+  /// Returns the input unchanged if it is not inside a data directory.
+  static ezString MakeDisplayPath(ezStringView sAbsolutePath);
+
+  /// Resolves what MakeDisplayPath() produced, or any absolute path, back to an absolute path.
+  /// Fails if the path names no known data directory.
+  static ezResult ResolveDisplayPath(ezStringView sPath, ezStringBuilder& out_sAbsolutePath);
+};

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/MeshPrefabActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/MeshPrefabActions.cpp
@@ -1,0 +1,155 @@
+#include <EditorPluginScene/EditorPluginScenePCH.h>
+
+#include <EditorFramework/Assets/AssetBrowserContext.h>
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorPluginScene/Actions/MeshPrefabActions.h>
+#include <EditorPluginScene/Dialogs/CreateMeshPrefabDlg.moc.h>
+#include <EditorPluginScene/Utils/MeshPrefabCreator.h>
+#include <GuiFoundation/Action/ActionManager.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshPrefabAction, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezActionDescriptorHandle ezMeshPrefabActions::s_hCategory;
+ezActionDescriptorHandle ezMeshPrefabActions::s_hCreatePrefabFromMesh;
+ezActionDescriptorHandle ezMeshPrefabActions::s_hCreatePrefabFromMeshDoc;
+
+void ezMeshPrefabActions::RegisterActions()
+{
+  s_hCategory = EZ_REGISTER_CATEGORY("MeshPrefabCategory");
+
+  s_hCreatePrefabFromMesh = EZ_REGISTER_ACTION_1("Prefabs.CreateFromMesh", ezActionScope::Global, "Prefabs", "", ezMeshPrefabAction, ezMeshPrefabAction::ActionType::CreatePrefabFromMesh);
+  s_hCreatePrefabFromMeshDoc = EZ_REGISTER_ACTION_1("Prefabs.CreateFromMeshDocument", ezActionScope::Document, "Prefabs", "", ezMeshPrefabAction, ezMeshPrefabAction::ActionType::CreatePrefabFromMesh);
+}
+
+void ezMeshPrefabActions::UnregisterActions()
+{
+  ezActionManager::UnregisterAction(s_hCategory);
+  ezActionManager::UnregisterAction(s_hCreatePrefabFromMesh);
+  ezActionManager::UnregisterAction(s_hCreatePrefabFromMeshDoc);
+}
+
+ezResult ezMeshPrefabActions::MapActions(ezStringView sActionMap, ezStringView sSubPath, bool bDocumentScope)
+{
+  // Not an assert: the mesh document's action maps belong to EditorPluginAssets, which is not
+  // guaranteed to have been loaded first.
+  ezActionMap* pMap = ezActionMapManager::GetActionMap(sActionMap);
+  if (pMap == nullptr)
+    return EZ_FAILURE;
+
+  pMap->MapAction(s_hCategory, sSubPath, 10.0f);
+  pMap->MapAction(bDocumentScope ? s_hCreatePrefabFromMeshDoc : s_hCreatePrefabFromMesh, "MeshPrefabCategory", 1.0f);
+  return EZ_SUCCESS;
+}
+
+void ezMeshPrefabAction::GetTargetAssets(ezDynamicArray<ezUuid>& out_assets) const
+{
+  out_assets.Clear();
+
+  if (const ezAssetDocument* pAssetDoc = ezDynamicCast<const ezAssetDocument*>(m_Context.m_pDocument))
+  {
+    if (ezMeshPrefabCreator::IsMeshAsset(pAssetDoc->GetGuid()))
+    {
+      out_assets.PushBack(pAssetDoc->GetGuid());
+    }
+
+    return;
+  }
+
+  for (const ezUuid& guid : ezAssetBrowserSelection::GetCurrent().m_AssetGuids)
+  {
+    if (ezMeshPrefabCreator::IsMeshAsset(guid))
+    {
+      out_assets.PushBack(guid);
+    }
+  }
+}
+
+ezMeshPrefabAction::ezMeshPrefabAction(const ezActionContext& context, const char* szName, ezMeshPrefabAction::ActionType type)
+  : ezButtonAction(context, szName, false, "")
+{
+  m_Type = type;
+
+  switch (m_Type)
+  {
+    case ActionType::CreatePrefabFromMesh:
+      SetIconPath(":/AssetIcons/Prefab.svg");
+      break;
+  }
+
+  RefreshState();
+}
+
+void ezMeshPrefabAction::RefreshState()
+{
+  switch (m_Type)
+  {
+    case ActionType::CreatePrefabFromMesh:
+    {
+      ezHybridArray<ezUuid, 16> assets;
+      GetTargetAssets(assets);
+
+      SetVisible(!assets.IsEmpty(), false);
+      SetEnabled(!assets.IsEmpty(), false);
+      break;
+    }
+  }
+}
+
+void ezMeshPrefabAction::Execute(const ezVariant& value)
+{
+  switch (m_Type)
+  {
+    case ActionType::CreatePrefabFromMesh:
+    {
+      ezHybridArray<ezUuid, 16> assets;
+      GetTargetAssets(assets);
+
+      if (assets.IsEmpty())
+        return;
+
+      if (assets.GetCount() == 1)
+      {
+        ezMeshPrefabSource source;
+        if (ezMeshPrefabCreator::GatherMeshPrefabSource(assets[0], source).Failed())
+        {
+          ezQtUiServices::MessageBoxWarning("The selected asset is not a mesh asset.");
+          return;
+        }
+
+        ezQtCreateMeshPrefabDlg dlg(source, nullptr);
+        if (dlg.exec() != QDialog::Accepted)
+          return;
+
+        const ezStatus res = ezMeshPrefabCreator::CreateMeshPrefab(source, dlg.GetOptions());
+        ezQtUiServices::MessageBoxStatus(res, "Failed to create the prefab.", "", true);
+        return;
+      }
+
+      ezQtCreateMeshPrefabDlg dlg(assets.GetCount(), nullptr);
+      if (dlg.exec() != QDialog::Accepted)
+        return;
+
+      ezUInt32 uiCreated = 0;
+      ezUInt32 uiSkipped = 0;
+      const ezStatus res = ezMeshPrefabCreator::CreateMeshPrefabs(assets, dlg.GetOptions(), uiCreated, uiSkipped);
+
+      if (res.Failed())
+      {
+        ezQtUiServices::MessageBoxStatus(res, "Failed to create the prefabs.", "", true);
+        return;
+      }
+
+      // which meshes were skipped and why is in the log
+      if (uiSkipped > 0)
+      {
+        ezQtUiServices::MessageBoxInformation(ezFmt("Created {} prefab(s), skipped {}.\n\nSee the log for details.", uiCreated, uiSkipped));
+      }
+      break;
+    }
+  }
+}

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/MeshPrefabActions.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/MeshPrefabActions.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <EditorPluginScene/EditorPluginSceneDLL.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Types/Uuid.h>
+#include <GuiFoundation/Action/BaseActions.h>
+
+/// Creates prefabs from mesh assets. Hides itself unless the target is one or more mesh assets.
+class ezMeshPrefabActions
+{
+public:
+  static void RegisterActions();
+  static void UnregisterActions();
+
+  /// Pass bDocumentScope for a map belonging to a document window, so that the action is given that
+  /// document; leave it off for the asset browser, which has none and uses ezAssetBrowserSelection.
+  ///
+  /// Fails if the action map does not exist, i.e. the plugin that owns it is not loaded.
+  static ezResult MapActions(ezStringView sActionMap, ezStringView sSubPath, bool bDocumentScope = false);
+
+  static ezActionDescriptorHandle s_hCategory;
+  static ezActionDescriptorHandle s_hCreatePrefabFromMesh;
+  static ezActionDescriptorHandle s_hCreatePrefabFromMeshDoc;
+};
+
+class ezMeshPrefabAction : public ezButtonAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMeshPrefabAction, ezButtonAction);
+
+public:
+  enum class ActionType
+  {
+    CreatePrefabFromMesh,
+  };
+
+  ezMeshPrefabAction(const ezActionContext& context, const char* szName, ActionType type);
+
+  virtual void Execute(const ezVariant& value) override;
+  virtual void RefreshState() override;
+
+private:
+  /// The action's own document, or else every mesh asset in the asset browser selection. Empty when
+  /// neither names a mesh asset.
+  ///
+  /// Non-mesh assets in the selection are dropped rather than disabling the action.
+  void GetTargetAssets(ezDynamicArray<ezUuid>& out_assets) const;
+
+  ActionType m_Type;
+};

--- a/Code/EditorPlugins/Scene/EditorPluginScene/CMakeLists.txt
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/CMakeLists.txt
@@ -12,8 +12,10 @@ ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets Svg)
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
   EditorFramework
+  EditorPluginAssets
   GameEngine
   SharedPluginScene
+  Mcp
 )
 
 add_dependencies(${PROJECT_NAME}

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/CreateMeshPrefabDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/CreateMeshPrefabDlg.cpp
@@ -1,0 +1,292 @@
+#include <EditorPluginScene/EditorPluginScenePCH.h>
+
+#include <EditorPluginScene/Dialogs/CreateMeshPrefabDlg.moc.h>
+#include <Foundation/IO/OSFile.h>
+#include <QFileDialog>
+#include <QPushButton>
+#include <ToolsFoundation/Project/ToolsProject.h>
+
+ezInt32 ezQtCreateMeshPrefabDlg::s_iPhysicsMode = ezMeshPrefabPhysics::None;
+ezInt32 ezQtCreateMeshPrefabDlg::s_iCollisionLayer = 0;
+bool ezQtCreateMeshPrefabDlg::s_bOpenAfterCreate = true;
+
+ezQtCreateMeshPrefabDlg::ezQtCreateMeshPrefabDlg(const ezMeshPrefabSource& source, QWidget* pParent)
+  : ezQtDialog(pParent)
+  , m_pSource(&source)
+{
+  Setup();
+
+  UpdateSuggestedPath();
+
+  {
+    // The animated components need a skeleton, which only an animated mesh asset has. The other way
+    // round is fine: an animated mesh can be rendered by a static component.
+    RenderComponent->addItem("ezMeshComponent", QVariant("ezMeshComponent"));
+    RenderComponent->addItem("ezLodMeshComponent", QVariant("ezLodMeshComponent"));
+
+    if (source.m_bAnimated)
+    {
+      RenderComponent->addItem("ezAnimatedMeshComponent", QVariant("ezAnimatedMeshComponent"));
+      RenderComponent->addItem("ezLodAnimatedMeshComponent", QVariant("ezLodAnimatedMeshComponent"));
+    }
+
+    const ezStringView sDefault = source.GetDefaultRenderComponentType();
+    RenderComponent->setCurrentIndex(RenderComponent->findData(QVariant(ezMakeQString(sDefault))));
+  }
+
+  UpdateLodInfo();
+
+  if (PhysicsGroup->isVisible())
+  {
+    // the box modes need bounds, which only exist once the mesh has been transformed
+    if (!source.m_bHasBounds)
+    {
+      const char* szReason = "The bounds of this mesh are unknown. Transform the mesh asset to make this available.";
+
+      for (ezInt32 i : {(ezInt32)ezMeshPrefabPhysics::StaticBox, (ezInt32)ezMeshPrefabPhysics::DynamicBox})
+      {
+        const int idx = PhysicsMode->findData(QVariant(i));
+        PhysicsMode->setItemData(idx, QVariant(0), Qt::UserRole - 1); // disables the item
+        PhysicsMode->setItemData(idx, QString(szReason), Qt::ToolTipRole);
+      }
+    }
+
+    // generating a collision mesh needs the original model file
+    if (source.m_sMeshFile.IsEmpty())
+    {
+      const char* szReason = "The source file of this mesh asset could not be read, so no collision mesh can be generated from it.";
+
+      for (ezInt32 i : {(ezInt32)ezMeshPrefabPhysics::StaticTriangleMesh, (ezInt32)ezMeshPrefabPhysics::StaticConvexHull, (ezInt32)ezMeshPrefabPhysics::DynamicConvexHull})
+      {
+        const int idx = PhysicsMode->findData(QVariant(i));
+        PhysicsMode->setItemData(idx, QVariant(0), Qt::UserRole - 1);
+        PhysicsMode->setItemData(idx, QString(szReason), Qt::ToolTipRole);
+      }
+    }
+
+    // what was decided for this mesh beats what was picked for some other mesh last time
+    const ezEnum<ezMeshPrefabPhysics> detected = source.GetDefaultPhysics();
+    const ezInt32 iPreferred = (detected != ezMeshPrefabPhysics::None) ? (ezInt32)detected.GetValue() : s_iPhysicsMode;
+
+    const int idxPreferred = PhysicsMode->findData(QVariant(iPreferred));
+    if (idxPreferred >= 0 && (PhysicsMode->itemData(idxPreferred, Qt::UserRole - 1).isNull() || PhysicsMode->itemData(idxPreferred, Qt::UserRole - 1).toBool()))
+    {
+      PhysicsMode->setCurrentIndex(idxPreferred);
+    }
+
+    if (detected != ezMeshPrefabPhysics::None)
+    {
+      PhysicsMode->setToolTip("A collision mesh built from this model already exists and will be reused.");
+    }
+  }
+
+  UpdateWarnings();
+}
+
+ezQtCreateMeshPrefabDlg::ezQtCreateMeshPrefabDlg(ezUInt32 uiMeshCount, QWidget* pParent)
+  : ezQtDialog(pParent)
+  , m_uiMeshCount(uiMeshCount)
+{
+  Setup();
+
+  // with several meshes there is no one path to pick, each prefab goes next to its own mesh
+  PrefabPath->setEnabled(false);
+  BrowseButton->setEnabled(false);
+  m_bSettingPath = true;
+  PrefabPath->setText(QLatin1String("<next to each mesh asset>"));
+  m_bSettingPath = false;
+
+  // which component fits depends on the mesh - animated or not, with LODs or without
+  RenderComponent->addItem("<the one that fits each mesh>");
+  RenderComponent->setEnabled(false);
+
+  LodInfo->setText("LOD meshes found next to a mesh are added to its prefab, if its component uses them.");
+
+  OverwriteExisting->setText(QLatin1String("Overwrite prefabs that already exist"));
+
+  if (PhysicsGroup->isVisible())
+  {
+    const int idx = PhysicsMode->findData(QVariant(s_iPhysicsMode));
+    if (idx >= 0)
+    {
+      PhysicsMode->setCurrentIndex(idx);
+    }
+
+    PhysicsMode->setToolTip("Meshes this cannot be applied to are skipped.");
+  }
+
+  // the box stays available, it is only unticked by default for a large selection
+  OpenAfterCreate->setText(QString("Open all %1 prefabs after creating them").arg(uiMeshCount));
+  OpenAfterCreate->setChecked(s_bOpenAfterCreate && uiMeshCount <= s_uiMaxAutoOpen);
+
+  UpdateWarnings();
+}
+
+void ezQtCreateMeshPrefabDlg::Setup()
+{
+  setupUi(this);
+
+  if (!ezMeshPrefabCreator::IsPhysicsAvailable())
+  {
+    PhysicsGroup->setVisible(false);
+  }
+  else
+  {
+    PhysicsMode->addItem("None", QVariant(ezMeshPrefabPhysics::None));
+    PhysicsMode->addItem("Static - triangle collision mesh", QVariant(ezMeshPrefabPhysics::StaticTriangleMesh));
+    PhysicsMode->addItem("Static - convex hull collision mesh", QVariant(ezMeshPrefabPhysics::StaticConvexHull));
+    PhysicsMode->addItem("Static - box from mesh bounds", QVariant(ezMeshPrefabPhysics::StaticBox));
+    PhysicsMode->addItem("Dynamic - convex hull collision mesh", QVariant(ezMeshPrefabPhysics::DynamicConvexHull));
+    PhysicsMode->addItem("Dynamic - box from mesh bounds", QVariant(ezMeshPrefabPhysics::DynamicBox));
+
+    CollisionLayer->setValue(s_iCollisionLayer);
+  }
+
+  OpenAfterCreate->setChecked(s_bOpenAfterCreate);
+}
+
+void ezQtCreateMeshPrefabDlg::UpdateLodInfo()
+{
+  if (m_pSource == nullptr)
+    return;
+
+  // only the LOD components use the extra meshes
+  const ezString sRenderType = qtToEzString(RenderComponent->currentData().toString());
+  const bool bLodComponent = (sRenderType == "ezLodMeshComponent") || (sRenderType == "ezLodAnimatedMeshComponent");
+
+  if (m_pSource->m_LodGuids.IsEmpty())
+  {
+    LodInfo->setText("No LOD meshes were found next to this mesh.");
+  }
+  else if (bLodComponent)
+  {
+    LodInfo->setText(QString("Found %1 LOD mesh(es), they will be added to the component in order.").arg(m_pSource->m_LodGuids.GetCount()));
+  }
+  else
+  {
+    LodInfo->setText(QString("Found %1 LOD mesh(es), but this component does not use them.").arg(m_pSource->m_LodGuids.GetCount()));
+  }
+}
+
+void ezQtCreateMeshPrefabDlg::UpdateSuggestedPath()
+{
+  if (m_pSource == nullptr || !m_bPathIsSuggestion)
+    return;
+
+  const ezString sPath = ezMeshPrefabCreator::MakeDisplayPath(
+    ezMeshPrefabCreator::SuggestPrefabPath(*m_pSource, OverwriteExisting->isChecked()));
+
+  // the change is our own, so the text handler must not treat it as the user typing a path
+  m_bSettingPath = true;
+  PrefabPath->setText(ezMakeQString(sPath));
+  m_bSettingPath = false;
+}
+
+void ezQtCreateMeshPrefabDlg::UpdateWarnings()
+{
+  ezStringBuilder sWarning;
+
+  if (m_pSource != nullptr)
+  {
+    const ezString sTyped = qtToEzString(PrefabPath->text());
+
+    ezStringBuilder sAbsolute;
+    if (sTyped.IsEmpty())
+    {
+      sWarning = "Enter a path for the prefab.";
+    }
+    else if (ezMeshPrefabCreator::ResolveDisplayPath(sTyped, sAbsolute).Failed())
+    {
+      sWarning = "This path does not start with the name of a data directory.";
+    }
+    else if (ezOSFile::ExistsFile(sAbsolute) && !OverwriteExisting->isChecked())
+    {
+      sWarning = "This file already exists. Tick the box below to overwrite it, or choose a different name.";
+    }
+  }
+
+  WarningLabel->setText(ezMakeQString(sWarning));
+
+  if (QPushButton* pOk = ButtonBox->button(QDialogButtonBox::Ok))
+  {
+    pOk->setEnabled(sWarning.IsEmpty());
+  }
+}
+
+void ezQtCreateMeshPrefabDlg::on_PrefabPath_textChanged(const QString& text)
+{
+  if (!m_bSettingPath)
+  {
+    m_bPathIsSuggestion = false;
+  }
+
+  UpdateWarnings();
+}
+
+void ezQtCreateMeshPrefabDlg::on_RenderComponent_currentIndexChanged(int index)
+{
+  UpdateLodInfo();
+}
+
+void ezQtCreateMeshPrefabDlg::on_OverwriteExisting_toggled(bool checked)
+{
+  // the suggestion dodges an existing file by appending a number, which overwriting no longer wants
+  UpdateSuggestedPath();
+  UpdateWarnings();
+}
+
+void ezQtCreateMeshPrefabDlg::on_BrowseButton_clicked()
+{
+  // the file dialog needs a real path, the line edit holds a data directory relative one
+  ezStringBuilder sStart;
+  if (ezMeshPrefabCreator::ResolveDisplayPath(qtToEzString(PrefabPath->text()), sStart).Failed() && m_pSource != nullptr)
+  {
+    sStart = ezMeshPrefabCreator::SuggestPrefabPath(*m_pSource);
+  }
+
+  QString sFile = QFileDialog::getSaveFileName(this, QLatin1String("Create Prefab"), ezMakeQString(sStart), QLatin1String("Prefab (*.ezPrefab)"),
+    nullptr, QFileDialog::Option::DontResolveSymlinks);
+
+  if (sFile.isEmpty())
+    return;
+
+  // a path the user browsed to must survive a change of the overwrite box
+  m_bPathIsSuggestion = false;
+  PrefabPath->setText(ezMakeQString(ezMeshPrefabCreator::MakeDisplayPath(qtToEzString(sFile))));
+}
+
+void ezQtCreateMeshPrefabDlg::on_ButtonBox_accepted()
+{
+  // Both are left empty for several meshes, which is what makes the creator decide them per mesh.
+  if (m_pSource != nullptr)
+  {
+    m_Options.m_sPrefabPath = qtToEzString(PrefabPath->text());
+    m_Options.m_sRenderComponentType = qtToEzString(RenderComponent->currentData().toString());
+  }
+
+  m_Options.m_bOverwriteExisting = OverwriteExisting->isChecked();
+
+  if (PhysicsGroup->isVisible())
+  {
+    s_iPhysicsMode = PhysicsMode->currentData().toInt();
+    s_iCollisionLayer = CollisionLayer->value();
+
+    m_Options.m_Physics = (ezMeshPrefabPhysics::Enum)s_iPhysicsMode;
+    m_Options.m_uiCollisionLayer = (ezUInt8)s_iCollisionLayer;
+  }
+
+  // Not remembered for a large selection, where the box was unticked by us rather than by the user.
+  if (m_uiMeshCount <= s_uiMaxAutoOpen)
+  {
+    s_bOpenAfterCreate = OpenAfterCreate->isChecked();
+  }
+
+  m_Options.m_bOpenAfterCreate = OpenAfterCreate->isChecked();
+
+  accept();
+}
+
+void ezQtCreateMeshPrefabDlg::on_ButtonBox_rejected()
+{
+  reject();
+}

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/CreateMeshPrefabDlg.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/CreateMeshPrefabDlg.moc.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <EditorPluginScene/EditorPluginSceneDLL.h>
+#include <EditorPluginScene/Utils/MeshPrefabCreator.h>
+#include <EditorPluginScene/ui_CreateMeshPrefabDlg.h>
+
+#include <GuiFoundation/Dialogs/Dialog.moc.h>
+
+/// Configures what ezMeshPrefabCreator::CreateMeshPrefab() should generate.
+///
+/// Options the mesh can't support are disabled rather than hidden, with a tooltip saying why.
+///
+/// Also used for several meshes at once, in which case there is no single output path or render
+/// component to configure: each prefab goes next to its own mesh, and each gets the component that
+/// suits it. \see ezMeshPrefabCreator::CreateMeshPrefabs()
+class ezQtCreateMeshPrefabDlg : public ezQtDialog, public Ui_CreateMeshPrefabDlg
+{
+  Q_OBJECT
+
+public:
+  /// For a single mesh, whose LODs are shown and whose path can be edited.
+  ezQtCreateMeshPrefabDlg(const ezMeshPrefabSource& source, QWidget* pParent);
+
+  /// For several meshes. Nothing mesh specific is shown, and the path is fixed to the default.
+  ezQtCreateMeshPrefabDlg(ezUInt32 uiMeshCount, QWidget* pParent);
+
+  /// The path and the render component type are empty for the multi-mesh case, which is what tells
+  /// the creator to decide both per mesh.
+  const ezMeshPrefabOptions& GetOptions() const { return m_Options; }
+
+private Q_SLOTS:
+  void on_BrowseButton_clicked();
+  void on_PrefabPath_textChanged(const QString& text);
+  void on_RenderComponent_currentIndexChanged(int index);
+  void on_OverwriteExisting_toggled(bool checked);
+  void on_ButtonBox_accepted();
+  void on_ButtonBox_rejected();
+
+private:
+  /// Everything both constructors do, before either fills in what is specific to its case.
+  void Setup();
+
+  void UpdateWarnings();
+
+  /// The LODs are only used by the LOD components, so what this says depends on the selected
+  /// component type as much as on what was found next to the mesh.
+  void UpdateLodInfo();
+
+  /// Puts the suggested path into the line edit, unless the user has typed or browsed to their own.
+  /// Does nothing without a single source mesh.
+  void UpdateSuggestedPath();
+
+  /// Null when several meshes were selected, as none of them speaks for the others.
+  const ezMeshPrefabSource* m_pSource = nullptr;
+
+  /// 1 unless several meshes were selected.
+  ezUInt32 m_uiMeshCount = 1;
+
+  /// False once the path was edited by hand, which stops the overwrite box from overwriting it.
+  bool m_bPathIsSuggestion = true;
+
+  /// Set while the path is filled in from code, so that this is not mistaken for the user typing.
+  bool m_bSettingPath = false;
+
+  ezMeshPrefabOptions m_Options;
+
+  /// Above this many meshes the "open after creation" box starts out unticked. It stays available.
+  static constexpr ezUInt32 s_uiMaxAutoOpen = 5;
+
+  // remembered across invocations
+  static ezInt32 s_iPhysicsMode;
+  static ezInt32 s_iCollisionLayer;
+  static bool s_bOpenAfterCreate;
+};

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/CreateMeshPrefabDlg.ui
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/CreateMeshPrefabDlg.ui
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateMeshPrefabDlg</class>
+ <widget class="QDialog" name="CreateMeshPrefabDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>460</width>
+    <height>360</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Prefab from Mesh</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+    <normaloff>:/GuiFoundation/EZ-logo.svg</normaloff>:/GuiFoundation/EZ-logo.svg</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelPath">
+       <property name="text">
+        <string>Prefab File:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayoutPath">
+       <item>
+        <widget class="QLineEdit" name="PrefabPath"/>
+       </item>
+       <item>
+        <widget class="QToolButton" name="BrowseButton">
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelRender">
+       <property name="text">
+        <string>Render Component:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="RenderComponent"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="LodInfo">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="PhysicsGroup">
+     <property name="title">
+      <string>Physics</string>
+     </property>
+     <layout class="QFormLayout" name="formLayoutPhysics">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelCollider">
+        <property name="text">
+         <string>Collider:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="PhysicsMode"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelLayer">
+        <property name="text">
+         <string>Collision Layer:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="CollisionLayer">
+        <property name="maximum">
+         <number>31</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="OverwriteExisting">
+     <property name="text">
+      <string>Overwrite the prefab if it already exists</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="OpenAfterCreate">
+     <property name="text">
+      <string>Open the prefab after creating it</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="WarningLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>13</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../QtResources/resources.qrc"/>
+  <include location="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc"/>
+  <include location="../../../../Editor/EditorFramework/QtResources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -7,10 +7,12 @@
 #include <EditorFramework/Actions/QuadViewActions.h>
 #include <EditorFramework/Actions/TransformGizmoActions.h>
 #include <EditorFramework/Actions/ViewActions.h>
+#include <EditorFramework/Assets/AssetBrowserContext.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Visualizers/VisualizerAdapterRegistry.h>
 #include <EditorPluginScene/Actions/LayerActions.h>
+#include <EditorPluginScene/Actions/MeshPrefabActions.h>
 #include <EditorPluginScene/Actions/SceneActions.h>
 #include <EditorPluginScene/Actions/SelectionActions.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
@@ -158,6 +160,12 @@ void OnLoadPlugin()
   ezSceneGizmoActions::RegisterActions();
   ezSceneActions::RegisterActions();
   ezLayerActions::RegisterActions();
+  ezMeshPrefabActions::RegisterActions();
+
+  // Lives here rather than with the mesh asset, because what it knows about is prefabs, not meshes.
+  ezMeshPrefabActions::MapActions("AssetBrowserContextMenu", ezAssetBrowserContextMenu::s_sAssetMenu).IgnoreResult();
+  ezMeshPrefabActions::MapActions("MeshAssetMenuBar", "G.Asset", true).IgnoreResult();
+  ezMeshPrefabActions::MapActions("AnimatedMeshAssetMenuBar", "G.Asset", true).IgnoreResult();
 
   // misc
   ezQtImageSliderWidget::s_ImageGenerators["LightTemperature"] = SliderImageGenerator_LightTemperature;
@@ -267,6 +275,7 @@ void OnUnloadPlugin()
   ezSceneGizmoActions::UnregisterActions();
   ezLayerActions::UnregisterActions();
   ezSceneActions::UnregisterActions();
+  ezMeshPrefabActions::UnregisterActions();
 }
 
 EZ_PLUGIN_ON_LOADED()

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -13,7 +13,9 @@
 #include <EditorFramework/Visualizers/VisualizerAdapterRegistry.h>
 #include <EditorPluginScene/Actions/LayerActions.h>
 #include <EditorPluginScene/Actions/MeshPrefabActions.h>
+#include <EditorPluginScene/McpTools/MeshPrefabTool.h>
 #include <EditorPluginScene/Actions/SceneActions.h>
+#include <Mcp/McpToolRegistry.h>
 #include <EditorPluginScene/Actions/SelectionActions.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
 #include <EditorPluginScene/Scene/Scene2DocumentWindow.moc.h>
@@ -276,6 +278,7 @@ void OnUnloadPlugin()
   ezLayerActions::UnregisterActions();
   ezSceneActions::UnregisterActions();
   ezMeshPrefabActions::UnregisterActions();
+  ezMcpToolRegistry::RemoveProvider(ezGetStaticRTTI<ezMcpMeshPrefabTool>());
 }
 
 EZ_PLUGIN_ON_LOADED()

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -13,10 +13,9 @@
 #include <EditorFramework/Visualizers/VisualizerAdapterRegistry.h>
 #include <EditorPluginScene/Actions/LayerActions.h>
 #include <EditorPluginScene/Actions/MeshPrefabActions.h>
-#include <EditorPluginScene/McpTools/MeshPrefabTool.h>
 #include <EditorPluginScene/Actions/SceneActions.h>
-#include <Mcp/McpToolRegistry.h>
 #include <EditorPluginScene/Actions/SelectionActions.h>
+#include <EditorPluginScene/McpTools/MeshPrefabTool.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
 #include <EditorPluginScene/Scene/Scene2DocumentWindow.moc.h>
 #include <EditorPluginScene/Scene/SceneDocumentManager.h>
@@ -36,6 +35,7 @@
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/UIServices/DynamicStringEnum.h>
+#include <Mcp/McpToolRegistry.h>
 #include <RendererCore/Components/SplineComponent.h>
 #include <RendererCore/Lights/BoxReflectionProbeComponent.h>
 #include <RendererCore/Lights/DirectionalLightComponent.h>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/McpTools/MeshPrefabTool.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/McpTools/MeshPrefabTool.cpp
@@ -1,0 +1,465 @@
+#include <EditorPluginScene/EditorPluginScenePCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginScene/McpTools/MeshPrefabTool.h>
+#include <EditorPluginScene/Utils/MeshPrefabCreator.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+#include <ToolsFoundation/Project/ToolsProject.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpMeshPrefabTool, 1, ezRTTIDefaultAllocator<ezMcpMeshPrefabTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  struct PhysicsName
+  {
+    ezStringView m_sName;
+    ezMeshPrefabPhysics::Enum m_Value;
+  };
+
+  /// The spellings that the 'physics' argument accepts, and that mesh_prefab_info reports back.
+  constexpr PhysicsName s_PhysicsNames[] = {
+    {"None"_ezsv, ezMeshPrefabPhysics::None},
+    {"StaticTriangleMesh"_ezsv, ezMeshPrefabPhysics::StaticTriangleMesh},
+    {"StaticConvexHull"_ezsv, ezMeshPrefabPhysics::StaticConvexHull},
+    {"StaticBox"_ezsv, ezMeshPrefabPhysics::StaticBox},
+    {"DynamicConvexHull"_ezsv, ezMeshPrefabPhysics::DynamicConvexHull},
+    {"DynamicBox"_ezsv, ezMeshPrefabPhysics::DynamicBox},
+  };
+
+  ezStringView PhysicsToString(ezMeshPrefabPhysics::Enum value)
+  {
+    for (const PhysicsName& n : s_PhysicsNames)
+    {
+      if (n.m_Value == value)
+        return n.m_sName;
+    }
+
+    return "None"_ezsv;
+  }
+
+  /// Case insensitive, because the argument comes from a language model reading the schema.
+  bool PhysicsFromString(ezStringView sName, ezMeshPrefabPhysics::Enum& out_value)
+  {
+    for (const PhysicsName& n : s_PhysicsNames)
+    {
+      if (n.m_sName.IsEqual_NoCase(sName))
+      {
+        out_value = n.m_Value;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Whether a mode can be used for this mesh, and why not if it can't.
+  ///
+  /// The box modes are sized from the bounds, which only exist once the asset was transformed. The
+  /// collision mesh modes generate an asset from the source model file, so they need that path.
+  ezStringView GetPhysicsUnavailableReason(const ezMeshPrefabSource& source, ezMeshPrefabPhysics::Enum mode)
+  {
+    if (mode == ezMeshPrefabPhysics::None)
+      return {};
+
+    if (!ezMeshPrefabCreator::IsPhysicsAvailable())
+      return "The Jolt plugin is not loaded, so no collider components exist."_ezsv;
+
+    switch (mode)
+    {
+      case ezMeshPrefabPhysics::StaticBox:
+      case ezMeshPrefabPhysics::DynamicBox:
+        if (!source.m_bHasBounds)
+          return "The mesh asset has no bounds. Transform it first, with asset_transform."_ezsv;
+        break;
+
+      case ezMeshPrefabPhysics::StaticTriangleMesh:
+      case ezMeshPrefabPhysics::StaticConvexHull:
+      case ezMeshPrefabPhysics::DynamicConvexHull:
+        if (source.m_sMeshFile.IsEmpty())
+          return "The mesh asset has no source model file, so no collision mesh asset can be generated from it."_ezsv;
+        break;
+
+      default:
+        break;
+    }
+
+    return {};
+  }
+
+  /// Turns whatever the caller passed into an absolute path.
+  ///
+  /// Same three spellings the document tools accept, except that the file must not exist yet, so the
+  /// data directory lookup cannot go by existence.
+  ///
+  /// The result is always absolute, as everything downstream asserts on relative paths. A spelling
+  /// that resolves to no data directory is interpreted relative to the project directory.
+  ezStringBuilder ResolveOutputPath(ezStringView sPath)
+  {
+    ezStringBuilder sResult = sPath;
+    sResult.MakeCleanPath();
+
+    if (sResult.IsEmpty() || ezPathUtils::IsAbsolutePath(sResult))
+      return sResult;
+
+    ezStringBuilder sTemp = sResult;
+    if (ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(sTemp, false))
+      return sTemp;
+
+    // only finds a path whose file already exists, but it is what resolves a rooted path or a guid
+    sTemp = sResult;
+    if (ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sTemp))
+      return sTemp;
+
+    if (ezToolsProject::IsProjectOpen())
+    {
+      sTemp = ezToolsProject::GetSingleton()->GetProjectDirectory();
+      sTemp.AppendPath(sResult);
+      sTemp.MakeCleanPath();
+      return sTemp;
+    }
+
+    return sResult;
+  }
+
+  ezAssetCurator::ezLockedSubAsset ResolveAsset(ezStringView sPathOrGuid)
+  {
+    ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+    auto asset = pCurator->FindSubAsset(sPathOrGuid, false);
+
+    if (asset.isValid())
+      return asset;
+
+    return pCurator->FindSubAsset(sPathOrGuid, true);
+  }
+
+  /// Resolves the 'mesh' argument down to a mesh asset guid, or explains why it isn't one.
+  bool ResolveMeshArgument(const ezVariantDictionary& arguments, ezMcpToolResult& out_result, ezUuid& out_guid)
+  {
+    const ezStringView sMesh = ezMcpJson::GetString(arguments, "mesh");
+
+    if (sMesh.IsEmpty())
+    {
+      out_result.SetError("The 'mesh' argument is required. Pass the guid or path of a mesh asset, as returned by asset_find.");
+      return false;
+    }
+
+    if (ezAssetCurator::GetSingleton() == nullptr)
+    {
+      out_result.SetError("No project is open.");
+      return false;
+    }
+
+    ezUuid guid;
+    {
+      auto asset = ResolveAsset(sMesh);
+
+      if (!asset.isValid())
+      {
+        ezStringBuilder sError;
+        sError.SetFormat("No asset found for '{}'. Use asset_find to search for it.", sMesh);
+        out_result.SetError(sError);
+        return false;
+      }
+
+      guid = asset->m_Data.m_Guid;
+    }
+
+    if (!ezMeshPrefabCreator::IsMeshAsset(guid))
+    {
+      ezStringBuilder sError;
+      sError.SetFormat("'{}' is not a mesh or animated mesh asset, so no prefab can be created from it.", sMesh);
+      out_result.SetError(sError);
+      return false;
+    }
+
+    out_guid = guid;
+    return true;
+  }
+
+  /// The prefab path that mesh_prefab_info suggests and that mesh_prefab_create uses when the caller
+  /// names none: the mesh asset path with the extension swapped. Empty when that file exists, as
+  /// creation refuses to overwrite.
+  ezStringBuilder SuggestPrefabPath(const ezMeshPrefabSource& source)
+  {
+    if (source.m_sMeshAssetPath.IsEmpty())
+      return {};
+
+    ezStringBuilder sPath = source.m_sMeshAssetPath;
+    sPath.ChangeFileExtension("ezPrefab");
+
+    if (ezOSFile::ExistsFile(sPath))
+      return {};
+
+    return sPath;
+  }
+
+} // namespace
+
+void ezMcpMeshPrefabTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "mesh_prefab_info";
+    desc.m_sDescription =
+      "Reports what a prefab created from a mesh asset would contain, and which options are usable for it. Modifies nothing. "
+      "Returns the render component that fits the mesh (ezLodMeshComponent when the import produced LOD assets, "
+      "ezAnimatedMeshComponent for a skinned mesh, ezMeshComponent otherwise), the mesh bounds, any collision mesh asset that "
+      "already exists for the same source model, and for every physics mode whether it can be used and why not. "
+      "Call this before 'mesh_prefab_create' when the options matter; creating with the defaults needs no info call.";
+    desc.m_sInputSchema = R"({"type":"object","properties":{)"
+                          R"("mesh":{"type":"string","description":"Guid or path of a mesh or animated mesh asset, as returned by asset_find."})"
+                          R"(},"required":["mesh"]})";
+  }
+
+  {
+    ezMcpToolDesc& desc = out_tools.ExpandAndGetRef();
+    desc.m_sName = "mesh_prefab_create";
+    desc.m_sDescription =
+      "Creates and saves a prefab document that displays one mesh asset: a root game object with the render component that fits the "
+      "mesh, and optionally a Jolt collider. This is the same operation as 'Create Prefab...' in the asset browser's context menu. "
+      "The collision mesh modes generate an ezJoltCollisionMeshAsset (or convex one) next to the mesh asset, reusing an existing one "
+      "built from the same source model rather than creating a duplicate. The box modes need the mesh bounds and therefore a mesh "
+      "asset that was transformed at least once. "
+      "Fails if the target file already exists - it never overwrites a prefab. The new prefab is not transformed here; call "
+      "asset_transform on it before using it in a scene.";
+    desc.m_sInputSchema =
+      R"({"type":"object","properties":{)"
+      R"("mesh":{"type":"string","description":"Guid or path of a mesh or animated mesh asset, as returned by asset_find."},)"
+      R"("prefab":{"type":"string","description":"Where to write the prefab. Absolute, or relative to a data directory or its parent. A missing '.ezPrefab' extension is added. Defaults to the mesh asset path with the extension swapped."},)"
+      R"("renderComponent":{"type":"string","description":"RTTI name of the component that renders the mesh, e.g. 'ezMeshComponent'. Defaults to what mesh_prefab_info reports as 'renderComponent'."},)"
+      R"("physics":{"type":"string","enum":["None","StaticTriangleMesh","StaticConvexHull","StaticBox","DynamicConvexHull","DynamicBox"],"description":"Which collider to set up. Defaults to 'defaultPhysics' from mesh_prefab_info, which is a mode matching an already existing collision mesh asset, or 'None'."},)"
+      R"("collisionLayer":{"type":"number","description":"Jolt collision layer for the actor component. Defaults to 0."},)"
+      R"("surface":{"type":"string","description":"Guid or path of a surface asset for the collider. Optional."})"
+      R"(},"required":["mesh"]})";
+  }
+}
+
+void ezMcpMeshPrefabTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "mesh_prefab_info")
+    ExecuteInfo(arguments, out_result);
+  else if (sToolName == "mesh_prefab_create")
+    ExecuteCreate(arguments, out_result);
+}
+
+void ezMcpMeshPrefabTool::ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezUuid meshGuid;
+  if (!ResolveMeshArgument(arguments, out_result, meshGuid))
+    return;
+
+  ezMeshPrefabSource source;
+  if (ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Failed())
+  {
+    out_result.SetError("The mesh asset could not be read.");
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableUuid("mesh", source.m_MeshAssetGuid);
+  writer.AddVariableString("meshPath", source.m_sMeshAssetPath);
+  writer.AddVariableString("sourceModelFile", source.m_sMeshFile);
+  writer.AddVariableBool("animated", source.m_bAnimated);
+  writer.AddVariableString("renderComponent", source.GetDefaultRenderComponentType());
+
+  writer.BeginArray("lodMeshes");
+  for (const ezUuid& lod : source.m_LodGuids)
+  {
+    ezStringBuilder sGuid;
+    ezConversionUtils::ToString(lod, sGuid);
+    writer.WriteString(sGuid);
+  }
+  writer.EndArray();
+
+  writer.AddVariableBool("hasBounds", source.m_bHasBounds);
+
+  if (source.m_bHasBounds)
+  {
+    writer.BeginObject("bounds");
+    writer.AddVariableVec3("center", source.m_vBoundsCenter);
+    writer.AddVariableVec3("halfExtents", source.m_vBoundsHalfExtents);
+    writer.AddVariableFloat("radius", source.m_fBoundsRadius);
+    writer.EndObject();
+  }
+
+  writer.AddVariableBool("physicsAvailable", ezMeshPrefabCreator::IsPhysicsAvailable());
+  writer.AddVariableString("defaultPhysics", PhysicsToString(source.GetDefaultPhysics()));
+
+  if (source.m_ExistingTriangleColMesh.IsValid())
+    writer.AddVariableUuid("existingTriangleCollisionMesh", source.m_ExistingTriangleColMesh);
+
+  if (source.m_ExistingConvexColMesh.IsValid())
+    writer.AddVariableUuid("existingConvexCollisionMesh", source.m_ExistingConvexColMesh);
+
+  // Every mode is listed, usable or not, so that a caller can tell a mode that does not exist from
+  // one this mesh is missing a prerequisite for.
+  writer.BeginArray("physicsModes");
+  for (const PhysicsName& n : s_PhysicsNames)
+  {
+    const ezStringView sReason = GetPhysicsUnavailableReason(source, n.m_Value);
+
+    writer.BeginObject();
+    writer.AddVariableString("mode", n.m_sName);
+    writer.AddVariableBool("usable", sReason.IsEmpty());
+
+    if (!sReason.IsEmpty())
+      writer.AddVariableString("reason", sReason);
+
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  const ezStringBuilder sSuggested = SuggestPrefabPath(source);
+
+  if (sSuggested.IsEmpty())
+  {
+    writer.AddVariableString("note", "A prefab already exists at the default path, so 'prefab' has to be given explicitly. "
+                                     "mesh_prefab_create does not overwrite.");
+  }
+  else
+  {
+    writer.AddVariableString("suggestedPrefabPath", sSuggested);
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+void ezMcpMeshPrefabTool::ExecuteCreate(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezUuid meshGuid;
+  if (!ResolveMeshArgument(arguments, out_result, meshGuid))
+    return;
+
+  ezMeshPrefabSource source;
+  if (ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Failed())
+  {
+    out_result.SetError("The mesh asset could not be read.");
+    return;
+  }
+
+  ezMeshPrefabOptions options;
+
+  {
+    const ezStringView sPrefab = ezMcpJson::GetString(arguments, "prefab");
+
+    ezStringBuilder sPath = sPrefab.IsEmpty() ? SuggestPrefabPath(source) : ResolveOutputPath(sPrefab);
+
+    if (sPath.IsEmpty())
+    {
+      out_result.SetError("A prefab already exists at the default path next to the mesh asset. Pass 'prefab' to write it somewhere "
+                          "else - this never overwrites an existing prefab.");
+      return;
+    }
+
+    // creation resolves the document type from the extension, which a caller often leaves off
+    if (!ezPathUtils::HasExtension(sPath, "ezPrefab"))
+      sPath.ChangeFileExtension("ezPrefab");
+
+    options.m_sPrefabPath = sPath;
+  }
+
+  options.m_sRenderComponentType = ezMcpJson::GetString(arguments, "renderComponent", source.GetDefaultRenderComponentType());
+
+  {
+    const ezStringView sPhysics = ezMcpJson::GetString(arguments, "physics");
+
+    if (sPhysics.IsEmpty())
+    {
+      options.m_Physics = source.GetDefaultPhysics();
+    }
+    else
+    {
+      ezMeshPrefabPhysics::Enum mode = ezMeshPrefabPhysics::None;
+
+      if (!PhysicsFromString(sPhysics, mode))
+      {
+        ezStringBuilder sError;
+        sError.SetFormat("'{}' is not a physics mode. Valid values are None, StaticTriangleMesh, StaticConvexHull, StaticBox, "
+                         "DynamicConvexHull and DynamicBox.",
+          sPhysics);
+        out_result.SetError(sError);
+        return;
+      }
+
+      // checked here, so that the reason names the missing prerequisite
+      const ezStringView sReason = GetPhysicsUnavailableReason(source, mode);
+
+      if (!sReason.IsEmpty())
+      {
+        ezStringBuilder sError;
+        sError.SetFormat("Physics mode '{}' cannot be used for this mesh. {}", sPhysics, sReason);
+        out_result.SetError(sError);
+        return;
+      }
+
+      options.m_Physics = mode;
+    }
+  }
+
+  options.m_uiCollisionLayer = static_cast<ezUInt8>(ezMath::Clamp<ezInt64>(ezMcpJson::GetInt(arguments, "collisionLayer", 0), 0, 31));
+
+  {
+    const ezStringView sSurface = ezMcpJson::GetString(arguments, "surface");
+
+    if (!sSurface.IsEmpty())
+    {
+      auto asset = ResolveAsset(sSurface);
+
+      if (!asset.isValid())
+      {
+        ezStringBuilder sError;
+        sError.SetFormat("No asset found for surface '{}'.", sSurface);
+        out_result.SetError(sError);
+        return;
+      }
+
+      ezStringBuilder sGuid;
+      ezConversionUtils::ToString(asset->m_Data.m_Guid, sGuid);
+      options.m_sSurfaceAsset = sGuid;
+    }
+  }
+
+  // not opened: that would put a window in front of the user for something they did not click on
+  options.m_bOpenAfterCreate = false;
+
+  const ezStatus res = ezMeshPrefabCreator::CreateMeshPrefab(source, options);
+
+  if (res.Failed())
+  {
+    out_result.SetError(res.GetMessageString());
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  writer.AddVariableString("prefabPath", options.m_sPrefabPath);
+  writer.AddVariableUuid("mesh", source.m_MeshAssetGuid);
+  writer.AddVariableString("renderComponent", options.m_sRenderComponentType);
+  writer.AddVariableString("physics", PhysicsToString(options.m_Physics));
+  writer.AddVariableUInt32("lodCount", source.m_LodGuids.GetCount() + 1);
+
+  // the curator has to have seen the file before anything can look it up by guid
+  ezAssetCurator::GetSingleton()->CheckFileSystem();
+
+  auto created = ezAssetCurator::GetSingleton()->FindSubAsset(options.m_sPrefabPath, false);
+
+  if (created.isValid())
+    writer.AddVariableUuid("prefab", created->m_Data.m_Guid);
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}

--- a/Code/EditorPlugins/Scene/EditorPluginScene/McpTools/MeshPrefabTool.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/McpTools/MeshPrefabTool.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Mcp/McpTool.h>
+
+/// Creates prefabs from mesh assets, which is otherwise only reachable through the asset browser's
+/// context menu and its dialog.
+///
+/// Split in two because the options that make sense depend on the mesh: a box collider needs bounds,
+/// a triangle mesh collider cannot be used for a dynamic actor, and without the Jolt plugin none of
+/// them exist. 'mesh_prefab_info' reports that for one mesh, 'mesh_prefab_create' then acts on it.
+/// Calling create directly is fine when the defaults are wanted.
+class ezMcpMeshPrefabTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpMeshPrefabTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteInfo(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteCreate(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+};

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Utils/MeshPrefabCreator.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Utils/MeshPrefabCreator.cpp
@@ -1,0 +1,645 @@
+#include <EditorPluginScene/EditorPluginScenePCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorPluginAssets/Util/MeshColliderUtils.h>
+#include <EditorPluginAssets/Util/MeshLodCreator.h>
+#include <EditorPluginScene/Utils/MeshPrefabCreator.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Utilities/AssetInfoFile.h>
+#include <ToolsFoundation/Command/TreeCommands.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+
+namespace
+{
+  /// Equivalent of ezSimpleAssetDocument::GetPropertyObject(), which can't be called without knowing
+  /// the concrete asset type.
+  const ezDocumentObject* GetTopLevelObject(const ezDocument* pDoc)
+  {
+    const ezDocumentObject* pRoot = pDoc->GetObjectManager()->GetRootObject();
+    if (pRoot == nullptr || pRoot->GetChildren().GetCount() != 1)
+      return nullptr;
+
+    return pRoot->GetChildren()[0];
+  }
+
+  /// Reads a property from an asset document without knowing its C++ type.
+  ///
+  /// Only closes the document again if it had to be opened here and nothing has claimed a window for
+  /// it, so that a document someone else is working with is left alone.
+  ezVariant ReadAssetProperty(ezStringView sAbsDocumentPath, ezStringView sProperty)
+  {
+    bool bWasOpen = false;
+    ezDocument* pDoc = nullptr;
+
+    const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+    if (ezDocumentManager::FindDocumentTypeFromPath(sAbsDocumentPath, false, pTypeDesc).Succeeded())
+    {
+      pDoc = pTypeDesc->m_pManager->GetDocumentByPath(sAbsDocumentPath);
+      bWasOpen = (pDoc != nullptr);
+    }
+
+    if (pDoc == nullptr)
+      pDoc = ezQtEditorApp::GetSingleton()->OpenDocument(sAbsDocumentPath, ezDocumentFlags::None);
+
+    if (pDoc == nullptr)
+      return {};
+
+    ezVariant res;
+    if (const ezDocumentObject* pPropObj = GetTopLevelObject(pDoc))
+    {
+      res = pPropObj->GetTypeAccessor().GetValue(sProperty);
+    }
+
+    if (!bWasOpen && !pDoc->HasWindowBeenRequested())
+    {
+      pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    }
+
+    return res;
+  }
+
+  /// An asset reference is the guid in braces, which is how ezUuid already formats itself.
+  ezString FormatResourceRef(const ezUuid& guid)
+  {
+    ezStringBuilder s;
+    s.SetFormat("{}", guid);
+    return s;
+  }
+
+  /// Returns an invalid uuid if the type is unknown, i.e. its plugin is not loaded.
+  ezUuid AddComponent(ezCommandHistory* pHistory, const ezUuid& parentObject, ezStringView sType)
+  {
+    if (ezRTTI::FindTypeByName(sType) == nullptr)
+      return {};
+
+    ezAddObjectCommand cmd;
+    cmd.m_Index = -1;
+    cmd.SetType(sType);
+    cmd.m_Parent = parentObject;
+    cmd.m_sParentProperty = "Components";
+
+    if (pHistory->AddCommand(cmd).Failed())
+      return {};
+
+    return cmd.m_NewObjectGuid;
+  }
+
+  ezStatus SetProperty(ezCommandHistory* pHistory, const ezUuid& object, ezStringView sProperty, const ezVariant& value)
+  {
+    ezSetObjectPropertyCommand cmd;
+    cmd.m_Object = object;
+    cmd.m_sProperty = sProperty;
+    cmd.m_NewValue = value;
+    return pHistory->AddCommand(cmd);
+  }
+} // namespace
+
+ezStringView ezMeshPrefabSource::GetDefaultRenderComponentType() const
+{
+  if (m_bAnimated)
+    return m_LodGuids.IsEmpty() ? "ezAnimatedMeshComponent"_ezsv : "ezLodAnimatedMeshComponent"_ezsv;
+
+  return m_LodGuids.IsEmpty() ? "ezMeshComponent"_ezsv : "ezLodMeshComponent"_ezsv;
+}
+
+bool ezMeshPrefabCreator::IsPhysicsAvailable()
+{
+  return ezRTTI::FindTypeByName("ezJoltStaticActorComponent") != nullptr;
+}
+
+bool ezMeshPrefabCreator::IsMeshAsset(const ezUuid& assetGuid)
+{
+  return ezMeshColliderUtils::IsMeshAsset(assetGuid);
+}
+
+namespace
+{
+  /// Collects LOD-1..N from one folder. Stops at the first gap, as LODs form a contiguous run.
+  void CollectLodsFromFolder(ezStringView sFolder, ezDynamicArray<ezUuid>& out_lodGuids)
+  {
+    for (ezUInt32 uiLod = 1; uiLod <= ezMeshLodCreator::s_uiMaxLods; ++uiLod)
+    {
+      ezStringBuilder sLodName;
+      sLodName.SetFormat("LOD-{}.ezMeshAsset", uiLod);
+
+      ezStringBuilder sLodPath = sFolder;
+      sLodPath.AppendPath(sLodName);
+
+      auto pLod = ezAssetCurator::GetSingleton()->FindSubAsset(sLodPath);
+      if (!pLod.isValid())
+        return;
+
+      out_lodGuids.PushBack(pLod->m_Data.m_Guid);
+    }
+  }
+
+  /// Looks in the same folders that ezMeshLodCreator writes to, so that LODs it created are picked up.
+  void FindLodSiblings(ezStringView sMeshAssetPath, ezStringView sMeshFile, ezDynamicArray<ezUuid>& out_lodGuids)
+  {
+    ezHybridArray<ezString, 2> folders;
+    ezMeshLodCreator::GetLodFolderCandidates(sMeshAssetPath, sMeshFile, folders);
+
+    for (const ezString& sFolder : folders)
+    {
+      CollectLodsFromFolder(sFolder, out_lodGuids);
+
+      if (!out_lodGuids.IsEmpty())
+        return;
+    }
+  }
+} // namespace
+
+ezResult ezMeshPrefabCreator::GatherMeshPrefabSource(const ezUuid& meshAssetGuid, ezMeshPrefabSource& out_source)
+{
+  out_source = ezMeshPrefabSource();
+  out_source.m_MeshAssetGuid = meshAssetGuid;
+
+  ezStringBuilder sMeshAssetPath;
+
+  // the curator lock must not be held while documents are opened further below
+  {
+    auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(meshAssetGuid);
+    if (!pSubAsset.isValid() || pSubAsset->m_pAssetInfo == nullptr)
+      return EZ_FAILURE;
+
+    const ezAssetInfo* pAssetInfo = pSubAsset->m_pAssetInfo;
+    if (pAssetInfo->m_pDocumentTypeDescriptor == nullptr)
+      return EZ_FAILURE;
+
+    const ezStringView sDocType = pAssetInfo->m_pDocumentTypeDescriptor->m_sDocumentTypeName;
+    if (sDocType != ezMeshColliderUtils::s_sMeshDocType && sDocType != ezMeshColliderUtils::s_sAnimatedMeshDocType)
+      return EZ_FAILURE;
+
+    out_source.m_bAnimated = (sDocType == ezMeshColliderUtils::s_sAnimatedMeshDocType);
+    sMeshAssetPath = pAssetInfo->m_Path.GetAbsolutePath();
+    out_source.m_sMeshAssetPath = sMeshAssetPath;
+
+    // bounds are only available once the asset has been transformed at least once
+    if (const ezAssetInfoFile* pInfo = pAssetInfo->GetTransformInfo())
+    {
+      const ezVariant center = pInfo->GetValue(ezAssetInfoFile::Keys::BoundsCenter);
+      const ezVariant extents = pInfo->GetValue(ezAssetInfoFile::Keys::BoundsHalfExtents);
+      const ezVariant radius = pInfo->GetValue(ezAssetInfoFile::Keys::BoundsRadius);
+
+      if (center.IsA<ezVec3>() && extents.IsA<ezVec3>())
+      {
+        out_source.m_vBoundsCenter = center.Get<ezVec3>();
+        out_source.m_vBoundsHalfExtents = extents.Get<ezVec3>();
+        out_source.m_fBoundsRadius = radius.IsValid() ? radius.ConvertTo<float>() : out_source.m_vBoundsHalfExtents.GetLength();
+        out_source.m_bHasBounds = true;
+      }
+    }
+  }
+
+  const ezVariant meshFile = ReadAssetProperty(sMeshAssetPath, "MeshFile");
+  if (meshFile.IsA<ezString>())
+  {
+    out_source.m_sMeshFile = meshFile.Get<ezString>();
+  }
+
+  FindLodSiblings(sMeshAssetPath, out_source.m_sMeshFile, out_source.m_LodGuids);
+
+  ezVariantDictionary subMeshProperties;
+  ezMeshColliderUtils::ReadMeshProperties(sMeshAssetPath, ezMeshColliderUtils::GetSubMeshPropertyNames(), subMeshProperties).IgnoreResult();
+
+  out_source.m_ExistingTriangleColMesh = ezMeshColliderUtils::FindExisting(ezCollisionMeshKind::TriangleMesh, out_source.m_sMeshFile, subMeshProperties, out_source.m_sMeshAssetPath);
+  out_source.m_ExistingConvexColMesh = ezMeshColliderUtils::FindExisting(ezCollisionMeshKind::ConvexHull, out_source.m_sMeshFile, subMeshProperties, out_source.m_sMeshAssetPath);
+
+  return EZ_SUCCESS;
+}
+
+ezEnum<ezMeshPrefabPhysics> ezMeshPrefabSource::GetDefaultPhysics() const
+{
+  // a triangle mesh is only usable for static bodies, so its existence is the more specific signal
+  if (m_ExistingTriangleColMesh.IsValid())
+    return ezMeshPrefabPhysics::StaticTriangleMesh;
+
+  // a convex hull works for both; dynamic additionally needs mass and material set up sensibly
+  if (m_ExistingConvexColMesh.IsValid())
+    return ezMeshPrefabPhysics::StaticConvexHull;
+
+  return ezMeshPrefabPhysics::None;
+}
+
+namespace
+{
+  /// Creates a collision mesh asset next to the mesh asset, or reuses a matching existing one.
+  /// \see ezMeshColliderUtils
+  ezStatus GetOrCreateCollisionMesh(const ezMeshPrefabSource& source, bool bConvex, ezUuid& out_guid)
+  {
+    const ezEnum<ezCollisionMeshKind> kind = bConvex ? ezCollisionMeshKind::ConvexHull : ezCollisionMeshKind::TriangleMesh;
+
+    if (source.m_sMeshFile.IsEmpty())
+      return ezStatus("The mesh asset has no source file, so no collision mesh can be generated from it.");
+
+    ezHybridArray<ezStringView, 24> toRead;
+    toRead = ezMeshColliderUtils::GetImportPropertyNames();
+    toRead.PushBackRange(ezMeshColliderUtils::GetSimplificationPropertyNames());
+
+    ezVariantDictionary importProperties;
+    ezMeshColliderUtils::ReadMeshProperties(source.m_sMeshAssetPath, toRead, importProperties).IgnoreResult();
+
+    // A matching collider counts wherever it sits, so this finds more than the path check below.
+    out_guid = ezMeshColliderUtils::FindExisting(kind, source.m_sMeshFile, importProperties, source.m_sMeshAssetPath);
+    if (out_guid.IsValid())
+      return ezStatus(EZ_SUCCESS);
+
+    ezStringBuilder sColMeshPath = source.m_sMeshAssetPath;
+    sColMeshPath.ChangeFileExtension(ezMeshColliderUtils::GetExtension(kind));
+
+    if (ezOSFile::ExistsFile(sColMeshPath))
+    {
+      auto pExisting = ezAssetCurator::GetSingleton()->FindSubAsset(sColMeshPath);
+      if (pExisting.isValid())
+      {
+        out_guid = pExisting->m_Data.m_Guid;
+        return ezStatus(EZ_SUCCESS);
+      }
+
+      return ezStatus(ezFmt("'{}' already exists but is not a collision mesh asset.", sColMeshPath));
+    }
+
+    // the mesh file is what the collider is built from
+    if (!importProperties.Contains("MeshFile"_ezsv))
+    {
+      importProperties.Insert("MeshFile"_ezsv, ezVariant(source.m_sMeshFile));
+    }
+
+    // no surface here: a prefab's collider gets whatever the shape component specifies
+    return ezMeshColliderUtils::CreateCollisionMesh(sColMeshPath, kind, importProperties, {}, false, out_guid);
+  }
+} // namespace
+
+ezString ezMeshPrefabCreator::SuggestPrefabPath(const ezMeshPrefabSource& source, bool bAllowExisting)
+{
+  ezStringBuilder sPath = source.m_sMeshAssetPath;
+  sPath.ChangeFileExtension("ezPrefab");
+
+  if (bAllowExisting || !ezOSFile::ExistsFile(sPath))
+    return sPath;
+
+  const ezString sBaseName = ezPathUtils::GetFileName(sPath);
+
+  for (ezUInt32 i = 2; i < 100; ++i)
+  {
+    ezStringBuilder sCandidateName;
+    sCandidateName.SetFormat("{}{}", sBaseName, i);
+
+    ezStringBuilder sCandidate = sPath;
+    sCandidate.ChangeFileName(sCandidateName);
+
+    if (!ezOSFile::ExistsFile(sCandidate))
+      return sCandidate;
+  }
+
+  return sPath;
+}
+
+ezString ezMeshPrefabCreator::MakeDisplayPath(ezStringView sAbsolutePath)
+{
+  ezStringBuilder sPath = sAbsolutePath;
+  ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sPath);
+  return sPath;
+}
+
+ezResult ezMeshPrefabCreator::ResolveDisplayPath(ezStringView sPath, ezStringBuilder& out_sAbsolutePath)
+{
+  out_sAbsolutePath = sPath;
+
+  if (out_sAbsolutePath.IsEmpty())
+    return EZ_FAILURE;
+
+  // the file is about to be created, so it does not exist yet
+  return ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(out_sAbsolutePath, false) ? EZ_SUCCESS : EZ_FAILURE;
+}
+
+ezStatus ezMeshPrefabCreator::CreateMeshPrefab(const ezMeshPrefabSource& source, const ezMeshPrefabOptions& options)
+{
+  // An empty path means "wherever this prefab belongs", which is what creating several at once uses.
+  ezStringBuilder sPrefabPath;
+  if (options.m_sPrefabPath.IsEmpty())
+  {
+    sPrefabPath = SuggestPrefabPath(source);
+  }
+  else if (ResolveDisplayPath(options.m_sPrefabPath, sPrefabPath).Failed())
+  {
+    return ezStatus(ezFmt("'{}' does not name a known data directory.", options.m_sPrefabPath));
+  }
+
+  if (sPrefabPath.IsEmpty())
+    return ezStatus("No prefab path was given.");
+
+  const bool bExists = ezOSFile::ExistsFile(sPrefabPath);
+
+  // CreateDocument reports an already open document through a modal message box, which would hang an
+  // automated caller. Refuse here instead.
+  if (bExists && !options.m_bOverwriteExisting)
+  {
+    return ezStatus(ezFmt("'{}' already exists. Delete it first, or choose a different name.", sPrefabPath));
+  }
+
+  const bool bWantsPhysics = options.m_Physics != ezMeshPrefabPhysics::None;
+  const bool bConvex = options.m_Physics == ezMeshPrefabPhysics::StaticConvexHull || options.m_Physics == ezMeshPrefabPhysics::DynamicConvexHull;
+  const bool bDynamic = options.m_Physics == ezMeshPrefabPhysics::DynamicConvexHull || options.m_Physics == ezMeshPrefabPhysics::DynamicBox;
+  const bool bBoxShape = options.m_Physics == ezMeshPrefabPhysics::StaticBox || options.m_Physics == ezMeshPrefabPhysics::DynamicBox;
+
+  if (bWantsPhysics && !IsPhysicsAvailable())
+    return ezStatus("Physics components are not available. Enable the Jolt plugin in the project settings.");
+
+  if (bBoxShape && !source.m_bHasBounds)
+    return ezStatus("The mesh bounds are unknown. Transform the mesh asset first, or use a collision mesh instead of a box.");
+
+  // first, so that a failure here doesn't leave a half-built prefab behind
+  ezUuid colMeshGuid;
+  if (bWantsPhysics && !bBoxShape)
+  {
+    EZ_SUCCEED_OR_RETURN(GetOrCreateCollisionMesh(source, bConvex, colMeshGuid));
+  }
+
+  // An existing prefab is rewritten in place rather than deleted and created again, so that it keeps
+  // its guid and anything referencing it keeps working.
+  ezDocument* pDoc = bExists ? ezQtEditorApp::GetSingleton()->OpenDocument(sPrefabPath, ezDocumentFlags::None)
+                             : ezQtEditorApp::GetSingleton()->CreateDocument(sPrefabPath, ezDocumentFlags::None);
+
+  if (pDoc == nullptr)
+    return ezStatus(ezFmt("Failed to {} prefab document '{}'.", bExists ? "open" : "create", sPrefabPath));
+
+  ezStatus result = ezStatus(EZ_SUCCESS);
+
+  {
+    auto pHistory = pDoc->GetCommandHistory();
+    pHistory->StartTransaction("Create Prefab from Mesh");
+
+    // in a lambda, so that every failure path below cancels the transaction
+    auto BuildPrefab = [&]() -> ezStatus
+    {
+      // A new prefab is not empty: the document manager clones a template that provides the root
+      // object. A second one would make the prefab invalid.
+      ezUuid rootObject;
+      for (const ezDocumentObject* pChild : pDoc->GetObjectManager()->GetRootObject()->GetChildren())
+      {
+        if (pChild->GetParentProperty() == "Children"_ezsv)
+        {
+          rootObject = pChild->GetGuid();
+          break;
+        }
+      }
+
+      if (!rootObject.IsValid())
+      {
+        ezAddObjectCommand cmd;
+        cmd.m_Index = -1;
+        cmd.SetType("ezGameObject");
+        cmd.m_sParentProperty = "Children";
+        EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(cmd));
+        rootObject = cmd.m_NewObjectGuid;
+      }
+
+      // this exact name is what marks the object as the prefab root
+      EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, rootObject, "Name", "<Prefab-Root>"));
+
+      // a prefab that is being rewritten still holds the components and children it had
+      if (const ezDocumentObject* pRoot = pDoc->GetObjectManager()->GetObject(rootObject))
+      {
+        ezHybridArray<ezUuid, 16> toRemove;
+        for (const ezDocumentObject* pChild : pRoot->GetChildren())
+        {
+          toRemove.PushBack(pChild->GetGuid());
+        }
+
+        for (const ezUuid& guid : toRemove)
+        {
+          ezRemoveObjectCommand remove;
+          remove.m_Object = guid;
+          EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(remove));
+        }
+      }
+
+      {
+        const ezString sRenderType = options.m_sRenderComponentType.IsEmpty() ? ezString(source.GetDefaultRenderComponentType()) : options.m_sRenderComponentType;
+
+        const ezUuid renderComponent = AddComponent(pHistory, rootObject, sRenderType);
+        if (!renderComponent.IsValid())
+          return ezStatus(ezFmt("Failed to add component '{}'.", sRenderType));
+
+        // The two LOD components are separate types with identical properties, one skinned and one not.
+        const bool bLodComponent = (sRenderType == "ezLodMeshComponent") || (sRenderType == "ezLodAnimatedMeshComponent");
+
+        if (bLodComponent)
+        {
+          // LOD 0 is the mesh asset itself, the gathered guids continue from LOD 1
+          ezHybridArray<ezUuid, 8> allLods;
+          allLods.PushBack(source.m_MeshAssetGuid);
+          allLods.PushBackRange(source.m_LodGuids);
+
+          // Screen coverage fractions, not distances: the coverage below which the component switches
+          // away from that LOD. Even a nearby model covers little of the screen, hence the small
+          // values. The last LOD gets 0, so that it is used out to the horizon.
+          const float fThresholds[] = {0.2f, 0.1f, 0.05f, 0.02f};
+
+          for (ezUInt32 i = 0; i < allLods.GetCount(); ++i)
+          {
+            ezAddObjectCommand cmd;
+            cmd.m_Index = (ezInt32)i;
+            cmd.SetType((sRenderType == "ezLodAnimatedMeshComponent") ? "ezLodAnimatedMeshLod" : "ezLodMeshLod");
+            cmd.m_Parent = renderComponent;
+            cmd.m_sParentProperty = "Meshes";
+            EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(cmd));
+
+            // halving past the end of the table keeps the values strictly decreasing, which the
+            // component needs to switch between LODs
+            const bool bLastLod = (i + 1 == allLods.GetCount());
+
+            float fThreshold = 0.0f;
+            if (!bLastLod)
+            {
+              fThreshold = fThresholds[EZ_ARRAY_SIZE(fThresholds) - 1];
+
+              for (ezUInt32 uiExtra = EZ_ARRAY_SIZE(fThresholds); uiExtra <= i; ++uiExtra)
+              {
+                fThreshold *= 0.5f;
+              }
+
+              if (i < EZ_ARRAY_SIZE(fThresholds))
+              {
+                fThreshold = fThresholds[i];
+              }
+            }
+
+            EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, cmd.m_NewObjectGuid, "Mesh", FormatResourceRef(allLods[i])));
+            EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, cmd.m_NewObjectGuid, "Threshold", fThreshold));
+          }
+
+          // the component culls by these rather than deriving them from the meshes
+          if (source.m_bHasBounds)
+          {
+            EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, renderComponent, "BoundsOffset", source.m_vBoundsCenter));
+            EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, renderComponent, "BoundsRadius", ezMath::Clamp(source.m_fBoundsRadius, 0.01f, 100.0f)));
+          }
+        }
+        else
+        {
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, renderComponent, "Mesh", FormatResourceRef(source.m_MeshAssetGuid)));
+        }
+      }
+
+      if (bWantsPhysics)
+      {
+        const ezStringView sActorType = bDynamic ? "ezJoltDynamicActorComponent"_ezsv : "ezJoltStaticActorComponent"_ezsv;
+
+        const ezUuid actorComponent = AddComponent(pHistory, rootObject, sActorType);
+        if (!actorComponent.IsValid())
+          return ezStatus(ezFmt("Failed to add component '{}'.", sActorType));
+
+        EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, actorComponent, "CollisionLayer", options.m_uiCollisionLayer));
+
+        if (!options.m_sSurfaceAsset.IsEmpty())
+        {
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, actorComponent, "Surface", options.m_sSurfaceAsset));
+        }
+
+        if (bBoxShape)
+        {
+          // a child object, so that the box can be offset to the mesh bounds centre
+          ezUuid shapeObject;
+          {
+            ezAddObjectCommand cmd;
+            cmd.m_Index = -1;
+            cmd.SetType("ezGameObject");
+            cmd.m_Parent = rootObject;
+            cmd.m_sParentProperty = "Children";
+            EZ_SUCCEED_OR_RETURN(pHistory->AddCommand(cmd));
+            shapeObject = cmd.m_NewObjectGuid;
+          }
+
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, shapeObject, "Name", "Collider"));
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, shapeObject, "LocalPosition", source.m_vBoundsCenter));
+
+          const ezUuid shapeComponent = AddComponent(pHistory, shapeObject, "ezJoltShapeBoxComponent");
+          if (!shapeComponent.IsValid())
+            return ezStatus("Failed to add component 'ezJoltShapeBoxComponent'.");
+
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, shapeComponent, "HalfExtents", source.m_vBoundsHalfExtents));
+        }
+        else if (bConvex)
+        {
+          const ezUuid shapeComponent = AddComponent(pHistory, rootObject, "ezJoltShapeConvexHullComponent");
+          if (!shapeComponent.IsValid())
+            return ezStatus("Failed to add component 'ezJoltShapeConvexHullComponent'.");
+
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, shapeComponent, "CollisionMesh", FormatResourceRef(colMeshGuid)));
+        }
+        else
+        {
+          // a triangle mesh is referenced by the actor directly, no shape component involved
+          EZ_SUCCEED_OR_RETURN(SetProperty(pHistory, actorComponent, "CollisionMesh", FormatResourceRef(colMeshGuid)));
+        }
+      }
+
+      return ezStatus(EZ_SUCCESS);
+    };
+
+    result = BuildPrefab();
+
+    if (result.Succeeded())
+    {
+      pHistory->FinishTransaction();
+    }
+    else
+    {
+      pHistory->CancelTransaction();
+    }
+  }
+
+  if (result.Failed())
+  {
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    return result;
+  }
+
+  if (pDoc->SaveDocument(true).Failed())
+  {
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+    return ezStatus(ezFmt("Failed to save prefab '{}'.", sPrefabPath));
+  }
+
+  const ezString sPath = pDoc->GetDocumentPath();
+  pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sPath);
+
+  if (options.m_bOpenAfterCreate)
+  {
+    ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sPath);
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}
+
+ezStatus ezMeshPrefabCreator::CreateMeshPrefabs(ezArrayPtr<const ezUuid> meshAssetGuids, const ezMeshPrefabOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped)
+{
+  out_uiCreated = 0;
+  out_uiSkipped = 0;
+
+  const bool bWantsPhysics = options.m_Physics != ezMeshPrefabPhysics::None;
+  const bool bBoxShape = options.m_Physics == ezMeshPrefabPhysics::StaticBox || options.m_Physics == ezMeshPrefabPhysics::DynamicBox;
+
+  if (bWantsPhysics && !IsPhysicsAvailable())
+    return ezStatus("Physics components are not available. Enable the Jolt plugin in the project settings.");
+
+  for (const ezUuid& meshGuid : meshAssetGuids)
+  {
+    ezMeshPrefabSource source;
+    if (GatherMeshPrefabSource(meshGuid, source).Failed())
+    {
+      // not a mesh asset - with a mixed selection this is the normal case, not a problem
+      ++out_uiSkipped;
+      continue;
+    }
+
+    // SuggestPrefabPath() dodges an existing file by appending a number, which is wrong here: a mesh
+    // that already has a prefab is done, it should not get a second, numbered one.
+    ezStringBuilder sPath = source.m_sMeshAssetPath;
+    sPath.ChangeFileExtension("ezPrefab");
+
+    if (!options.m_bOverwriteExisting && ezOSFile::ExistsFile(sPath))
+    {
+      ezLog::Info("Skipping '{}': '{}' already exists.", MakeDisplayPath(source.m_sMeshAssetPath), MakeDisplayPath(sPath));
+      ++out_uiSkipped;
+      continue;
+    }
+
+    if (bBoxShape && !source.m_bHasBounds)
+    {
+      ezLog::Info("Skipping '{}': its bounds are unknown, so no box collider can be sized. Transform the mesh asset first.", MakeDisplayPath(source.m_sMeshAssetPath));
+      ++out_uiSkipped;
+      continue;
+    }
+
+    if (bWantsPhysics && !bBoxShape && source.m_sMeshFile.IsEmpty())
+    {
+      ezLog::Info("Skipping '{}': it has no model file to build a collision mesh from.", MakeDisplayPath(source.m_sMeshAssetPath));
+      ++out_uiSkipped;
+      continue;
+    }
+
+    ezMeshPrefabOptions perMesh = options;
+
+    // the path was just checked to be free, so it is passed on explicitly
+    perMesh.m_sPrefabPath = sPath;
+
+    // a selection can mix animated and static meshes, so the component type is decided per mesh
+    perMesh.m_sRenderComponentType.Clear();
+
+    // "nothing to do here" was handled above, so what is left is a real failure and stops the run
+    EZ_SUCCEED_OR_RETURN(CreateMeshPrefab(source, perMesh));
+
+    ezLog::Success("Created '{}'.", MakeDisplayPath(sPath));
+    ++out_uiCreated;
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Utils/MeshPrefabCreator.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Utils/MeshPrefabCreator.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <EditorPluginScene/EditorPluginSceneDLL.h>
+#include <Foundation/Types/ArrayPtr.h>
+#include <Foundation/Containers/DynamicArray.h>
+#include <Foundation/Math/Vec3.h>
+#include <Foundation/Types/Status.h>
+#include <Foundation/Types/Uuid.h>
+
+/// How a prefab created from a mesh should be set up for physics.
+struct ezMeshPrefabPhysics
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    None,
+
+    /// Generates an ezJoltCollisionMeshAsset next to the mesh asset, unless a suitable one exists.
+    /// Triangle meshes cannot be used for dynamic actors.
+    StaticTriangleMesh,
+
+    /// Fills in concave parts of the shape.
+    StaticConvexHull,
+
+    /// Sized from the mesh bounds, so it needs no additional asset but requires ezMeshPrefabSource::m_bHasBounds.
+    StaticBox,
+
+    /// Generates an ezJoltConvexCollisionMeshAsset. Dynamic actors require a convex shape.
+    DynamicConvexHull,
+
+    DynamicBox,
+
+    Default = None
+  };
+};
+
+/// \see ezMeshPrefabCreator::CreateMeshPrefab()
+struct ezMeshPrefabOptions
+{
+  /// Where to write the prefab. Absolute, or relative to the parent of a data directory
+  /// ("Testing Chambers/Objects/Barrel.ezPrefab"). Empty means the suggested path, which is what
+  /// creating prefabs for several meshes at once uses.
+  /// \see ezMeshPrefabCreator::SuggestPrefabPath()
+  ezString m_sPrefabPath;
+
+  /// RTTI name of the component that renders the mesh. Empty falls back to
+  /// ezMeshPrefabSource::GetDefaultRenderComponentType().
+  ezString m_sRenderComponentType;
+
+  ezEnum<ezMeshPrefabPhysics> m_Physics;
+  ezUInt8 m_uiCollisionLayer = 0;
+  ezString m_sSurfaceAsset;
+
+  /// Overwrites a prefab that already exists instead of refusing.
+  ///
+  /// The contents are rewritten in place, so the prefab keeps its guid and references to it still
+  /// resolve. Changes made to it by hand are lost.
+  bool m_bOverwriteExisting = false;
+
+  bool m_bOpenAfterCreate = true;
+};
+
+/// What a mesh asset offers for prefab creation. Filled by GatherMeshPrefabSource().
+struct EZ_EDITORPLUGINSCENE_DLL ezMeshPrefabSource
+{
+  ezUuid m_MeshAssetGuid;
+  ezString m_sMeshAssetPath;
+
+  /// The mesh asset's "MeshFile" property. Empty if it could not be read, in which case no collision
+  /// mesh asset can be generated.
+  ezString m_sMeshFile;
+
+  /// LOD-1 and up, in ascending order. Does not include the mesh asset itself, which is LOD 0.
+  ezDynamicArray<ezUuid> m_LodGuids;
+
+  bool m_bAnimated = false;
+
+  /// An existing collision mesh asset built from the same source file, if there is one.
+  ezUuid m_ExistingTriangleColMesh;
+  ezUuid m_ExistingConvexColMesh;
+
+  /// False when the asset was never transformed, in which case the box collider modes can't be used.
+  bool m_bHasBounds = false;
+  ezVec3 m_vBoundsCenter = ezVec3::MakeZero();
+  ezVec3 m_vBoundsHalfExtents = ezVec3(0.5f);
+  float m_fBoundsRadius = 1.0f;
+
+  /// ezAnimatedMeshComponent for animated meshes, ezLodMeshComponent when LODs were found,
+  /// otherwise ezMeshComponent.
+  ezStringView GetDefaultRenderComponentType() const;
+
+  /// Derived from an existing collision mesh asset built from the same source. None when there is
+  /// none, so that generating a collider is a deliberate choice.
+  ezEnum<ezMeshPrefabPhysics> GetDefaultPhysics() const;
+};
+
+/// Creates prefab documents that display a single mesh.
+///
+/// Components are added by RTTI name, so that this does not depend on the mesh or physics plugins.
+/// Consequently the physics options only work while the Jolt plugin is loaded.
+class EZ_EDITORPLUGINSCENE_DLL ezMeshPrefabCreator
+{
+public:
+  /// Fails if the guid does not belong to a mesh asset. Missing bounds are not a failure, they are
+  /// reported through ezMeshPrefabSource::m_bHasBounds.
+  ///
+  /// Opens the mesh asset document to read its source file, if it is not open already.
+  static ezResult GatherMeshPrefabSource(const ezUuid& meshAssetGuid, ezMeshPrefabSource& out_source);
+
+  /// Creates and saves the prefab document, plus a collision mesh asset if the physics option needs one.
+  ///
+  /// Fails if a file already exists at the target path, unless
+  /// ezMeshPrefabOptions::m_bOverwriteExisting is set.
+  static ezStatus CreateMeshPrefab(const ezMeshPrefabSource& source, const ezMeshPrefabOptions& options);
+
+  /// Creates a prefab for each of the given mesh assets, each at its suggested path.
+  ///
+  /// Meshes that already have a prefab at that path, and ones the chosen options cannot be applied
+  /// to, are skipped with a log message rather than failing the whole run. Only an outright error,
+  /// such as a document that cannot be written, is reported back.
+  ///
+  /// The render component type is decided per mesh, so that a selection can mix animated and static
+  /// meshes; ezMeshPrefabOptions::m_sRenderComponentType is ignored here.
+  static ezStatus CreateMeshPrefabs(ezArrayPtr<const ezUuid> meshAssetGuids, const ezMeshPrefabOptions& options, ezUInt32& out_uiCreated, ezUInt32& out_uiSkipped);
+
+  /// The default absolute path for a mesh asset's prefab, next to it.
+  ///
+  /// Appends a number if that file is already taken, unless bAllowExisting is set.
+  static ezString SuggestPrefabPath(const ezMeshPrefabSource& source, bool bAllowExisting = false);
+
+  /// Turns an absolute path into one relative to the parent of its data directory, for display.
+  /// Returns the input unchanged if it is not inside a data directory.
+  static ezString MakeDisplayPath(ezStringView sAbsolutePath);
+
+  /// Resolves what MakeDisplayPath() produced, or any absolute path, back to an absolute path.
+  /// Fails if the path names no known data directory.
+  static ezResult ResolveDisplayPath(ezStringView sPath, ezStringBuilder& out_sAbsolutePath);
+
+  /// Whether the Jolt plugin is loaded, i.e. whether the physics options can be used at all.
+  static bool IsPhysicsAvailable();
+
+  /// Whether the given guid refers to a mesh or animated mesh asset.
+  static bool IsMeshAsset(const ezUuid& assetGuid);
+};

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Utils/MeshPrefabCreator.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Utils/MeshPrefabCreator.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <EditorPluginScene/EditorPluginSceneDLL.h>
-#include <Foundation/Types/ArrayPtr.h>
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Math/Vec3.h>
+#include <Foundation/Types/ArrayPtr.h>
 #include <Foundation/Types/Status.h>
 #include <Foundation/Types/Uuid.h>
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
@@ -1173,7 +1173,12 @@ void ezStringBuilder::ReadAll(ezStreamReader& inout_stream)
 
   Bytes.PushBack('\0');
 
-  *this = (const char*)&Bytes[0];
+  // A BOM is an encoding marker, not part of the text. Many editors write one silently, so it
+  // would otherwise end up in the first token of whatever parses the result.
+  const char* szData = (const char*)&Bytes[0];
+  ezUnicodeUtils::SkipUtf8Bom(szData);
+
+  *this = szData;
 }
 
 void ezStringBuilder::Trim(const char* szTrimChars)

--- a/Code/Engine/Mcp/McpToolRegistry.cpp
+++ b/Code/Engine/Mcp/McpToolRegistry.cpp
@@ -49,6 +49,36 @@ void ezMcpToolRegistry::UpdateProviders()
     ezRTTI::ForEachOptions::ExcludeNotConcrete);
 }
 
+void ezMcpToolRegistry::RemoveProvider(const ezRTTI* pProviderType)
+{
+  for (ezUInt32 i = s_Providers.GetCount(); i > 0; --i)
+  {
+    ezMcpToolProvider* pProvider = s_Providers[i - 1];
+
+    // GetDynamicRTTI() reads the vtable, so this must run before the module is actually unmapped
+    const ezRTTI* pRtti = pProvider->GetDynamicRTTI();
+    if (pRtti != pProviderType)
+      continue;
+
+    for (ezUInt32 uiTool = s_Tools.GetCount(); uiTool > 0; --uiTool)
+    {
+      const ezString& sToolName = s_Tools[uiTool - 1].m_sName;
+
+      if (s_ToolLookup.GetValueOrDefault(sToolName, nullptr) == pProvider)
+      {
+        s_ToolLookup.Remove(sToolName);
+        s_Tools.RemoveAtAndCopy(uiTool - 1);
+      }
+    }
+
+    pProvider->OnDeactivate();
+    pRtti->GetAllocator()->Deallocate(pProvider);
+
+    s_Providers.RemoveAtAndCopy(i - 1);
+    s_KnownTypes.Remove(pRtti);
+  }
+}
+
 void ezMcpToolRegistry::Clear()
 {
   for (ezMcpToolProvider* pProvider : s_Providers)

--- a/Code/Engine/Mcp/McpToolRegistry.h
+++ b/Code/Engine/Mcp/McpToolRegistry.h
@@ -36,6 +36,16 @@ public:
   /// \brief Destroys all providers. Called when the plugin is unloaded.
   static void Clear();
 
+  /// \brief Destroys the provider of the given type, along with its tools.
+  ///
+  /// A provider may live in a different plugin than the registry, and plugins are not unloaded in any
+  /// particular order. Once its plugin is gone, the provider's vtable and RTTI allocator point into an
+  /// unmapped module, so a plugin that declares a provider has to call this from its unload function,
+  /// while its own code is still mapped. Does nothing if no such provider exists, so it is safe to call
+  /// when the registry was never filled. UpdateProviders() instantiates the type again if the plugin is
+  /// loaded once more.
+  static void RemoveProvider(const ezRTTI* pProviderType);
+
   /// \brief All tools of all providers, in registration order.
   static const ezDynamicArray<ezMcpToolDesc>& GetTools() { return s_Tools; }
 

--- a/Code/Tools/Libs/GuiFoundation/Action/Action.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/Action.h
@@ -98,7 +98,7 @@ struct EZ_GUIFOUNDATION_DLL ezActionDescriptor
   ezString m_sActionName;   ///< Unique within category path, shown in key configuration dialog
   ezString m_sCategoryPath; ///< Category in key configuration dialog, e.g. "Tree View" or "File"
 
-  ezString m_sShortcut;        ///< The currently configured shortcut. May be modified by the user, empty means no shortcut.
+  ezString m_sShortcut;     ///< The currently configured shortcut. May be modified by the user, empty means no shortcut.
   ezString m_sDefaultShortcut; ///< The shortcut that the action was registered with, used to reset m_sShortcut.
 
   /// Creates an action instance for the given context and adds it to GetCreatedActions().

--- a/Code/Tools/Libs/GuiFoundation/Action/Action.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/Action.h
@@ -17,10 +17,13 @@ class ezAction;
 struct ezActionContext;
 
 using ezActionId = ezGenericId<24, 8>;
+
+/// Creates an instance of an action for the given context. See ezActionDescriptor::CreateAction().
 using CreateActionFunc = ezAction* (*)(const ezActionContext&);
+/// Destroys an instance created by a CreateActionFunc. If none is given, the action is deleted with the default allocator.
 using DeleteActionFunc = void (*)(ezAction*);
 
-/// \brief Handle for a ezAction.
+/// \brief Handle for a ezActionDescriptor.
 ///
 /// ezAction can be invalidated at runtime so don't store them.
 class EZ_GUIFOUNDATION_DLL ezActionDescriptorHandle
@@ -35,46 +38,52 @@ public:
   const ezActionDescriptor* GetDescriptor() const;
 };
 
-///
+/// Determines the range in which an action's shortcut is active and which contexts it needs.
 struct ezActionScope
 {
   enum Enum
   {
-    Global,
-    Document,
-    Window,
+    Global,   ///< Available application wide, independent of any document or window.
+    Document, ///< Requires ezActionContext::m_pDocument. Its shortcut is only active while that document's window has focus.
+    Window,   ///< Requires ezActionContext::m_pWindow. Its shortcut is only active within that window.
     Default = Global
   };
   using StorageType = ezUInt8;
 };
 
-///
+/// What kind of UI element an action maps to when a menu, menu bar or toolbar is built from an action map.
 struct ezActionType
 {
   enum Enum
   {
-    Action,
-    Category,
-    Menu,
-    ActionAndMenu,
+    Action,        ///< A single clickable item (menu entry, toolbar button).
+    Category,      ///< Groups the items mapped below it, displayed as a separator or a separate toolbar section.
+    Menu,          ///< A sub-menu that only holds other items, it cannot be executed itself.
+    ActionAndMenu, ///< Can both be executed and opened as a sub-menu, e.g. a toolbar button with an attached drop-down.
     Default = Action
   };
   using StorageType = ezUInt8;
 };
 
+/// The environment that an action instance operates on.
 ///
+/// Which members have to be filled out depends on the ezActionScope of the action.
 struct EZ_GUIFOUNDATION_DLL ezActionContext
 {
   ezActionContext() = default;
   ezActionContext(ezDocument* pDoc) { m_pDocument = pDoc; }
 
-  ezDocument* m_pDocument = nullptr;
-  ezString m_sMapping;
-  QWidget* m_pWindow = nullptr;
+  ezDocument* m_pDocument = nullptr; ///< The document that the action shall affect. Required for ezActionScope::Document.
+  ezString m_sMapping;               ///< Name of the ezActionMap from which the UI element was built.
+  QWidget* m_pWindow = nullptr;      ///< The widget that the action belongs to. Required for ezActionScope::Window.
 };
 
 
+/// Describes a type of action, from which any number of action instances can be created.
 ///
+/// Descriptors are registered once (see ezActionManager and the EZ_REGISTER_ACTION macros) and hold everything
+/// that is shared between all instances, such as the name and the configured shortcut. Refer to them through
+/// ezActionDescriptorHandle rather than by pointer.
 struct EZ_GUIFOUNDATION_DLL ezActionDescriptor
 {
   ezActionDescriptor() = default;
@@ -82,19 +91,26 @@ struct EZ_GUIFOUNDATION_DLL ezActionDescriptor
   ezActionDescriptor(ezActionType::Enum type, ezActionScope::Enum scope, const char* szName, const char* szCategoryPath, const char* szShortcut,
     CreateActionFunc createAction, DeleteActionFunc deleteAction = nullptr);
 
-  ezActionDescriptorHandle m_Handle;
+  ezActionDescriptorHandle m_Handle; ///< Set by ezActionManager during registration.
   ezEnum<ezActionType> m_Type;
 
   ezEnum<ezActionScope> m_Scope;
   ezString m_sActionName;   ///< Unique within category path, shown in key configuration dialog
   ezString m_sCategoryPath; ///< Category in key configuration dialog, e.g. "Tree View" or "File"
 
-  ezString m_sShortcut;
-  ezString m_sDefaultShortcut;
+  ezString m_sShortcut;        ///< The currently configured shortcut. May be modified by the user, empty means no shortcut.
+  ezString m_sDefaultShortcut; ///< The shortcut that the action was registered with, used to reset m_sShortcut.
 
+  /// Creates an action instance for the given context and adds it to GetCreatedActions().
+  ///
+  /// The result must be destroyed through DeleteAction(), not deleted directly. Usually only called by the
+  /// view classes that build menus and toolbars from an action map.
   ezAction* CreateAction(const ezActionContext& context) const;
+
+  /// Destroys an instance that was returned by CreateAction().
   void DeleteAction(ezAction* pAction) const;
 
+  /// Makes all existing instances broadcast their status update event, e.g. after the shortcut was reconfigured.
   void UpdateExistingActions();
 
   /// The action instances that currently exist for this descriptor.
@@ -114,7 +130,10 @@ private:
 
 
 
+/// Base class for all actions, meaning commands that can be triggered through menus, toolbars or shortcuts.
 ///
+/// An instance is always tied to one ezActionContext and is created through its ezActionDescriptor.
+/// Derived classes are typically not instantiated directly, see ezButtonAction, ezCategoryAction, ezMenuAction and others.
 class EZ_GUIFOUNDATION_DLL ezAction : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezAction, ezReflectedClass);
@@ -122,9 +141,23 @@ class EZ_GUIFOUNDATION_DLL ezAction : public ezReflectedClass
 
 public:
   ezAction(const ezActionContext& context) { m_Context = context; }
+
+  /// Performs whatever the action does.
+  ///
+  /// The meaning of the value depends on the concrete action, for buttons it is typically the new checked state,
+  /// for others it is an invalid variant.
   virtual void Execute(const ezVariant& value) = 0;
 
+  /// Recomputes the action's enabled/visible state.
+  ///
+  /// Action proxies are cached and reused, so an action whose state depends on something outside its
+  /// context (such as the asset browser selection) cannot compute it once in its constructor.
+  /// Callers that build a menu from such actions have to call this before showing it.
+  virtual void RefreshState() {}
+
+  /// Broadcasts m_StatusUpdateEvent, so that the UI element displaying this action updates itself.
   void TriggerUpdate();
+
   const ezActionContext& GetContext() const { return m_Context; }
   ezActionDescriptorHandle GetDescriptorHandle() { return m_hDescriptorHandle; }
 

--- a/Code/UnitTests/EditorTest/CMakeLists.txt
+++ b/Code/UnitTests/EditorTest/CMakeLists.txt
@@ -10,6 +10,8 @@ ez_create_target(APPLICATION ${PROJECT_NAME})
 ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets Network)
 
 target_include_directories (${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../EditorPlugins/Scene")
+target_include_directories (${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../EditorPlugins/Jolt")
+target_include_directories (${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../EditorPlugins/Assets")
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
@@ -17,6 +19,8 @@ target_link_libraries(${PROJECT_NAME}
   EditorFramework
   EditorEngineProcessFramework
   EditorPluginScene
+  EditorPluginJolt
+  EditorPluginAssets
 )
 
 add_dependencies(${PROJECT_NAME}

--- a/Code/UnitTests/EditorTest/MeshCollider/MeshColliderTest.cpp
+++ b/Code/UnitTests/EditorTest/MeshCollider/MeshColliderTest.cpp
@@ -1,0 +1,790 @@
+#include <EditorTest/EditorTestPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorPluginJolt/Utils/MeshColliderCreator.h>
+#include <EditorTest/MeshCollider/MeshColliderTest.h>
+#include <Foundation/IO/OSFile.h>
+#include <RendererCore/Declarations.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+static ezEditorMeshColliderTest s_EditorMeshColliderTest;
+
+const char* ezEditorMeshColliderTest::GetTestName() const
+{
+  return "Mesh Collider Tests";
+}
+
+void ezEditorMeshColliderTest::SetupSubTests()
+{
+  AddSubTest("Triangle Mesh", SubTests::ST_TriangleMesh);
+  AddSubTest("Convex Mesh", SubTests::ST_ConvexMesh);
+  AddSubTest("Transferred Settings", SubTests::ST_TransferredSettings);
+  AddSubTest("Existing Collider", SubTests::ST_ExistingCollider);
+  AddSubTest("Primitive Mesh", SubTests::ST_PrimitiveMesh);
+  AddSubTest("Keeps Open Documents", SubTests::ST_KeepsOpenDocuments);
+  AddSubTest("Simplification Settings", SubTests::ST_SimplificationSettings);
+  AddSubTest("Data Dir Relative Path", SubTests::ST_DataDirRelativePath);
+  AddSubTest("Multiple Meshes", SubTests::ST_MultipleMeshes);
+  AddSubTest("Shared Source File", SubTests::ST_SharedSourceFile);
+  AddSubTest("Surface", SubTests::ST_Surface);
+}
+
+ezResult ezEditorMeshColliderTest::InitializeTest()
+{
+  if (SUPER::InitializeTest().Failed())
+    return EZ_FAILURE;
+
+  if (SUPER::OpenProject("Data/UnitTests/EditorTest").Failed())
+    return EZ_FAILURE;
+
+  // the project has to be settled first, or the curator keeps rehashing while the sub-tests
+  // create their assets
+  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually); res.Failed())
+  {
+    ezLog::Error("Asset transform failed: {}", res.GetMessageString());
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezEditorMeshColliderTest::DeInitializeTest()
+{
+  if (SUPER::DeInitializeTest().Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+ezTestAppRun ezEditorMeshColliderTest::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+{
+  switch (iIdentifier)
+  {
+    case SubTests::ST_TriangleMesh:
+      TriangleMesh();
+      break;
+    case SubTests::ST_ConvexMesh:
+      ConvexMesh();
+      break;
+    case SubTests::ST_TransferredSettings:
+      TransferredSettings();
+      break;
+    case SubTests::ST_ExistingCollider:
+      ExistingCollider();
+      break;
+    case SubTests::ST_PrimitiveMesh:
+      PrimitiveMesh();
+      break;
+    case SubTests::ST_KeepsOpenDocuments:
+      KeepsOpenDocuments();
+      break;
+    case SubTests::ST_SimplificationSettings:
+      SimplificationSettings();
+      break;
+    case SubTests::ST_DataDirRelativePath:
+      DataDirRelativePath();
+      break;
+    case SubTests::ST_MultipleMeshes:
+      MultipleMeshes();
+      break;
+    case SubTests::ST_Surface:
+      Surface();
+      break;
+    case SubTests::ST_SharedSourceFile:
+      SharedSourceFile();
+      break;
+  }
+
+  return ezTestAppRun::Quit;
+}
+
+ezString ezEditorMeshColliderTest::MakePrivateSourceMesh(const char* szName)
+{
+  ezStringBuilder sSrc = m_sProjectPath;
+  sSrc.AppendPath("Meshes/Cube.obj");
+
+  ezStringBuilder sRelative;
+  sRelative.SetFormat("Meshes/{}.obj", szName);
+
+  ezStringBuilder sDst = m_sProjectPath;
+  sDst.AppendPath(sRelative);
+
+  if (ezOSFile::CopyFile(sSrc, sDst).Failed())
+    return {};
+
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sDst);
+  return sRelative;
+}
+
+ezUuid ezEditorMeshColliderTest::CreateMeshAsset(const char* szRelativePath, const char* szSourceFile, const ezVariantDictionary* pExtraProperties)
+{
+  ezStringBuilder sPath = m_sProjectPath;
+  sPath.AppendPath(szRelativePath);
+
+  ezDocument* pDoc = m_pApplication->m_pEditorApp->CreateDocument(sPath, ezDocumentFlags::None);
+  if (pDoc == nullptr)
+    return {};
+
+  {
+    ezDocumentObject* pProps = pDoc->GetObjectManager()->GetRootObject()->GetChildren()[0];
+    ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
+
+    pAcc->StartTransaction("Init");
+    pAcc->SetValueByName(pProps, "MeshFile", szSourceFile).AssertSuccess();
+
+    if (pExtraProperties != nullptr)
+    {
+      for (auto it : *pExtraProperties)
+      {
+        pAcc->SetValueByName(pProps, it.Key(), it.Value()).AssertSuccess();
+      }
+    }
+
+    pAcc->FinishTransaction();
+  }
+
+  pDoc->SaveDocument(true).AssertSuccess();
+
+  const ezUuid guid = pDoc->GetGuid();
+  pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  return guid;
+}
+
+ezVariant ezEditorMeshColliderTest::ReadColliderProperty(ezStringView sAbsPath, ezStringView sProperty)
+{
+  ezDocument* pDoc = m_pApplication->m_pEditorApp->OpenDocument(sAbsPath, ezDocumentFlags::None);
+  if (pDoc == nullptr)
+    return {};
+
+  EZ_SCOPE_EXIT(pDoc->GetDocumentManager()->CloseDocument(pDoc));
+
+  const auto& children = pDoc->GetObjectManager()->GetRootObject()->GetChildren();
+  if (children.GetCount() != 1)
+    return {};
+
+  return children[0]->GetTypeAccessor().GetValue(sProperty);
+}
+
+void ezEditorMeshColliderTest::TriangleMesh()
+{
+  // Colliders are matched to a mesh by source file, so every sub-test needs its own copy of the
+  // source, or it finds the colliders that the other sub-tests generated.
+  const ezString sSource = MakePrivateSourceMesh("ColliderTriangle");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Triangle.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_BOOL(!source.m_bAnimated);
+  EZ_TEST_BOOL(!source.m_bIsPrimitive);
+  EZ_TEST_STRING(source.m_sMeshFile, sSource);
+  EZ_TEST_BOOL(!source.GetExisting(ezMeshColliderKind::TriangleMesh).IsValid());
+
+  const ezString sSuggested = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+  EZ_TEST_STRING(ezPathUtils::GetFileExtension(sSuggested), "ezJoltCollisionMeshAsset");
+
+  ezMeshColliderOptions options;
+  options.m_sColliderPath = sSuggested;
+  options.m_Kind = ezMeshColliderKind::TriangleMesh;
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+    return;
+
+  if (!EZ_TEST_BOOL(ezOSFile::ExistsFile(sSuggested)))
+    return;
+
+  // the source file is what makes the collider describe the same geometry as the mesh
+  EZ_TEST_STRING(ReadColliderProperty(sSuggested, "MeshFile").ConvertTo<ezString>(), sSource);
+
+  // a triangle mesh document must not be flagged as convex, or it builds the wrong shape
+  EZ_TEST_BOOL(ReadColliderProperty(sSuggested, "IsConvexMesh").ConvertTo<bool>() == false);
+}
+
+void ezEditorMeshColliderTest::ConvexMesh()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderConvex");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Convex.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  const ezString sSuggested = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::ConvexHull);
+  EZ_TEST_STRING(ezPathUtils::GetFileExtension(sSuggested), "ezJoltConvexCollisionMeshAsset");
+
+  ezMeshColliderOptions options;
+  options.m_sColliderPath = sSuggested;
+  options.m_Kind = ezMeshColliderKind::ConvexHull;
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+    return;
+
+  if (!EZ_TEST_BOOL(ezOSFile::ExistsFile(sSuggested)))
+    return;
+
+  EZ_TEST_STRING(ReadColliderProperty(sSuggested, "MeshFile").ConvertTo<ezString>(), sSource);
+
+  // the convex flag comes from the document type, not from the transferred properties
+  EZ_TEST_BOOL(ReadColliderProperty(sSuggested, "IsConvexMesh").ConvertTo<bool>() == true);
+}
+
+void ezEditorMeshColliderTest::TransferredSettings()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderSettings");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  // every value differs from the collision mesh asset's default, so a transferred value cannot be
+  // mistaken for a coincidental match
+  const ezVec3 vOffset(1.0f, -2.0f, 3.5f);
+
+  ezVariantDictionary extras;
+  extras.Insert("MeshIncludeTags", "Collide");
+  extras.Insert("MeshExcludeTags", "NoCollide;UCX_");
+  extras.Insert("ImportTransform", (ezInt64)ezMeshImportTransform::Custom);
+  extras.Insert("RightDir", (ezInt64)ezBasisAxis::PositiveZ);
+  extras.Insert("UpDir", (ezInt64)ezBasisAxis::NegativeY);
+  extras.Insert("FlipForwardDir", true);
+  extras.Insert("PositionOffset", vOffset);
+  extras.Insert("UniformScaling", 5.0f);
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Settings.ezMeshAsset", sSource, &extras);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  const ezString sSuggested = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+
+  ezMeshColliderOptions options;
+  options.m_sColliderPath = sSuggested;
+  options.m_Kind = ezMeshColliderKind::TriangleMesh;
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+    return;
+
+  if (!EZ_TEST_BOOL(ezOSFile::ExistsFile(sSuggested)))
+    return;
+
+  // the collider has to describe the same geometry, in the same place, at the same size, as the mesh
+  EZ_TEST_STRING(ReadColliderProperty(sSuggested, "MeshFile").ConvertTo<ezString>(), sSource);
+  EZ_TEST_STRING(ReadColliderProperty(sSuggested, "MeshIncludeTags").ConvertTo<ezString>(), "Collide");
+  EZ_TEST_STRING(ReadColliderProperty(sSuggested, "MeshExcludeTags").ConvertTo<ezString>(), "NoCollide;UCX_");
+  EZ_TEST_INT(ReadColliderProperty(sSuggested, "ImportTransform").ConvertTo<ezInt64>(), (ezInt64)ezMeshImportTransform::Custom);
+  EZ_TEST_INT(ReadColliderProperty(sSuggested, "RightDir").ConvertTo<ezInt64>(), (ezInt64)ezBasisAxis::PositiveZ);
+  EZ_TEST_INT(ReadColliderProperty(sSuggested, "UpDir").ConvertTo<ezInt64>(), (ezInt64)ezBasisAxis::NegativeY);
+  EZ_TEST_BOOL(ReadColliderProperty(sSuggested, "FlipForwardDir").ConvertTo<bool>() == true);
+  EZ_TEST_VEC3(ReadColliderProperty(sSuggested, "PositionOffset").ConvertTo<ezVec3>(), vOffset, 0.0001f);
+  EZ_TEST_FLOAT(ReadColliderProperty(sSuggested, "UniformScaling").ConvertTo<float>(), 5.0f, 0.0001f);
+}
+
+void ezEditorMeshColliderTest::ExistingCollider()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderExisting");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Existing.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezString sColliderPath;
+
+  {
+    ezMeshColliderSource source;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(!source.GetExisting(ezMeshColliderKind::TriangleMesh).IsValid());
+
+    sColliderPath = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sColliderPath;
+    options.m_Kind = ezMeshColliderKind::TriangleMesh;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+
+    const ezStatus second = ezMeshColliderCreator::CreateMeshCollider(source, options);
+    EZ_TEST_BOOL_MSG(second.Failed(), "Creating a collider over an existing file should fail, not overwrite it.");
+    EZ_TEST_BOOL(!second.GetMessageString().IsEmpty());
+  }
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // gathering again has to report the collider that now exists, so the dialog can point it out
+  {
+    ezMeshColliderSource source;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(source.GetExisting(ezMeshColliderKind::TriangleMesh).IsValid());
+    EZ_TEST_BOOL_MSG(!source.GetExisting(ezMeshColliderKind::ConvexHull).IsValid(), "Only a triangle mesh was created.");
+  }
+
+  // and the suggested path must move on, rather than proposing a name that cannot be used
+  {
+    ezMeshColliderSource source;
+    ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).AssertSuccess();
+
+    const ezString sNext = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+    EZ_TEST_BOOL(sNext != sColliderPath);
+    EZ_TEST_BOOL(!ezOSFile::ExistsFile(sNext));
+  }
+}
+
+void ezEditorMeshColliderTest::PrimitiveMesh()
+{
+  // A procedural primitive has no model file, so there is nothing to build a collision mesh from.
+  // ezMeshPrimitive lives in EditorPluginAssets, which this test does not link. 6 is Sphere.
+  ezVariantDictionary extras;
+  extras.Insert("PrimitiveType", (ezInt64)6);
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Primitive.ezMeshAsset", "", &extras);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_BOOL_MSG(source.m_bIsPrimitive, "A non-File primitive type has to be recognized.");
+  EZ_TEST_BOOL(source.m_sMeshFile.IsEmpty());
+
+  ezStringBuilder sColliderPath = m_sProjectPath;
+  sColliderPath.AppendPath("MeshCollider/Primitive.ezJoltCollisionMeshAsset");
+
+  ezMeshColliderOptions options;
+  options.m_sColliderPath = sColliderPath;
+  options.m_Kind = ezMeshColliderKind::TriangleMesh;
+  options.m_bOpenAfterCreate = false;
+
+  const ezStatus res = ezMeshColliderCreator::CreateMeshCollider(source, options);
+  EZ_TEST_BOOL_MSG(res.Failed(), "A primitive mesh has no source file, so this must fail.");
+  EZ_TEST_BOOL_MSG(!ezOSFile::ExistsFile(sColliderPath), "A failed creation must not leave a document behind.");
+}
+
+void ezEditorMeshColliderTest::KeepsOpenDocuments()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderOpen");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshColliderOpen/Open.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezStringBuilder sMeshPath = m_sProjectPath;
+  sMeshPath.AppendPath("MeshColliderOpen/Open.ezMeshAsset");
+
+  // Opened without a window, which is what the curator does while transforming. Reading properties
+  // out of it must not close it.
+  ezDocument* pOpened = m_pApplication->m_pEditorApp->OpenDocument(sMeshPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pOpened != nullptr))
+    return;
+
+  ezMeshColliderSource source;
+  EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded());
+  EZ_TEST_STRING(source.m_sMeshFile, sSource);
+
+  const ezDocument* pStillOpen = ezDocumentManager::GetDocumentByGuid(meshGuid);
+  EZ_TEST_BOOL_MSG(pStillOpen == pOpened, "Gathering must not close a document that was already open.");
+
+  if (pStillOpen == pOpened)
+  {
+    pOpened->GetDocumentManager()->CloseDocument(pOpened);
+  }
+}
+
+void ezEditorMeshColliderTest::SimplificationSettings()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderSimplify");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  // Again every value differs from the collision mesh asset's default. MaxSimplificationError
+  // defaults to 5 on the mesh asset but to 20 on the collision mesh asset.
+  ezVariantDictionary extras;
+  extras.Insert("SimplifyMesh", true);
+  extras.Insert("MeshSimplification", (ezInt64)33);
+  extras.Insert("MaxSimplificationError", (ezInt64)7);
+  extras.Insert("NormalWeight", 0.75f);
+  extras.Insert("AggressiveSimplification", true);
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Simplify.ezMeshAsset", sSource, &extras);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  // A triangle mesh keeps the source geometry, so simplifying it changes the collision shape.
+  {
+    const ezString sPath = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sPath;
+    options.m_Kind = ezMeshColliderKind::TriangleMesh;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(ReadColliderProperty(sPath, "SimplifyMesh").ConvertTo<bool>() == true);
+    EZ_TEST_INT(ReadColliderProperty(sPath, "MeshSimplification").ConvertTo<ezInt64>(), 33);
+    EZ_TEST_INT(ReadColliderProperty(sPath, "MaxSimplificationError").ConvertTo<ezInt64>(), 7);
+    EZ_TEST_FLOAT(ReadColliderProperty(sPath, "NormalWeight").ConvertTo<float>(), 0.75f, 0.0001f);
+    EZ_TEST_BOOL(ReadColliderProperty(sPath, "AggressiveSimplification").ConvertTo<bool>() == true);
+  }
+
+  // A convex hull is built from the hull of the vertices, so simplifying the source first changes
+  // nothing about it. The collision mesh asset hides these options for a convex mesh.
+  {
+    const ezString sPath = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::ConvexHull);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sPath;
+    options.m_Kind = ezMeshColliderKind::ConvexHull;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL_MSG(ReadColliderProperty(sPath, "SimplifyMesh").ConvertTo<bool>() == false, "A convex hull must not take over the simplification settings.");
+    EZ_TEST_INT(ReadColliderProperty(sPath, "MeshSimplification").ConvertTo<ezInt64>(), 50);
+
+    // but the geometry settings still have to be there, this is not a general opt out
+    EZ_TEST_STRING(ReadColliderProperty(sPath, "MeshFile").ConvertTo<ezString>(), sSource);
+  }
+}
+
+void ezEditorMeshColliderTest::DataDirRelativePath()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderRelPath");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/RelPath.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  const ezString sAbsolute = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+  const ezString sDisplay = ezMeshColliderCreator::MakeDisplayPath(sAbsolute);
+
+  // What the dialog shows has to be the short form, not the full path off the drive root.
+  EZ_TEST_BOOL_MSG(!ezPathUtils::IsAbsolutePath(sDisplay), "The display path must be relative.");
+  EZ_TEST_BOOL_MSG(sDisplay.FindSubString("MeshCollider/RelPath") != nullptr, "The display path must still name the file.");
+
+  // and it has to round trip, or the dialog cannot hand it back to the creator
+  {
+    ezStringBuilder sResolved;
+    EZ_TEST_BOOL(ezMeshColliderCreator::ResolveDisplayPath(sDisplay, sResolved).Succeeded());
+    EZ_TEST_STRING(sResolved, sAbsolute);
+  }
+
+  // an absolute path stays valid input, which is what the file browse button produces
+  {
+    ezStringBuilder sResolved;
+    EZ_TEST_BOOL(ezMeshColliderCreator::ResolveDisplayPath(sAbsolute, sResolved).Succeeded());
+    EZ_TEST_STRING(sResolved, sAbsolute);
+  }
+
+  // a path that names no data directory has to be refused rather than written somewhere unexpected
+  {
+    ezStringBuilder sResolved;
+    EZ_TEST_BOOL(ezMeshColliderCreator::ResolveDisplayPath("NoSuchDataDir/Thing.ezJoltCollisionMeshAsset", sResolved).Failed());
+    EZ_TEST_BOOL(ezMeshColliderCreator::ResolveDisplayPath("", sResolved).Failed());
+  }
+
+  // and creating from the relative form has to put the file exactly where the absolute form would
+  {
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sDisplay;
+    options.m_Kind = ezMeshColliderKind::TriangleMesh;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(ezOSFile::ExistsFile(sAbsolute));
+  }
+
+  // an unresolvable path must fail instead of creating something
+  {
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = "NoSuchDataDir/Thing.ezJoltCollisionMeshAsset";
+    options.m_Kind = ezMeshColliderKind::TriangleMesh;
+    options.m_bOpenAfterCreate = false;
+
+    EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Failed());
+  }
+}
+
+void ezEditorMeshColliderTest::MultipleMeshes()
+{
+  ezHybridArray<ezUuid, 4> meshes;
+  ezHybridArray<ezString, 4> expectedColliders;
+
+  for (ezUInt32 i = 0; i < 3; ++i)
+  {
+    ezStringBuilder sName;
+    sName.SetFormat("ColliderBatch{}", i);
+
+    const ezString sSource = MakePrivateSourceMesh(sName);
+    if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+      return;
+
+    ezStringBuilder sAssetPath;
+    sAssetPath.SetFormat("MeshCollider/Batch{}.ezMeshAsset", i);
+
+    const ezUuid guid = CreateMeshAsset(sAssetPath, sSource);
+    if (!EZ_TEST_BOOL(guid.IsValid()))
+      return;
+
+    meshes.PushBack(guid);
+
+    ezStringBuilder sCollider = m_sProjectPath;
+    sCollider.AppendPath(sAssetPath);
+    sCollider.ChangeFileExtension("ezJoltCollisionMeshAsset");
+    expectedColliders.PushBack(sCollider);
+  }
+
+  ezMeshColliderOptions options;
+  options.m_Kind = ezMeshColliderKind::TriangleMesh;
+  options.m_bOpenAfterCreate = false;
+
+  // no path: each collider has to end up next to its own mesh
+  {
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshColliders(meshes, options, uiCreated, uiSkipped).Succeeded()))
+      return;
+
+    EZ_TEST_INT(uiCreated, 3);
+    EZ_TEST_INT(uiSkipped, 0);
+
+    for (const ezString& sCollider : expectedColliders)
+    {
+      EZ_TEST_BOOL_MSG(ezOSFile::ExistsFile(sCollider), "Every mesh has to get a collider at its own default path.");
+    }
+  }
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // running it again must not pile up numbered duplicates, a mesh that already has a collider is done
+  {
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshColliders(meshes, options, uiCreated, uiSkipped).Succeeded()))
+      return;
+
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 3);
+
+    for (const ezString& sCollider : expectedColliders)
+    {
+      ezStringBuilder sSecondName(ezPathUtils::GetFileName(sCollider), "2");
+
+      ezStringBuilder sSecond = sCollider;
+      sSecond.ChangeFileName(sSecondName);
+
+      EZ_TEST_BOOL_MSG(!ezOSFile::ExistsFile(sSecond), "A second run must not create a numbered duplicate.");
+    }
+  }
+
+  // A convex collider is a different kind, so none of them exists yet and all three are created.
+  {
+    ezMeshColliderOptions convex = options;
+    convex.m_Kind = ezMeshColliderKind::ConvexHull;
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshColliders(meshes, convex, uiCreated, uiSkipped).Succeeded()))
+      return;
+
+    EZ_TEST_INT(uiCreated, 3);
+    EZ_TEST_INT(uiSkipped, 0);
+  }
+
+  // A guid that is not a mesh asset is a skip, not a failure - a selection can hold anything.
+  {
+    ezHybridArray<ezUuid, 2> mixed;
+    mixed.PushBack(ezUuid::MakeUuid());
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshColliders(mixed, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 1);
+  }
+
+  // A path in the options is meant for a single collider and must not make every mesh write to it.
+  {
+    ezMeshColliderOptions withPath = options;
+    withPath.m_sColliderPath = expectedColliders[0];
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshColliders(meshes, withPath, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT_MSG(uiCreated, 0, "Everything already exists, so nothing may be created.");
+    EZ_TEST_INT(uiSkipped, 3);
+  }
+}
+
+void ezEditorMeshColliderTest::SharedSourceFile()
+{
+  // Two mesh assets importing different sub-meshes out of one model file, as is common for asset
+  // packs. Their colliders both depend on that file, so the file alone cannot tell them apart.
+  const ezString sSource = MakePrivateSourceMesh("ColliderShared");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  ezVariantDictionary propsA;
+  propsA.Insert("MeshIncludeTags", ezVariant(ezString("part_a")));
+
+  ezVariantDictionary propsB;
+  propsB.Insert("MeshIncludeTags", ezVariant(ezString("part_b")));
+
+  const ezUuid meshA = CreateMeshAsset("MeshCollider/SharedA.ezMeshAsset", sSource, &propsA);
+  const ezUuid meshB = CreateMeshAsset("MeshCollider/SharedB.ezMeshAsset", sSource, &propsB);
+  if (!EZ_TEST_BOOL(meshA.IsValid() && meshB.IsValid()))
+    return;
+
+  // give A a collider, B none
+  ezString sColliderA;
+  {
+    ezMeshColliderSource source;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshA, source).Succeeded()))
+      return;
+
+    sColliderA = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sColliderA;
+    options.m_Kind = ezMeshColliderKind::TriangleMesh;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+  }
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  {
+    ezMeshColliderSource source;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshA, source).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL_MSG(source.GetExisting(ezMeshColliderKind::TriangleMesh).IsValid(), "The mesh the collider was built from has to find it.");
+  }
+
+  {
+    ezMeshColliderSource source;
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshB, source).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL_MSG(!source.GetExisting(ezMeshColliderKind::TriangleMesh).IsValid(), "A collider for a different sub-mesh must not be picked up.");
+  }
+}
+
+void ezEditorMeshColliderTest::Surface()
+{
+  const ezString sSource = MakePrivateSourceMesh("ColliderSurface");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshCollider/Surface.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshColliderSource source;
+  if (!EZ_TEST_BOOL(ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, source).Succeeded()))
+    return;
+
+  // The surface is stored as an asset reference, which is a guid. Any guid does, it just has to
+  // arrive in the document unchanged.
+  ezStringBuilder sSurface;
+  ezConversionUtils::ToString(ezUuid::MakeUuid(), sSurface);
+
+  {
+    const ezString sPath = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::ConvexHull);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sPath;
+    options.m_Kind = ezMeshColliderKind::ConvexHull;
+    options.m_sSurface = sSurface;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+
+    EZ_TEST_STRING(ReadColliderProperty(sPath, "Surface").ConvertTo<ezString>(), sSurface);
+  }
+
+  // A triangle mesh gets one surface per material slot of the model when it is transformed, so the
+  // single "Surface" property is not its own and must be left alone.
+  {
+    const ezString sPath = ezMeshColliderCreator::SuggestColliderPath(source, ezMeshColliderKind::TriangleMesh);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sPath;
+    options.m_Kind = ezMeshColliderKind::TriangleMesh;
+    options.m_sSurface = sSurface;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(source, options).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL_MSG(ReadColliderProperty(sPath, "Surface").ConvertTo<ezString>().IsEmpty(), "A triangle mesh has no single surface.");
+  }
+
+  // no surface chosen has to leave the property alone rather than writing an empty reference
+  {
+    ezMeshColliderSource fresh;
+    ezMeshColliderCreator::GatherMeshColliderSource(meshGuid, fresh).AssertSuccess();
+
+    const ezString sPath = ezMeshColliderCreator::SuggestColliderPath(fresh, ezMeshColliderKind::ConvexHull);
+
+    ezMeshColliderOptions options;
+    options.m_sColliderPath = sPath;
+    options.m_Kind = ezMeshColliderKind::ConvexHull;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshColliderCreator::CreateMeshCollider(fresh, options).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(ReadColliderProperty(sPath, "Surface").ConvertTo<ezString>().IsEmpty());
+  }
+}

--- a/Code/UnitTests/EditorTest/MeshCollider/MeshColliderTest.h
+++ b/Code/UnitTests/EditorTest/MeshCollider/MeshColliderTest.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <EditorTest/EditorTestPCH.h>
+
+#include <EditorTest/TestClass/TestClass.h>
+
+class ezEditorMeshColliderTest : public ezEditorTest
+{
+public:
+  using SUPER = ezEditorTest;
+
+  virtual const char* GetTestName() const override;
+
+private:
+  enum SubTests
+  {
+    ST_TriangleMesh,
+    ST_ConvexMesh,
+    ST_TransferredSettings,
+    ST_ExistingCollider,
+    ST_PrimitiveMesh,
+    ST_KeepsOpenDocuments,
+    ST_SimplificationSettings,
+    ST_DataDirRelativePath,
+    ST_MultipleMeshes,
+    ST_SharedSourceFile,
+    ST_Surface,
+  };
+
+  virtual void SetupSubTests() override;
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
+  virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+
+  /// Creates a mesh asset at the given project relative path.
+  ///
+  /// The values that are set here are the ones the collider is expected to inherit, so that a test
+  /// can tell a transferred value from a coincidental default.
+  ezUuid CreateMeshAsset(const char* szRelativePath, const char* szSourceFile = "Meshes/Cube.obj", const ezVariantDictionary* pExtraProperties = nullptr);
+
+  /// Copies Cube.obj to a new name, so that a test can use a source file nothing else shares.
+  /// Returns the project relative path to use as a mesh asset's MeshFile.
+  ezString MakePrivateSourceMesh(const char* szName);
+
+  /// Reads a property from a saved asset document, by opening and closing it.
+  ezVariant ReadColliderProperty(ezStringView sAbsPath, ezStringView sProperty);
+
+  void TriangleMesh();
+  void ConvexMesh();
+  void TransferredSettings();
+  void ExistingCollider();
+  void PrimitiveMesh();
+  void KeepsOpenDocuments();
+  void SimplificationSettings();
+  void DataDirRelativePath();
+  void MultipleMeshes();
+  void SharedSourceFile();
+  void Surface();
+};

--- a/Code/UnitTests/EditorTest/MeshLod/MeshLodTest.cpp
+++ b/Code/UnitTests/EditorTest/MeshLod/MeshLodTest.cpp
@@ -1,0 +1,617 @@
+#include <EditorTest/EditorTestPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorPluginAssets/Util/MeshLodCreator.h>
+#include <EditorPluginScene/Utils/MeshPrefabCreator.h>
+#include <EditorTest/MeshLod/MeshLodTest.h>
+#include <Foundation/IO/OSFile.h>
+#include <RendererCore/Declarations.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+static ezEditorMeshLodTest s_EditorMeshLodTest;
+
+const char* ezEditorMeshLodTest::GetTestName() const
+{
+  return "Mesh LOD Tests";
+}
+
+void ezEditorMeshLodTest::SetupSubTests()
+{
+  AddSubTest("Simplification Ladder", SubTests::ST_SimplificationLadder);
+  AddSubTest("Create LODs", SubTests::ST_CreateLods);
+  AddSubTest("Continues From Simplified Base", SubTests::ST_ContinuesFromSimplifiedBase);
+  AddSubTest("Transferred Settings", SubTests::ST_TransferredSettings);
+  AddSubTest("Existing LODs", SubTests::ST_ExistingLods);
+  AddSubTest("Prefab Picks Them Up", SubTests::ST_PrefabPicksThemUp);
+  AddSubTest("Primitive Mesh", SubTests::ST_PrimitiveMesh);
+  AddSubTest("Multiple Meshes", SubTests::ST_MultipleMeshes);
+}
+
+ezResult ezEditorMeshLodTest::InitializeTest()
+{
+  if (SUPER::InitializeTest().Failed())
+    return EZ_FAILURE;
+
+  if (SUPER::OpenProject("Data/UnitTests/EditorTest").Failed())
+    return EZ_FAILURE;
+
+  // the project has to be settled first, or the curator keeps rehashing while the sub-tests
+  // create their assets
+  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually); res.Failed())
+  {
+    ezLog::Error("Asset transform failed: {}", res.GetMessageString());
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezEditorMeshLodTest::DeInitializeTest()
+{
+  if (SUPER::DeInitializeTest().Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+ezTestAppRun ezEditorMeshLodTest::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+{
+  switch (iIdentifier)
+  {
+    case SubTests::ST_SimplificationLadder:
+      SimplificationLadder();
+      break;
+    case SubTests::ST_CreateLods:
+      CreateLods();
+      break;
+    case SubTests::ST_ContinuesFromSimplifiedBase:
+      ContinuesFromSimplifiedBase();
+      break;
+    case SubTests::ST_TransferredSettings:
+      TransferredSettings();
+      break;
+    case SubTests::ST_ExistingLods:
+      ExistingLods();
+      break;
+    case SubTests::ST_PrefabPicksThemUp:
+      PrefabPicksThemUp();
+      break;
+    case SubTests::ST_PrimitiveMesh:
+      PrimitiveMesh();
+      break;
+    case SubTests::ST_MultipleMeshes:
+      MultipleMeshes();
+      break;
+  }
+
+  return ezTestAppRun::Quit;
+}
+
+ezString ezEditorMeshLodTest::MakePrivateSourceMesh(const char* szName)
+{
+  ezStringBuilder sSrc = m_sProjectPath;
+  sSrc.AppendPath("Meshes/Cube.obj");
+
+  ezStringBuilder sRelative;
+  sRelative.SetFormat("Meshes/{}.obj", szName);
+
+  ezStringBuilder sDst = m_sProjectPath;
+  sDst.AppendPath(sRelative);
+
+  if (ezOSFile::CopyFile(sSrc, sDst).Failed())
+    return {};
+
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sDst);
+  return sRelative;
+}
+
+ezUuid ezEditorMeshLodTest::CreateMeshAsset(const char* szRelativePath, const char* szSourceFile, const ezVariantDictionary* pExtraProperties)
+{
+  ezStringBuilder sPath = m_sProjectPath;
+  sPath.AppendPath(szRelativePath);
+
+  ezDocument* pDoc = m_pApplication->m_pEditorApp->CreateDocument(sPath, ezDocumentFlags::None);
+  if (pDoc == nullptr)
+    return {};
+
+  {
+    ezDocumentObject* pProps = pDoc->GetObjectManager()->GetRootObject()->GetChildren()[0];
+    ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
+
+    pAcc->StartTransaction("Init");
+    pAcc->SetValueByName(pProps, "MeshFile", szSourceFile).AssertSuccess();
+
+    if (pExtraProperties != nullptr)
+    {
+      for (auto it : *pExtraProperties)
+      {
+        pAcc->SetValueByName(pProps, it.Key(), it.Value()).AssertSuccess();
+      }
+    }
+
+    pAcc->FinishTransaction();
+  }
+
+  pDoc->SaveDocument(true).AssertSuccess();
+
+  const ezUuid guid = pDoc->GetGuid();
+  pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  return guid;
+}
+
+ezVariant ezEditorMeshLodTest::ReadAssetProperty(ezStringView sAbsPath, ezStringView sProperty)
+{
+  ezDocument* pDoc = m_pApplication->m_pEditorApp->OpenDocument(sAbsPath, ezDocumentFlags::None);
+  if (pDoc == nullptr)
+    return {};
+
+  EZ_SCOPE_EXIT(pDoc->GetDocumentManager()->CloseDocument(pDoc));
+
+  const auto& children = pDoc->GetObjectManager()->GetRootObject()->GetChildren();
+  if (children.GetCount() != 1)
+    return {};
+
+  return children[0]->GetTypeAccessor().GetValue(sProperty);
+}
+
+void ezEditorMeshLodTest::SimplificationLadder()
+{
+  // Each level takes the midpoint of what is left between the level before it and 100, so from an
+  // unsimplified mesh the ladder is 50, 75, 88, 94.
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(0, 1), 50);
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(0, 2), 75);
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(0, 3), 88);
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(0, 4), 94);
+
+  // A mesh that is already simplified continues from where it stands: LOD-1 of a mesh at 50% has to
+  // be sparser than the mesh, not equal to it.
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(50, 1), 75);
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(50, 2), 88);
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplification(75, 1), 88);
+
+  // every level has to be strictly sparser than the one before, from every starting point
+  for (ezUInt8 uiBase = 0; uiBase < 99; ++uiBase)
+  {
+    ezUInt8 uiPrev = uiBase;
+
+    for (ezUInt32 uiLod = 1; uiLod <= ezMeshLodCreator::s_uiMaxLods; ++uiLod)
+    {
+      const ezUInt8 uiThis = ezMeshLodCreator::GetLodSimplification(uiBase, uiLod);
+
+      // At the very top the steps round down to nothing, which is expected - there is no room left.
+      if (uiPrev >= 97)
+        break;
+
+      EZ_TEST_BOOL_MSG(uiThis > uiPrev, "Every LOD has to be sparser than the one before it.");
+      uiPrev = uiThis;
+    }
+  }
+
+  // 100 would remove the entire mesh, so the ladder must never reach it.
+  for (ezUInt8 uiBase = 0; uiBase <= 99; ++uiBase)
+  {
+    for (ezUInt32 uiLod = 1; uiLod <= ezMeshLodCreator::s_uiMaxLods; ++uiLod)
+    {
+      EZ_TEST_BOOL(ezMeshLodCreator::GetLodSimplification(uiBase, uiLod) < 100);
+      EZ_TEST_BOOL(ezMeshLodCreator::GetLodSimplification(uiBase, uiLod) >= 1);
+    }
+  }
+
+  // The tolerated error grows with the level, because a distant mesh can afford a coarser silhouette.
+  EZ_TEST_INT(ezMeshLodCreator::GetLodSimplificationError(1), 5);
+  EZ_TEST_BOOL(ezMeshLodCreator::GetLodSimplificationError(3) > ezMeshLodCreator::GetLodSimplificationError(1));
+
+  // past the table it must still answer rather than reading out of bounds
+  EZ_TEST_BOOL(ezMeshLodCreator::GetLodSimplificationError(ezMeshLodCreator::s_uiMaxLods) > 0);
+}
+
+void ezEditorMeshLodTest::CreateLods()
+{
+  const ezString sSource = MakePrivateSourceMesh("LodBasic");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshLod/Basic.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshLodSource source;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_BOOL(!source.m_bIsPrimitive);
+  EZ_TEST_STRING(source.m_sMeshFile, sSource);
+  EZ_TEST_INT_MSG(source.m_uiBaseSimplification, 0, "This mesh does not simplify, so the ladder starts from the full model.");
+
+  // The folder name is what the prefab tool looks for, so it is not a free choice.
+  EZ_TEST_BOOL_MSG(source.m_sLodFolder.EndsWith("Basic_data"), "The LODs belong in <MeshName>_data.");
+
+  ezMeshLodOptions options;
+  options.m_uiLodCount = 2;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded()))
+    return;
+
+  EZ_TEST_INT(uiCreated, 2);
+  EZ_TEST_INT(uiSkipped, 0);
+
+  const ezString sLod1 = ezMeshLodCreator::GetLodPath(source, 1);
+  const ezString sLod2 = ezMeshLodCreator::GetLodPath(source, 2);
+
+  if (!EZ_TEST_BOOL(ezOSFile::ExistsFile(sLod1) && ezOSFile::ExistsFile(sLod2)))
+    return;
+
+  // The exact names matter: LOD-1 and LOD-2, so that the prefab tool finds them.
+  EZ_TEST_STRING(ezPathUtils::GetFileName(sLod1), "LOD-1");
+  EZ_TEST_STRING(ezPathUtils::GetFileName(sLod2), "LOD-2");
+
+  // each LOD is a simplified version of the same model, not a copy of it
+  EZ_TEST_STRING(ReadAssetProperty(sLod1, "MeshFile").ConvertTo<ezString>(), sSource);
+  EZ_TEST_BOOL(ReadAssetProperty(sLod1, "SimplifyMesh").ConvertTo<bool>() == true);
+  EZ_TEST_INT(ReadAssetProperty(sLod1, "MeshSimplification").ConvertTo<ezInt64>(), 50);
+  EZ_TEST_INT(ReadAssetProperty(sLod2, "MeshSimplification").ConvertTo<ezInt64>(), 75);
+
+  // and it must not re-import the materials, which would produce a second set for the same model
+  EZ_TEST_BOOL(ReadAssetProperty(sLod1, "ImportMaterials").ConvertTo<bool>() == false);
+}
+
+void ezEditorMeshLodTest::ContinuesFromSimplifiedBase()
+{
+  const ezString sSource = MakePrivateSourceMesh("LodContinue");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  // The mesh is already simplified, so its LODs have to go further rather than starting at 50 again.
+  ezVariantDictionary extras;
+  extras.Insert("SimplifyMesh", true);
+  extras.Insert("MeshSimplification", (ezInt64)50);
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshLod/Continue.ezMeshAsset", sSource, &extras);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshLodSource source;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_INT(source.m_uiBaseSimplification, 50);
+
+  ezMeshLodOptions options;
+  options.m_uiLodCount = 2;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded()))
+    return;
+
+  const ezString sLod1 = ezMeshLodCreator::GetLodPath(source, 1);
+  const ezString sLod2 = ezMeshLodCreator::GetLodPath(source, 2);
+
+  // a LOD of a mesh that is already at 50% has to be sparser than that mesh, not equal to it
+  EZ_TEST_INT(ReadAssetProperty(sLod1, "MeshSimplification").ConvertTo<ezInt64>(), 75);
+  EZ_TEST_INT(ReadAssetProperty(sLod2, "MeshSimplification").ConvertTo<ezInt64>(), 88);
+}
+
+void ezEditorMeshLodTest::TransferredSettings()
+{
+  const ezString sSource = MakePrivateSourceMesh("LodSettings");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  // every value differs from the mesh asset's default, so a transferred value cannot be mistaken
+  // for a coincidental match
+  const ezVec3 vOffset(1.0f, -2.0f, 3.5f);
+
+  ezVariantDictionary extras;
+  extras.Insert("MeshIncludeTags", "Render");
+  extras.Insert("MeshExcludeTags", "NoRender;UCX_");
+  extras.Insert("ImportTransform", (ezInt64)ezMeshImportTransform::Custom);
+  extras.Insert("RightDir", (ezInt64)ezBasisAxis::PositiveZ);
+  extras.Insert("UpDir", (ezInt64)ezBasisAxis::NegativeY);
+  extras.Insert("FlipForwardDir", true);
+  extras.Insert("PositionOffset", vOffset);
+  extras.Insert("UniformScaling", 5.0f);
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshLod/Settings.ezMeshAsset", sSource, &extras);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshLodSource source;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).Succeeded()))
+    return;
+
+  ezMeshLodOptions options;
+  options.m_uiLodCount = 1;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded()))
+    return;
+
+  const ezString sLod1 = ezMeshLodCreator::GetLodPath(source, 1);
+
+  // A LOD has to sit in the same place, at the same size, built from the same part of the model as
+  // the mesh it stands in for - otherwise the object visibly jumps when the LOD switches.
+  EZ_TEST_STRING(ReadAssetProperty(sLod1, "MeshFile").ConvertTo<ezString>(), sSource);
+  EZ_TEST_STRING(ReadAssetProperty(sLod1, "MeshIncludeTags").ConvertTo<ezString>(), "Render");
+  EZ_TEST_STRING(ReadAssetProperty(sLod1, "MeshExcludeTags").ConvertTo<ezString>(), "NoRender;UCX_");
+  EZ_TEST_INT(ReadAssetProperty(sLod1, "ImportTransform").ConvertTo<ezInt64>(), (ezInt64)ezMeshImportTransform::Custom);
+  EZ_TEST_INT(ReadAssetProperty(sLod1, "RightDir").ConvertTo<ezInt64>(), (ezInt64)ezBasisAxis::PositiveZ);
+  EZ_TEST_INT(ReadAssetProperty(sLod1, "UpDir").ConvertTo<ezInt64>(), (ezInt64)ezBasisAxis::NegativeY);
+  EZ_TEST_BOOL(ReadAssetProperty(sLod1, "FlipForwardDir").ConvertTo<bool>() == true);
+  EZ_TEST_VEC3(ReadAssetProperty(sLod1, "PositionOffset").ConvertTo<ezVec3>(), vOffset, 0.0001f);
+  EZ_TEST_FLOAT(ReadAssetProperty(sLod1, "UniformScaling").ConvertTo<float>(), 5.0f, 0.0001f);
+}
+
+void ezEditorMeshLodTest::ExistingLods()
+{
+  const ezString sSource = MakePrivateSourceMesh("LodExisting");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshLod/Existing.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezString sLod1;
+
+  {
+    ezMeshLodSource source;
+    ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).AssertSuccess();
+    EZ_TEST_BOOL_MSG(!source.HasLod(1), "Nothing has been created yet.");
+
+    sLod1 = ezMeshLodCreator::GetLodPath(source, 1);
+
+    ezMeshLodOptions options;
+    options.m_uiLodCount = 1;
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 1);
+  }
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // a LOD may have been tuned by hand, so a second run must not throw that away
+  {
+    ezDocument* pLod = m_pApplication->m_pEditorApp->OpenDocument(sLod1, ezDocumentFlags::None);
+    if (EZ_TEST_BOOL(pLod != nullptr))
+    {
+      ezDocumentObject* pProps = pLod->GetObjectManager()->GetRootObject()->GetChildren()[0];
+      ezObjectAccessorBase* pAcc = pLod->GetObjectAccessor();
+
+      pAcc->StartTransaction("Tune");
+      pAcc->SetValueByName(pProps, "MeshSimplification", (ezInt64)62).AssertSuccess();
+      pAcc->FinishTransaction();
+
+      pLod->SaveDocument(true).AssertSuccess();
+      pLod->GetDocumentManager()->CloseDocument(pLod);
+    }
+  }
+
+  {
+    ezMeshLodSource source;
+    ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).AssertSuccess();
+    EZ_TEST_BOOL_MSG(source.HasLod(1), "Gathering has to report the LOD that now exists.");
+
+    ezMeshLodOptions options;
+    options.m_uiLodCount = 1;
+    options.m_bOverwriteExisting = false;
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 1);
+
+    EZ_TEST_INT_MSG(ReadAssetProperty(sLod1, "MeshSimplification").ConvertTo<ezInt64>(), 62, "The hand-tuned value had to survive.");
+  }
+
+  // asking for it explicitly does replace it
+  {
+    ezMeshLodSource source;
+    ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).AssertSuccess();
+
+    ezMeshLodOptions options;
+    options.m_uiLodCount = 1;
+    options.m_bOverwriteExisting = true;
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 1);
+    EZ_TEST_INT(uiSkipped, 0);
+
+    EZ_TEST_INT_MSG(ReadAssetProperty(sLod1, "MeshSimplification").ConvertTo<ezInt64>(), 50, "Replacing has to restore the generated value.");
+  }
+
+  // Raising the count adds only what is missing, rather than refusing because something is there.
+  {
+    ezMeshLodSource source;
+    ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).AssertSuccess();
+
+    ezMeshLodOptions options;
+    options.m_uiLodCount = 3;
+    options.m_bOverwriteExisting = false;
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT_MSG(uiCreated, 2, "LOD-2 and LOD-3 were missing.");
+    EZ_TEST_INT_MSG(uiSkipped, 1, "LOD-1 was already there.");
+  }
+}
+
+void ezEditorMeshLodTest::PrefabPicksThemUp()
+{
+  const ezString sSource = MakePrivateSourceMesh("LodForPrefab");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshLodPrefab/ForPrefab.ezMeshAsset", sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  // Before the LODs exist, the mesh is just a mesh.
+  {
+    ezMeshPrefabSource prefabSource;
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, prefabSource).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(prefabSource.m_LodGuids.IsEmpty());
+    EZ_TEST_BOOL(prefabSource.GetDefaultRenderComponentType() == "ezMeshComponent"_ezsv);
+  }
+
+  ezMeshLodSource source;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).Succeeded()))
+    return;
+
+  ezMeshLodOptions options;
+  options.m_uiLodCount = 2;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped).Succeeded()))
+    return;
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // creating a prefab afterwards has to find the LODs by itself and build a LOD component instead
+  // of a plain mesh component, which is why the names and the folder are not a free choice
+  {
+    ezMeshPrefabSource prefabSource;
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, prefabSource).Succeeded()))
+      return;
+
+    EZ_TEST_INT_MSG(prefabSource.m_LodGuids.GetCount(), 2, "The prefab tool has to find the LODs that were just created.");
+    EZ_TEST_BOOL(prefabSource.GetDefaultRenderComponentType() == "ezLodMeshComponent"_ezsv);
+  }
+}
+
+void ezEditorMeshLodTest::PrimitiveMesh()
+{
+  // A procedural primitive has no model file, so there is no geometry to simplify.
+  // ezMeshPrimitive lives in EditorPluginAssets, which this test does not link. 6 is Sphere.
+  ezVariantDictionary extras;
+  extras.Insert("PrimitiveType", (ezInt64)6);
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshLod/Primitive.ezMeshAsset", "", &extras);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshLodSource source;
+  if (!EZ_TEST_BOOL(ezMeshLodCreator::GatherMeshLodSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_BOOL_MSG(source.m_bIsPrimitive, "A non-File primitive type has to be recognized.");
+  EZ_TEST_BOOL(source.m_sMeshFile.IsEmpty());
+
+  ezMeshLodOptions options;
+  options.m_uiLodCount = 2;
+
+  ezUInt32 uiCreated = 0;
+  ezUInt32 uiSkipped = 0;
+  const ezStatus res = ezMeshLodCreator::CreateMeshLods(source, options, uiCreated, uiSkipped);
+
+  EZ_TEST_BOOL_MSG(res.Failed(), "A primitive mesh has no source file, so this must fail.");
+  EZ_TEST_INT(uiCreated, 0);
+  EZ_TEST_BOOL_MSG(!ezOSFile::ExistsFile(ezMeshLodCreator::GetLodPath(source, 1)), "A failed run must not leave a document behind.");
+}
+
+void ezEditorMeshLodTest::MultipleMeshes()
+{
+  ezHybridArray<ezUuid, 4> meshes;
+  ezHybridArray<ezMeshLodSource, 4> sources;
+
+  for (ezUInt32 i = 0; i < 3; ++i)
+  {
+    ezStringBuilder sName;
+    sName.SetFormat("LodBatch{}", i);
+
+    const ezString sSource = MakePrivateSourceMesh(sName);
+    if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+      return;
+
+    ezStringBuilder sAssetPath;
+    sAssetPath.SetFormat("MeshLodBatch/Batch{}.ezMeshAsset", i);
+
+    const ezUuid guid = CreateMeshAsset(sAssetPath, sSource);
+    if (!EZ_TEST_BOOL(guid.IsValid()))
+      return;
+
+    meshes.PushBack(guid);
+
+    ezMeshLodSource& source = sources.ExpandAndGetRef();
+    ezMeshLodCreator::GatherMeshLodSource(guid, source).AssertSuccess();
+  }
+
+  ezMeshLodOptions options;
+  options.m_uiLodCount = 2;
+
+  {
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    if (!EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLodsForAll(meshes, options, uiCreated, uiSkipped).Succeeded()))
+      return;
+
+    EZ_TEST_INT_MSG(uiCreated, 6, "Three meshes, two LODs each.");
+    EZ_TEST_INT(uiSkipped, 0);
+
+    for (const ezMeshLodSource& source : sources)
+    {
+      EZ_TEST_BOOL(ezOSFile::ExistsFile(ezMeshLodCreator::GetLodPath(source, 1)));
+      EZ_TEST_BOOL(ezOSFile::ExistsFile(ezMeshLodCreator::GetLodPath(source, 2)));
+    }
+  }
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // Running it again leaves everything alone rather than replacing what is there.
+  {
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLodsForAll(meshes, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 6);
+  }
+
+  // A guid that is not a mesh asset is a skip, not a failure - a selection can hold anything.
+  {
+    ezHybridArray<ezUuid, 2> mixed;
+    mixed.PushBack(ezUuid::MakeUuid());
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLodsForAll(mixed, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 1);
+  }
+
+  // A LOD asset must never get LODs of its own, or the _data folders nest without end.
+  {
+    auto pLod = ezAssetCurator::GetSingleton()->FindSubAsset(ezMeshLodCreator::GetLodPath(sources[0], 1));
+    if (EZ_TEST_BOOL(pLod.isValid()))
+    {
+      ezHybridArray<ezUuid, 2> lodOnly;
+      lodOnly.PushBack(pLod->m_Data.m_Guid);
+
+      ezUInt32 uiCreated = 0;
+      ezUInt32 uiSkipped = 0;
+      EZ_TEST_BOOL(ezMeshLodCreator::CreateMeshLodsForAll(lodOnly, options, uiCreated, uiSkipped).Succeeded());
+      EZ_TEST_INT_MSG(uiCreated, 0, "A LOD must not get LODs of its own.");
+      EZ_TEST_INT(uiSkipped, 1);
+    }
+  }
+}

--- a/Code/UnitTests/EditorTest/MeshLod/MeshLodTest.h
+++ b/Code/UnitTests/EditorTest/MeshLod/MeshLodTest.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <EditorTest/EditorTestPCH.h>
+
+#include <EditorTest/TestClass/TestClass.h>
+
+class ezEditorMeshLodTest : public ezEditorTest
+{
+public:
+  using SUPER = ezEditorTest;
+
+  virtual const char* GetTestName() const override;
+
+private:
+  enum SubTests
+  {
+    ST_SimplificationLadder,
+    ST_CreateLods,
+    ST_ContinuesFromSimplifiedBase,
+    ST_TransferredSettings,
+    ST_ExistingLods,
+    ST_PrefabPicksThemUp,
+    ST_PrimitiveMesh,
+    ST_MultipleMeshes,
+  };
+
+  virtual void SetupSubTests() override;
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
+  virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+
+  /// Creates a mesh asset at the given project relative path.
+  ezUuid CreateMeshAsset(const char* szRelativePath, const char* szSourceFile = "Meshes/Cube.obj", const ezVariantDictionary* pExtraProperties = nullptr);
+
+  /// Copies Cube.obj to a new name, so that a test can use a source file nothing else shares.
+  /// Returns the project relative path to use as a mesh asset's MeshFile.
+  ezString MakePrivateSourceMesh(const char* szName);
+
+  /// Reads a property from a saved asset document, by opening and closing it.
+  ezVariant ReadAssetProperty(ezStringView sAbsPath, ezStringView sProperty);
+
+  void SimplificationLadder();
+  void CreateLods();
+  void ContinuesFromSimplifiedBase();
+  void TransferredSettings();
+  void ExistingLods();
+  void PrefabPicksThemUp();
+  void PrimitiveMesh();
+  void MultipleMeshes();
+};

--- a/Code/UnitTests/EditorTest/MeshPrefab/MeshPrefabTest.cpp
+++ b/Code/UnitTests/EditorTest/MeshPrefab/MeshPrefabTest.cpp
@@ -1,0 +1,827 @@
+#include <EditorTest/EditorTestPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorPluginScene/Utils/MeshPrefabCreator.h>
+#include <EditorTest/MeshPrefab/MeshPrefabTest.h>
+#include <Foundation/IO/OSFile.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+static ezEditorMeshPrefabTest s_EditorMeshPrefabTest;
+
+namespace
+{
+  void GetComponentTypes(const ezDocumentObject* pObject, ezDynamicArray<ezString>& out_types)
+  {
+    out_types.Clear();
+
+    for (const ezDocumentObject* pChild : pObject->GetChildren())
+    {
+      if (pChild->GetParentProperty() == "Components"_ezsv)
+      {
+        out_types.PushBack(pChild->GetType()->GetTypeName());
+      }
+    }
+  }
+
+  const ezDocumentObject* FindComponent(const ezDocumentObject* pObject, ezStringView sType)
+  {
+    for (const ezDocumentObject* pChild : pObject->GetChildren())
+    {
+      if (pChild->GetParentProperty() == "Components"_ezsv && pChild->GetType()->GetTypeName() == sType)
+        return pChild;
+    }
+
+    return nullptr;
+  }
+
+  ezDynamicArray<const ezDocumentObject*> GetChildObjects(const ezDocumentObject* pObject)
+  {
+    ezDynamicArray<const ezDocumentObject*> res;
+
+    for (const ezDocumentObject* pChild : pObject->GetChildren())
+    {
+      if (pChild->GetParentProperty() == "Children"_ezsv)
+        res.PushBack(pChild);
+    }
+
+    return res;
+  }
+} // namespace
+
+const char* ezEditorMeshPrefabTest::GetTestName() const
+{
+  return "Mesh Prefab Tests";
+}
+
+void ezEditorMeshPrefabTest::SetupSubTests()
+{
+  AddSubTest("Simple Mesh", SubTests::ST_SimpleMesh);
+  AddSubTest("LOD Mesh", SubTests::ST_LodMesh);
+  AddSubTest("Box Collider", SubTests::ST_BoxCollider);
+  AddSubTest("Collision Mesh", SubTests::ST_CollisionMesh);
+  AddSubTest("Convex And Defaults", SubTests::ST_ConvexAndDefaults);
+  AddSubTest("Existing Prefab", SubTests::ST_ExistingPrefab);
+  AddSubTest("Keeps Open Documents", SubTests::ST_KeepsOpenDocuments);
+  AddSubTest("Data Dir Relative Path", SubTests::ST_DataDirRelativePath);
+  AddSubTest("Multiple Prefabs", SubTests::ST_MultiplePrefabs);
+  AddSubTest("Animated LOD Component", SubTests::ST_AnimatedLodComponent);
+}
+
+ezResult ezEditorMeshPrefabTest::InitializeTest()
+{
+  if (SUPER::InitializeTest().Failed())
+    return EZ_FAILURE;
+
+  if (SUPER::OpenProject("Data/UnitTests/EditorTest").Failed())
+    return EZ_FAILURE;
+
+  // the project has to be settled first, or the curator keeps rehashing while the sub-tests
+  // create their assets
+  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually); res.Failed())
+  {
+    ezLog::Error("Asset transform failed: {}", res.GetMessageString());
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezEditorMeshPrefabTest::DeInitializeTest()
+{
+  if (SUPER::DeInitializeTest().Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+ezTestAppRun ezEditorMeshPrefabTest::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+{
+  switch (iIdentifier)
+  {
+    case SubTests::ST_SimpleMesh:
+      SimpleMesh();
+      break;
+    case SubTests::ST_LodMesh:
+      LodMesh();
+      break;
+    case SubTests::ST_BoxCollider:
+      BoxCollider();
+      break;
+    case SubTests::ST_CollisionMesh:
+      CollisionMesh();
+      break;
+    case SubTests::ST_ConvexAndDefaults:
+      ConvexAndDefaults();
+      break;
+    case SubTests::ST_ExistingPrefab:
+      ExistingPrefab();
+      break;
+    case SubTests::ST_KeepsOpenDocuments:
+      KeepsOpenDocuments();
+      break;
+    case SubTests::ST_DataDirRelativePath:
+      PrefabDataDirRelativePath();
+      break;
+    case SubTests::ST_MultiplePrefabs:
+      MultiplePrefabs();
+      break;
+    case SubTests::ST_AnimatedLodComponent:
+      AnimatedLodComponent();
+      break;
+  }
+
+  return ezTestAppRun::Quit;
+}
+
+ezString ezEditorMeshPrefabTest::MakePrivateSourceMesh(const char* szName)
+{
+  ezStringBuilder sSrc = m_sProjectPath;
+  sSrc.AppendPath("Meshes/Cube.obj");
+
+  ezStringBuilder sRelative;
+  sRelative.SetFormat("Meshes/{}.obj", szName);
+
+  ezStringBuilder sDst = m_sProjectPath;
+  sDst.AppendPath(sRelative);
+
+  if (ezOSFile::CopyFile(sSrc, sDst).Failed())
+    return {};
+
+  ezFileSystemModel::GetSingleton()->NotifyOfChange(sDst);
+  return sRelative;
+}
+
+ezUuid ezEditorMeshPrefabTest::CreateMeshAsset(const char* szRelativePath, ezUInt8 uiSimplification, const char* szSourceFile)
+{
+  ezStringBuilder sPath = m_sProjectPath;
+  sPath.AppendPath(szRelativePath);
+
+  ezDocument* pDoc = m_pApplication->m_pEditorApp->CreateDocument(sPath, ezDocumentFlags::None);
+  if (pDoc == nullptr)
+    return {};
+
+  {
+    ezDocumentObject* pProps = pDoc->GetObjectManager()->GetRootObject()->GetChildren()[0];
+    ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
+
+    pAcc->StartTransaction("Init");
+    pAcc->SetValueByName(pProps, "MeshFile", szSourceFile).AssertSuccess();
+
+    if (uiSimplification > 0)
+    {
+      pAcc->SetValueByName(pProps, "SimplifyMesh", true).AssertSuccess();
+      pAcc->SetValueByName(pProps, "MeshSimplification", uiSimplification).AssertSuccess();
+    }
+
+    pAcc->FinishTransaction();
+  }
+
+  pDoc->SaveDocument(true).AssertSuccess();
+
+  const ezUuid guid = pDoc->GetGuid();
+  pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // Bounds are recorded by a transform, under the asset hash current at that moment. The curator
+  // keeps rehashing a newly created asset while indexing it, so a single transform tends to write
+  // them under a hash that is stale by the time they are read. Retry until they can be read back.
+  // Only this asset is transformed, transforming the generated prefabs would log unrelated errors.
+  for (ezUInt32 i = 0; i < 10; ++i)
+  {
+    ezTransformStatus transformRes = ezAssetCurator::GetSingleton()->TransformAsset(guid, ezTransformFlags::TriggeredManually);
+    EZ_IGNORE_UNUSED(transformRes);
+    ProcessEvents(5);
+    ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+    auto pCheck = ezAssetCurator::GetSingleton()->GetSubAsset(guid);
+    if (pCheck.isValid() && pCheck->m_pAssetInfo != nullptr && pCheck->m_pAssetInfo->GetTransformInfo() != nullptr)
+      break;
+  }
+
+  return guid;
+}
+
+void ezEditorMeshPrefabTest::SimpleMesh()
+{
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefab/Simple.ezMeshAsset");
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_BOOL(!source.m_bAnimated);
+  EZ_TEST_BOOL(source.m_LodGuids.IsEmpty());
+  EZ_TEST_BOOL_MSG(source.m_bHasBounds, "The mesh was transformed, so its bounds should be known.");
+  EZ_TEST_BOOL(source.GetDefaultRenderComponentType() == "ezMeshComponent"_ezsv);
+
+  ezStringBuilder sPrefabPath = m_sProjectPath;
+  sPrefabPath.AppendPath("MeshPrefab/Simple.ezPrefab");
+
+  ezMeshPrefabOptions options;
+  options.m_sPrefabPath = sPrefabPath;
+  options.m_sRenderComponentType = source.GetDefaultRenderComponentType();
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+    return;
+
+  EZ_TEST_BOOL(ezOSFile::ExistsFile(sPrefabPath));
+
+  ezDocument* pPrefab = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pPrefab != nullptr))
+    return;
+
+  EZ_SCOPE_EXIT(pPrefab->GetDocumentManager()->CloseDocument(pPrefab));
+
+  const ezDocumentObject* pRoot = pPrefab->GetObjectManager()->GetRootObject();
+  auto topLevel = GetChildObjects(pRoot);
+  if (!EZ_TEST_INT(topLevel.GetCount(), 1))
+    return;
+
+  const ezDocumentObject* pPrefabRoot = topLevel[0];
+  EZ_TEST_STRING(pPrefabRoot->GetTypeAccessor().GetValue("Name").ConvertTo<ezString>(), "<Prefab-Root>");
+
+  const ezDocumentObject* pMeshComp = FindComponent(pPrefabRoot, "ezMeshComponent");
+  if (!EZ_TEST_BOOL(pMeshComp != nullptr))
+    return;
+
+  ezStringBuilder sExpectedRef;
+  sExpectedRef.SetFormat("{}", meshGuid);
+  EZ_TEST_STRING(pMeshComp->GetTypeAccessor().GetValue("Mesh").ConvertTo<ezString>(), sExpectedRef);
+}
+
+void ezEditorMeshPrefabTest::LodMesh()
+{
+  // the layout the mesh import produces: the main asset plus LOD-N assets in a sibling _data folder
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefab/Lod.ezMeshAsset");
+  const ezUuid lod1Guid = CreateMeshAsset("MeshPrefab/Lod_data/LOD-1.ezMeshAsset", 50);
+  const ezUuid lod2Guid = CreateMeshAsset("MeshPrefab/Lod_data/LOD-2.ezMeshAsset", 75);
+
+  if (!EZ_TEST_BOOL(meshGuid.IsValid() && lod1Guid.IsValid() && lod2Guid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  if (!EZ_TEST_INT(source.m_LodGuids.GetCount(), 2))
+    return;
+
+  EZ_TEST_BOOL(source.m_LodGuids[0] == lod1Guid);
+  EZ_TEST_BOOL(source.m_LodGuids[1] == lod2Guid);
+  EZ_TEST_BOOL(source.GetDefaultRenderComponentType() == "ezLodMeshComponent"_ezsv);
+
+  // A mesh asset renamed after import keeps its original _data folder, named after the source model
+  // file. The LODs still have to be found.
+  {
+    ezStringBuilder sRenamedDir = m_sProjectPath;
+    sRenamedDir.AppendPath("MeshPrefabRenamed");
+    ezOSFile::CreateDirectoryStructure(sRenamedDir).AssertSuccess();
+
+    const ezUuid renamedGuid = CreateMeshAsset("MeshPrefabRenamed/Renamed.ezMeshAsset");
+    const ezUuid renamedLod1 = CreateMeshAsset("MeshPrefabRenamed/Cube_data/LOD-1.ezMeshAsset", 50);
+
+    if (EZ_TEST_BOOL(renamedGuid.IsValid() && renamedLod1.IsValid()))
+    {
+      ezMeshPrefabSource renamedSource;
+      if (EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(renamedGuid, renamedSource).Succeeded()))
+      {
+        if (EZ_TEST_INT(renamedSource.m_LodGuids.GetCount(), 1))
+        {
+          EZ_TEST_BOOL(renamedSource.m_LodGuids[0] == renamedLod1);
+        }
+      }
+    }
+  }
+
+  ezStringBuilder sPrefabPath = m_sProjectPath;
+  sPrefabPath.AppendPath("MeshPrefab/Lod.ezPrefab");
+
+  ezMeshPrefabOptions options;
+  options.m_sPrefabPath = sPrefabPath;
+  options.m_sRenderComponentType = source.GetDefaultRenderComponentType();
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+    return;
+
+  ezDocument* pPrefab = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pPrefab != nullptr))
+    return;
+
+  EZ_SCOPE_EXIT(pPrefab->GetDocumentManager()->CloseDocument(pPrefab));
+
+  const ezDocumentObject* pPrefabRoot = GetChildObjects(pPrefab->GetObjectManager()->GetRootObject())[0];
+  const ezDocumentObject* pLodComp = FindComponent(pPrefabRoot, "ezLodMeshComponent");
+  if (!EZ_TEST_BOOL(pLodComp != nullptr))
+    return;
+
+  // LOD 0 is the mesh asset itself, so there is one entry more than there are LOD assets
+  ezHybridArray<const ezDocumentObject*, 4> lods;
+  for (const ezDocumentObject* pChild : pLodComp->GetChildren())
+  {
+    if (pChild->GetParentProperty() == "Meshes"_ezsv)
+      lods.PushBack(pChild);
+  }
+
+  if (!EZ_TEST_INT(lods.GetCount(), 3))
+    return;
+
+  const ezUuid expected[] = {meshGuid, lod1Guid, lod2Guid};
+  float fPrevThreshold = 2.0f;
+
+  for (ezUInt32 i = 0; i < 3; ++i)
+  {
+    ezStringBuilder sExpectedRef;
+    sExpectedRef.SetFormat("{}", expected[i]);
+    EZ_TEST_STRING(lods[i]->GetTypeAccessor().GetValue("Mesh").ConvertTo<ezString>(), sExpectedRef);
+
+    // thresholds have to decrease, otherwise the component never switches LOD
+    const float fThreshold = lods[i]->GetTypeAccessor().GetValue("Threshold").ConvertTo<float>();
+    EZ_TEST_BOOL(fThreshold < fPrevThreshold);
+    fPrevThreshold = fThreshold;
+  }
+
+  EZ_TEST_FLOAT(lods[0]->GetTypeAccessor().GetValue("Threshold").ConvertTo<float>(), 0.2f, 0.001f);
+  EZ_TEST_FLOAT(lods[1]->GetTypeAccessor().GetValue("Threshold").ConvertTo<float>(), 0.1f, 0.001f);
+
+  // the last LOD has to reach all the way out, or the mesh disappears in the distance
+  EZ_TEST_FLOAT(lods[2]->GetTypeAccessor().GetValue("Threshold").ConvertTo<float>(), 0.0f, 0.001f);
+
+  const float fRadius = pLodComp->GetTypeAccessor().GetValue("BoundsRadius").ConvertTo<float>();
+  EZ_TEST_FLOAT(fRadius, source.m_fBoundsRadius, 0.001f);
+  EZ_TEST_BOOL_MSG(fRadius != 1.0f, "The bounds radius should come from the mesh, not stay at the default.");
+}
+
+void ezEditorMeshPrefabTest::BoxCollider()
+{
+  if (!ezMeshPrefabCreator::IsPhysicsAvailable())
+  {
+    ezLog::Info("Jolt is not available, skipping the collider test.");
+    return;
+  }
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefab/Box.ezMeshAsset");
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  if (!EZ_TEST_BOOL_MSG(source.m_bHasBounds, "A box collider cannot be sized without bounds."))
+    return;
+
+  ezStringBuilder sPrefabPath = m_sProjectPath;
+  sPrefabPath.AppendPath("MeshPrefab/Box.ezPrefab");
+
+  ezMeshPrefabOptions options;
+  options.m_sPrefabPath = sPrefabPath;
+  options.m_sRenderComponentType = "ezMeshComponent";
+  options.m_Physics = ezMeshPrefabPhysics::StaticBox;
+  options.m_uiCollisionLayer = 3;
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+    return;
+
+  ezDocument* pPrefab = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pPrefab != nullptr))
+    return;
+
+  EZ_SCOPE_EXIT(pPrefab->GetDocumentManager()->CloseDocument(pPrefab));
+
+  const ezDocumentObject* pPrefabRoot = GetChildObjects(pPrefab->GetObjectManager()->GetRootObject())[0];
+
+  const ezDocumentObject* pActor = FindComponent(pPrefabRoot, "ezJoltStaticActorComponent");
+  if (!EZ_TEST_BOOL(pActor != nullptr))
+    return;
+
+  EZ_TEST_INT(pActor->GetTypeAccessor().GetValue("CollisionLayer").ConvertTo<ezUInt32>(), 3);
+
+  auto children = GetChildObjects(pPrefabRoot);
+  if (!EZ_TEST_INT(children.GetCount(), 1))
+    return;
+
+  const ezDocumentObject* pShape = FindComponent(children[0], "ezJoltShapeBoxComponent");
+  if (!EZ_TEST_BOOL(pShape != nullptr))
+    return;
+
+  const ezVec3 vHalfExtents = pShape->GetTypeAccessor().GetValue("HalfExtents").ConvertTo<ezVec3>();
+  EZ_TEST_VEC3(vHalfExtents, source.m_vBoundsHalfExtents, 0.001f);
+
+  const ezVec3 vPos = children[0]->GetTypeAccessor().GetValue("LocalPosition").ConvertTo<ezVec3>();
+  EZ_TEST_VEC3(vPos, source.m_vBoundsCenter, 0.001f);
+}
+
+void ezEditorMeshPrefabTest::CollisionMesh()
+{
+  if (!ezMeshPrefabCreator::IsPhysicsAvailable())
+  {
+    ezLog::Info("Jolt is not available, skipping the collision mesh test.");
+    return;
+  }
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefab/ColMesh.ezMeshAsset");
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  EZ_TEST_STRING(source.m_sMeshFile, "Meshes/Cube.obj");
+
+  ezStringBuilder sPrefabPath = m_sProjectPath;
+  sPrefabPath.AppendPath("MeshPrefab/ColMesh.ezPrefab");
+
+  ezMeshPrefabOptions options;
+  options.m_sPrefabPath = sPrefabPath;
+  options.m_sRenderComponentType = "ezMeshComponent";
+  options.m_Physics = ezMeshPrefabPhysics::StaticTriangleMesh;
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+    return;
+
+  ezStringBuilder sColMeshPath = m_sProjectPath;
+  sColMeshPath.AppendPath("MeshPrefab/ColMesh.ezJoltCollisionMeshAsset");
+  EZ_TEST_BOOL(ezOSFile::ExistsFile(sColMeshPath));
+
+  ezDocument* pPrefab = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pPrefab != nullptr))
+    return;
+
+  EZ_SCOPE_EXIT(pPrefab->GetDocumentManager()->CloseDocument(pPrefab));
+
+  const ezDocumentObject* pPrefabRoot = GetChildObjects(pPrefab->GetObjectManager()->GetRootObject())[0];
+  const ezDocumentObject* pActor = FindComponent(pPrefabRoot, "ezJoltStaticActorComponent");
+  if (!EZ_TEST_BOOL(pActor != nullptr))
+    return;
+
+  // a triangle mesh collider needs no separate shape component, the actor references the mesh itself
+  const ezString sColMeshRef = pActor->GetTypeAccessor().GetValue("CollisionMesh").ConvertTo<ezString>();
+  EZ_TEST_BOOL_MSG(!sColMeshRef.IsEmpty(), "The actor should reference the generated collision mesh.");
+  EZ_TEST_INT(GetChildObjects(pPrefabRoot).GetCount(), 0);
+
+  // running it again has to reuse that asset rather than create a second one
+  ezStringBuilder sPrefabPath2 = m_sProjectPath;
+  sPrefabPath2.AppendPath("MeshPrefab/ColMesh2.ezPrefab");
+
+  ezMeshPrefabOptions options2 = options;
+  options2.m_sPrefabPath = sPrefabPath2;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options2).Succeeded()))
+    return;
+
+  ezDocument* pPrefab2 = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath2, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pPrefab2 != nullptr))
+    return;
+
+  EZ_SCOPE_EXIT(pPrefab2->GetDocumentManager()->CloseDocument(pPrefab2));
+
+  const ezDocumentObject* pPrefabRoot2 = GetChildObjects(pPrefab2->GetObjectManager()->GetRootObject())[0];
+  const ezDocumentObject* pActor2 = FindComponent(pPrefabRoot2, "ezJoltStaticActorComponent");
+  if (!EZ_TEST_BOOL(pActor2 != nullptr))
+    return;
+
+  EZ_TEST_STRING(pActor2->GetTypeAccessor().GetValue("CollisionMesh").ConvertTo<ezString>(), sColMeshRef);
+}
+
+void ezEditorMeshPrefabTest::ConvexAndDefaults()
+{
+  if (!ezMeshPrefabCreator::IsPhysicsAvailable())
+  {
+    ezLog::Info("Jolt is not available, skipping the convex hull test.");
+    return;
+  }
+
+  // Collision meshes are matched by source file, and every other mesh here is built from Cube.obj.
+  // Without a private source this would find the colliders the other sub-tests generated.
+  const ezString sSource = MakePrivateSourceMesh("ConvexCube");
+  if (!EZ_TEST_BOOL(!sSource.IsEmpty()))
+    return;
+
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefabConvex/Convex.ezMeshAsset", 0, sSource);
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  {
+    ezMeshPrefabSource source;
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(source.GetDefaultPhysics() == ezMeshPrefabPhysics::None);
+    EZ_TEST_BOOL(!source.m_ExistingConvexColMesh.IsValid());
+
+    ezStringBuilder sPrefabPath = m_sProjectPath;
+    sPrefabPath.AppendPath("MeshPrefabConvex/Convex.ezPrefab");
+
+    ezMeshPrefabOptions options;
+    options.m_sPrefabPath = sPrefabPath;
+    options.m_sRenderComponentType = "ezMeshComponent";
+    options.m_Physics = ezMeshPrefabPhysics::StaticConvexHull;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+      return;
+
+    // a convex hull is a static actor plus a shape component, unlike a triangle mesh
+    ezDocument* pPrefab = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath, ezDocumentFlags::None);
+    if (!EZ_TEST_BOOL(pPrefab != nullptr))
+      return;
+
+    EZ_SCOPE_EXIT(pPrefab->GetDocumentManager()->CloseDocument(pPrefab));
+
+    const ezDocumentObject* pPrefabRoot = GetChildObjects(pPrefab->GetObjectManager()->GetRootObject())[0];
+    EZ_TEST_BOOL(FindComponent(pPrefabRoot, "ezJoltStaticActorComponent") != nullptr);
+
+    const ezDocumentObject* pShape = FindComponent(pPrefabRoot, "ezJoltShapeConvexHullComponent");
+    if (!EZ_TEST_BOOL(pShape != nullptr))
+      return;
+
+    EZ_TEST_BOOL(!pShape->GetTypeAccessor().GetValue("CollisionMesh").ConvertTo<ezString>().IsEmpty());
+  }
+
+  // the convex collision mesh now exists, so it should drive the default on a second run
+  {
+    ezMeshPrefabSource source;
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(source.m_ExistingConvexColMesh.IsValid());
+    EZ_TEST_BOOL(source.GetDefaultPhysics() == ezMeshPrefabPhysics::StaticConvexHull);
+  }
+}
+
+void ezEditorMeshPrefabTest::ExistingPrefab()
+{
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefabExisting/Existing.ezMeshAsset");
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  ezStringBuilder sPrefabPath = m_sProjectPath;
+  sPrefabPath.AppendPath("MeshPrefabExisting/Existing.ezPrefab");
+
+  ezMeshPrefabOptions options;
+  options.m_sPrefabPath = sPrefabPath;
+  options.m_sRenderComponentType = "ezMeshComponent";
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+    return;
+
+  const ezStatus second = ezMeshPrefabCreator::CreateMeshPrefab(source, options);
+  EZ_TEST_BOOL_MSG(second.Failed(), "Creating a prefab over an existing one should fail, not overwrite it.");
+  EZ_TEST_BOOL(!second.GetMessageString().IsEmpty());
+}
+
+void ezEditorMeshPrefabTest::KeepsOpenDocuments()
+{
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefabOpen/Open.ezMeshAsset");
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezStringBuilder sMeshPath = m_sProjectPath;
+  sMeshPath.AppendPath("MeshPrefabOpen/Open.ezMeshAsset");
+
+  // Opened without a window, which is what the curator does while transforming. Reading a property
+  // out of it must not close it.
+  ezDocument* pOpened = m_pApplication->m_pEditorApp->OpenDocument(sMeshPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pOpened != nullptr))
+    return;
+
+  ezMeshPrefabSource source;
+  EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded());
+  EZ_TEST_STRING(source.m_sMeshFile, "Meshes/Cube.obj");
+
+  const ezDocument* pStillOpen = ezDocumentManager::GetDocumentByGuid(meshGuid);
+  EZ_TEST_BOOL_MSG(pStillOpen == pOpened, "Gathering must not close a document that was already open.");
+
+  if (pStillOpen == pOpened)
+  {
+    pOpened->GetDocumentManager()->CloseDocument(pOpened);
+  }
+}
+
+void ezEditorMeshPrefabTest::PrefabDataDirRelativePath()
+{
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefab/RelPath.ezMeshAsset");
+  if (!EZ_TEST_BOOL(meshGuid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  const ezString sAbsolute = ezMeshPrefabCreator::SuggestPrefabPath(source);
+  const ezString sDisplay = ezMeshPrefabCreator::MakeDisplayPath(sAbsolute);
+
+  // What the dialog shows has to be the short form, not the full path off the drive root.
+  EZ_TEST_BOOL_MSG(!ezPathUtils::IsAbsolutePath(sDisplay), "The display path must be relative.");
+  EZ_TEST_BOOL_MSG(sDisplay.FindSubString("MeshPrefab/RelPath") != nullptr, "The display path must still name the file.");
+
+  // and it has to round trip, or the dialog cannot hand it back to the creator
+  {
+    ezStringBuilder sResolved;
+    EZ_TEST_BOOL(ezMeshPrefabCreator::ResolveDisplayPath(sDisplay, sResolved).Succeeded());
+    EZ_TEST_STRING(sResolved, sAbsolute);
+  }
+
+  // an absolute path stays valid input, which is what the file browse button produces
+  {
+    ezStringBuilder sResolved;
+    EZ_TEST_BOOL(ezMeshPrefabCreator::ResolveDisplayPath(sAbsolute, sResolved).Succeeded());
+    EZ_TEST_STRING(sResolved, sAbsolute);
+  }
+
+  // a path that names no data directory has to be refused rather than written somewhere unexpected
+  {
+    ezStringBuilder sResolved;
+    EZ_TEST_BOOL(ezMeshPrefabCreator::ResolveDisplayPath("NoSuchDataDir/Thing.ezPrefab", sResolved).Failed());
+    EZ_TEST_BOOL(ezMeshPrefabCreator::ResolveDisplayPath("", sResolved).Failed());
+  }
+
+  // creating from the relative form has to put the file exactly where the absolute form would
+  {
+    ezMeshPrefabOptions options;
+    options.m_sPrefabPath = sDisplay;
+    options.m_bOpenAfterCreate = false;
+
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+      return;
+
+    EZ_TEST_BOOL(ezOSFile::ExistsFile(sAbsolute));
+  }
+
+  // an unresolvable path must fail instead of creating something
+  {
+    ezMeshPrefabOptions options;
+    options.m_sPrefabPath = "NoSuchDataDir/Thing.ezPrefab";
+    options.m_bOpenAfterCreate = false;
+
+    EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Failed());
+  }
+}
+
+void ezEditorMeshPrefabTest::MultiplePrefabs()
+{
+  ezHybridArray<ezUuid, 4> meshes;
+  ezHybridArray<ezString, 4> expectedPrefabs;
+
+  for (ezUInt32 i = 0; i < 3; ++i)
+  {
+    ezStringBuilder sAssetPath;
+    sAssetPath.SetFormat("MeshPrefabBatch/Batch{}.ezMeshAsset", i);
+
+    const ezUuid guid = CreateMeshAsset(sAssetPath);
+    if (!EZ_TEST_BOOL(guid.IsValid()))
+      return;
+
+    meshes.PushBack(guid);
+
+    ezStringBuilder sPrefab = m_sProjectPath;
+    sPrefab.AppendPath(sAssetPath);
+    sPrefab.ChangeFileExtension("ezPrefab");
+    expectedPrefabs.PushBack(sPrefab);
+  }
+
+  ezMeshPrefabOptions options;
+  options.m_bOpenAfterCreate = false;
+
+  // no path: each prefab has to end up next to its own mesh
+  {
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefabs(meshes, options, uiCreated, uiSkipped).Succeeded()))
+      return;
+
+    EZ_TEST_INT(uiCreated, 3);
+    EZ_TEST_INT(uiSkipped, 0);
+
+    for (const ezString& sPrefab : expectedPrefabs)
+    {
+      EZ_TEST_BOOL_MSG(ezOSFile::ExistsFile(sPrefab), "Every mesh has to get a prefab at its own default path.");
+    }
+  }
+
+  ProcessEvents(10);
+  ezAssetCurator::GetSingleton()->MainThreadTick(true);
+
+  // Running it again must not pile up numbered duplicates. A mesh that already has a prefab is done,
+  // which is why such a mesh is skipped rather than failing the run.
+  {
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefabs(meshes, options, uiCreated, uiSkipped).Succeeded()))
+      return;
+
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 3);
+
+    for (const ezString& sPrefab : expectedPrefabs)
+    {
+      ezStringBuilder sSecondName(ezPathUtils::GetFileName(sPrefab), "2");
+
+      ezStringBuilder sSecond = sPrefab;
+      sSecond.ChangeFileName(sSecondName);
+
+      EZ_TEST_BOOL_MSG(!ezOSFile::ExistsFile(sSecond), "A second run must not create a numbered duplicate.");
+    }
+  }
+
+  // A guid that is not a mesh asset is a skip, not a failure - a selection can hold anything.
+  {
+    ezHybridArray<ezUuid, 2> mixed;
+    mixed.PushBack(ezUuid::MakeUuid());
+
+    ezUInt32 uiCreated = 0;
+    ezUInt32 uiSkipped = 0;
+    EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefabs(mixed, options, uiCreated, uiSkipped).Succeeded());
+    EZ_TEST_INT(uiCreated, 0);
+    EZ_TEST_INT(uiSkipped, 1);
+  }
+}
+
+void ezEditorMeshPrefabTest::AnimatedLodComponent()
+{
+  // The LOD folder is found by the mesh asset name, so this mesh needs a name of its own.
+  const ezUuid meshGuid = CreateMeshAsset("MeshPrefabAnimLod/AnimLod.ezMeshAsset");
+  const ezUuid lod1Guid = CreateMeshAsset("MeshPrefabAnimLod/AnimLod_data/LOD-1.ezMeshAsset", 50);
+
+  if (!EZ_TEST_BOOL(meshGuid.IsValid() && lod1Guid.IsValid()))
+    return;
+
+  ezMeshPrefabSource source;
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::GatherMeshPrefabSource(meshGuid, source).Succeeded()))
+    return;
+
+  if (!EZ_TEST_INT(source.m_LodGuids.GetCount(), 1))
+    return;
+
+  // A static mesh with LODs still defaults to the static LOD component.
+  EZ_TEST_BOOL(source.GetDefaultRenderComponentType() == "ezLodMeshComponent"_ezsv);
+
+  // The animated LOD component is only offered for animated meshes. What matters here is that it is
+  // built correctly when asked for, including the LOD element type, which differs from the static one.
+  ezStringBuilder sPrefabPath = m_sProjectPath;
+  sPrefabPath.AppendPath("MeshPrefabAnimLod/AnimLod.ezPrefab");
+
+  ezMeshPrefabOptions options;
+  options.m_sPrefabPath = sPrefabPath;
+  options.m_sRenderComponentType = "ezLodAnimatedMeshComponent";
+  options.m_bOpenAfterCreate = false;
+
+  if (!EZ_TEST_BOOL(ezMeshPrefabCreator::CreateMeshPrefab(source, options).Succeeded()))
+    return;
+
+  ezDocument* pPrefab = m_pApplication->m_pEditorApp->OpenDocument(sPrefabPath, ezDocumentFlags::None);
+  if (!EZ_TEST_BOOL(pPrefab != nullptr))
+    return;
+
+  EZ_SCOPE_EXIT(pPrefab->GetDocumentManager()->CloseDocument(pPrefab));
+
+  auto topLevel = GetChildObjects(pPrefab->GetObjectManager()->GetRootObject());
+  if (!EZ_TEST_INT(topLevel.GetCount(), 1))
+    return;
+
+  const ezDocumentObject* pComp = FindComponent(topLevel[0], "ezLodAnimatedMeshComponent");
+  if (!EZ_TEST_BOOL(pComp != nullptr))
+    return;
+
+  // LOD 0 is the mesh itself, LOD 1 is the sibling that was found
+  ezHybridArray<const ezDocumentObject*, 4> lods;
+  for (const ezDocumentObject* pChild : pComp->GetChildren())
+  {
+    if (pChild->GetParentProperty() == "Meshes"_ezsv)
+      lods.PushBack(pChild);
+  }
+
+  if (!EZ_TEST_INT(lods.GetCount(), 2))
+    return;
+
+  // The two LOD components have separate element types with identical property names. Using the
+  // static one here would build a document the animated component cannot read.
+  EZ_TEST_STRING(lods[0]->GetTypeAccessor().GetType()->GetTypeName(), "ezLodAnimatedMeshLod");
+
+  ezStringBuilder sExpectedRef;
+  sExpectedRef.SetFormat("{}", meshGuid);
+  EZ_TEST_STRING(lods[0]->GetTypeAccessor().GetValue("Mesh").ConvertTo<ezString>(), sExpectedRef);
+
+  sExpectedRef.SetFormat("{}", lod1Guid);
+  EZ_TEST_STRING(lods[1]->GetTypeAccessor().GetValue("Mesh").ConvertTo<ezString>(), sExpectedRef);
+
+  // the last LOD has to reach out to the horizon, or the object disappears at a distance
+  EZ_TEST_FLOAT(lods[1]->GetTypeAccessor().GetValue("Threshold").ConvertTo<float>(), 0.0f, 0.0001f);
+  EZ_TEST_BOOL(lods[0]->GetTypeAccessor().GetValue("Threshold").ConvertTo<float>() > 0.0f);
+}

--- a/Code/UnitTests/EditorTest/MeshPrefab/MeshPrefabTest.h
+++ b/Code/UnitTests/EditorTest/MeshPrefab/MeshPrefabTest.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <EditorTest/EditorTestPCH.h>
+
+#include <EditorTest/TestClass/TestClass.h>
+
+class ezEditorMeshPrefabTest : public ezEditorTest
+{
+public:
+  using SUPER = ezEditorTest;
+
+  virtual const char* GetTestName() const override;
+
+private:
+  enum SubTests
+  {
+    ST_SimpleMesh,
+    ST_LodMesh,
+    ST_BoxCollider,
+    ST_CollisionMesh,
+    ST_ConvexAndDefaults,
+    ST_ExistingPrefab,
+    ST_KeepsOpenDocuments,
+    ST_DataDirRelativePath,
+    ST_MultiplePrefabs,
+    ST_AnimatedLodComponent,
+  };
+
+  virtual void SetupSubTests() override;
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
+  virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+
+  /// Creates a mesh asset at the given project relative path and transforms it, so that its bounds
+  /// are recorded.
+  ezUuid CreateMeshAsset(const char* szRelativePath, ezUInt8 uiSimplification = 0, const char* szSourceFile = "Meshes/Cube.obj");
+
+  /// Copies Cube.obj to a new name, so that a test can use a source file nothing else shares.
+  /// Returns the project relative path to use as a mesh asset's MeshFile.
+  ezString MakePrivateSourceMesh(const char* szName);
+
+  void SimpleMesh();
+  void LodMesh();
+  void BoxCollider();
+  void CollisionMesh();
+  void ConvexAndDefaults();
+  void ExistingPrefab();
+  void KeepsOpenDocuments();
+  void PrefabDataDirRelativePath();
+  void MultiplePrefabs();
+  void AnimatedLodComponent();
+};

--- a/Code/UnitTests/EditorTest/Project/Project.cpp
+++ b/Code/UnitTests/EditorTest/Project/Project.cpp
@@ -4,6 +4,7 @@
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/CodeGen/CppProject.h>
 #include <EditorFramework/CodeGen/CppSettings.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Strings/StringConversion.h>
 #include <RendererCore/Components/SkyBoxComponent.h>
@@ -67,12 +68,45 @@ ezTestAppRun ezEditorTestProject::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInv
   return ezTestAppRun::Quit;
 }
 
+namespace
+{
+  /// Whether the engine process can create a document context for this type.
+  ///
+  /// The engine side gets its context types from the engine plugins that the project's plugin bundles
+  /// pull in. EditorTest links some editor plugins directly, though, so their document types are
+  /// registered even when the project selects no bundle at all. Creating such a document asserts in the
+  /// engine process and takes it down, which then fails every document after it as well.
+  bool HasEngineCounterpart(const ezDocumentTypeDescriptor* pDesc)
+  {
+    const ezStringView sManagerType = pDesc->m_pManager->GetDynamicRTTI()->GetTypeName();
+
+    for (auto it : ezQtEditorApp::GetSingleton()->GetPluginBundles().m_Plugins)
+    {
+      const ezPluginBundle& bundle = it.Value();
+
+      if (bundle.m_bSelected || bundle.m_bMandatory || bundle.m_EditorEnginePlugins.IsEmpty())
+        continue;
+
+      // The bundle's own name is what its types are named after, e.g. the 'Jolt' bundle owns
+      // ezJoltCollisionMeshAssetDocumentManager. Matching on it is enough here: a manager that is
+      // registered while its bundle is off can only have come from EditorTest linking that plugin.
+      if (sManagerType.FindSubString_NoCase(it.Key()) != nullptr)
+        return false;
+    }
+
+    return true;
+  }
+} // namespace
+
 ezTestAppRun ezEditorTestProject::CreateDocuments()
 {
   const auto& allDesc = ezDocumentManager::GetAllDocumentDescriptors();
   for (auto it : allDesc)
   {
     auto pDesc = it.Value();
+
+    if (pDesc->m_pManager != nullptr && !HasEngineCounterpart(pDesc))
+      continue;
 
     if (pDesc->m_bCanCreate)
     {

--- a/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
@@ -1409,6 +1409,26 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s == szText);
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ReadAll (Utf8 BOM)")
+  {
+    ezDefaultMemoryStreamStorage StreamStorage;
+
+    ezMemoryStreamWriter MemoryWriter(&StreamStorage);
+    ezMemoryStreamReader MemoryReader(&StreamStorage);
+
+    // written as raw bytes, so that no editor can turn the BOM into something else
+    const ezUInt8 textWithBom[] = {0xEF, 0xBB, 0xBF, '#', ' ', 'S', 'o', 'm', 'e', ' ', 'T', 'e', 'x', 't'};
+
+    MemoryWriter.WriteBytes(textWithBom, EZ_ARRAY_SIZE(textWithBom)).IgnoreResult();
+
+    ezStringBuilder s;
+    s.ReadAll(MemoryReader);
+
+    // the BOM is an encoding marker and must not show up in the content
+    EZ_TEST_BOOL(s == "# Some Text");
+    EZ_TEST_BOOL(s.StartsWith("#"));
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetSubString_FromTo")
   {
     ezStringBuilder sb = "basf";

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -1,4 +1,4 @@
-# Editor
+﻿# Editor
 
 Editor.OpenDashboard;Show Dash&board...
 Project.Open;Open Project...
@@ -118,6 +118,13 @@ Prefabs.OpenDocument;Edit Prefab...;Opens the prefab template in a separate wind
 Prefabs.Unlink;Unlink from Template;The prefab instance is turned into a regular object with no connection to the original prefab
 Prefabs.ConvertToEngine;Convert to Engine Prefab
 Prefabs.ConvertToEditor;Convert to Editor Prefab
+AssetBrowser.AssetMenu;Asset;Operations for the type of the selected asset
+
+Meshes.CreateLods;Create LODs...;Creates simplified LOD mesh assets next to this mesh, using the same import settings
+Meshes.CreateLodsDocument;Create LODs...;Creates simplified LOD mesh assets next to this mesh, using the same import settings
+
+Prefabs.CreateFromMesh;Create Prefab...;Creates a prefab that displays this mesh
+Prefabs.CreateFromMeshDocument;Create Prefab...;Creates a prefab that displays this mesh
 
 # View
 

--- a/Data/Tools/ezEditor/Localization/en/JoltPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/JoltPlugin.txt
@@ -1,4 +1,4 @@
-# Asset Types
+﻿# Asset Types
 
 Jolt_Colmesh_Convex;Jolt Convex Collision Mesh;;https://ezengine.net/pages/docs/physics/jolt/collision-shapes/jolt-collision-meshes.html
 Jolt_Colmesh_Triangle;Jolt Triangle Collision Mesh;;https://ezengine.net/pages/docs/physics/jolt/collision-shapes/jolt-collision-meshes.html
@@ -58,4 +58,7 @@ ezJoltCharacterDebugFlags::PrintState;Print Stats
 ezJoltCharacterDebugFlags::VisContacts;Visualize All Contacts
 ezJoltCharacterDebugFlags::VisFootCheck;Visualize Foot Check
 
+# Collision Meshes from Meshes
 
+Jolt.CreateColliderFromMesh;Create Collider...;Creates a Jolt collision mesh asset from this mesh asset, using the same import settings
+Jolt.CreateColliderFromMeshDocument;Create Collider...;Creates a Jolt collision mesh asset from this mesh asset, using the same import settings


### PR DESCRIPTION
Adds three creation actions, reachable from a new "Asset" sub-menu in the asset browser context menu or from inside a mesh asset document:

* Create LODs: generates simplified copies of a mesh asset.
* Create Collider: generates a Jolt triangle or convex collision mesh.
* Create Prefab: generates a prefab with a render component, optional physics and, if requested, the collision mesh to go with it.

They copy the original mesh asset's import settings over to what they create. Existing assets can be overwritten in place, which keeps their guid and therefore existing references.


The new context menu with asset specific actions:

<img width="905" height="562" alt="grafik" src="https://github.com/user-attachments/assets/628122e4-71ff-48cb-ad73-f060d01e9b7d" />


The same can be found in the mesh asset menu:

<img width="792" height="455" alt="grafik" src="https://github.com/user-attachments/assets/458a0553-6c78-425f-8dec-bdaa616296ce" />


All actions work also with multi selections.


Dialog for creating colliders:

<img width="627" height="438" alt="grafik" src="https://github.com/user-attachments/assets/98f56f7b-7b45-4160-b515-e926884ca1df" />


Dialog for creating LODs:

<img width="640" height="501" alt="grafik" src="https://github.com/user-attachments/assets/afd9201a-beae-4c97-b10f-becdd4bf4fbd" />


Dialog for creating prefabs:

<img width="542" height="440" alt="grafik" src="https://github.com/user-attachments/assets/0141d610-a8a7-466f-af97-2d786ebc2c1e" />


The actions are also directly exposed to MCP servers, so AI agents can execute them directly as well.