### PR TITLE
Fixed asset state handling issues

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserModel.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserModel.moc.h
@@ -129,6 +129,12 @@ private:
 
 private:
   void AssetCuratorEventHandler(const ezAssetCuratorEvent& e);
+
+  /// Re-runs the filter for every asset that lists the given asset among its missing dependencies.
+  /// Needed because a filter's verdict can depend on whether those dependencies resolve, which
+  /// changes when an asset is removed without any event being sent for the dependents themselves.
+  void ReEvaluateDependents(const ezUuid& removedAssetGuid);
+
   void HandleEntry(const VisibleEntry& entry, AssetOp op);
   void FileSystemFileEventHandler(const ezFileChangedEvent& e);
   void FileSystemFolderEventHandler(const ezFolderChangedEvent& e);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -154,6 +154,8 @@ void ezQtAssetBrowserModel::AssetCuratorEventHandler(const ezAssetCuratorEvent& 
 {
   switch (e.m_Type)
   {
+    case ezAssetCuratorEvent::Type::AssetAdded:
+    case ezAssetCuratorEvent::Type::AssetMoved:
     case ezAssetCuratorEvent::Type::AssetUpdated:
     {
       VisibleEntry ve;
@@ -167,6 +169,17 @@ void ezQtAssetBrowserModel::AssetCuratorEventHandler(const ezAssetCuratorEvent& 
       HandleEntry(ve, AssetOp::Updated);
       break;
     }
+    case ezAssetCuratorEvent::Type::AssetRemoved:
+    {
+      // A filter's verdict can depend on assets other than the one being filtered: the asset curator
+      // panel hides an asset whose missing dependencies all resolve to known assets, on the grounds
+      // that those are reported instead. Removing an asset can therefore change the verdict for
+      // everything that depends on it, without their own transform state changing - which means no
+      // event is sent for them. Re-evaluate those here, or they keep a stale verdict until the model
+      // is rebuilt from scratch.
+      ReEvaluateDependents(e.m_AssetGuid);
+      break;
+    }
     case ezAssetCuratorEvent::Type::AssetListReset:
     {
       m_ImportExtensions.Clear();
@@ -175,6 +188,41 @@ void ezQtAssetBrowserModel::AssetCuratorEventHandler(const ezAssetCuratorEvent& 
     }
     default:
       break;
+  }
+}
+
+void ezQtAssetBrowserModel::ReEvaluateDependents(const ezUuid& removedAssetGuid)
+{
+  ezStringBuilder sRemovedGuid;
+  ezConversionUtils::ToString(removedAssetGuid, sRemovedGuid);
+
+  ezTempHybridArray<VisibleEntry, 8> toReEvaluate;
+
+  {
+    ezAssetCurator::ezLockedAssetTable allAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownAssets();
+
+    for (auto it : *allAssetsLocked)
+    {
+      const ezAssetInfo* pAssetInfo = it.Value();
+
+      auto references = [&](const ezSet<ezString>& deps) -> bool
+      {
+        return deps.Contains(sRemovedGuid);
+      };
+
+      if (!references(pAssetInfo->m_MissingTransformDeps) && !references(pAssetInfo->m_MissingThumbnailDeps) && !references(pAssetInfo->m_MissingPackageDeps))
+        continue;
+
+      auto& ve = toReEvaluate.ExpandAndGetRef();
+      ve.m_Guid = it.Key();
+      ve.m_sAbsFilePath = pAssetInfo->m_Path;
+      ve.m_Flags = ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset;
+    }
+  }
+
+  for (const VisibleEntry& ve : toReEvaluate)
+  {
+    HandleEntry(ve, AssetOp::Updated);
   }
 }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -592,6 +592,23 @@ ezTransformStatus ezAssetCurator::TransformAsset(const ezUuid& assetGuid, ezBitf
 
     sAbsPath = pInfo->m_Path;
     res = ProcessAsset(pInfo, pAssetProfile, transformFlags);
+
+    // A manually triggered transform reports failures only through the log, leaving the transform state
+    // at whatever it was before. The asset curator panel filters on that state, so a broken asset would
+    // not be listed until something else invalidates it. Record the error here rather than in
+    // ProcessAsset, which recurses into the dependencies and would blame them for a failure of this
+    // asset. The background path does its own recording in ezAssetProcessor once the result comes back
+    // from the processor, so this only covers the manual case.
+    if (res.Failed() && transformFlags.IsSet(ezTransformFlags::TriggeredManually))
+    {
+      ezDynamicArray<ezLogEntry> logEntries;
+      auto& entry = logEntries.ExpandAndGetRef();
+      entry.m_sMsg = res.m_sMessage;
+      entry.m_Type = ezLogMsgType::ErrorMsg;
+
+      UpdateAssetTransformLog(assetGuid, logEntries);
+      UpdateAssetTransformState(assetGuid, ezAssetInfo::TransformState::TransformError);
+    }
   }
   if (pTypeDesc && transformFlags.IsAnySet(ezTransformFlags::TriggeredManually))
   {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -672,6 +672,13 @@ void ezAssetCurator::UpdateAssetTransformState(const ezUuid& assetGuid, ezAssetI
           }
         }
 
+        // Invalidating a dependent also invalidates everything that dependent transitively depends on,
+        // which can lead back to this asset. Being stale would make the update task recompute the state
+        // we just recorded, and since the error is only known to the code that ran the transform, that
+        // recomputation would silently drop it - the asset would fall back to NeedsTransform and the
+        // curator would stop reporting it. Keep the error until something actually changes on disk.
+        m_TransformStateStale.Remove(assetGuid);
+
         break;
       }
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
@@ -19,6 +19,13 @@ public:
 public:
   virtual bool IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const override;
 
+  /// Whether this asset is in a state that the curator panel reports at all.
+  static bool HasIssue(const ezSubAsset* pInfo);
+
+  /// Whether the asset's issue is only a consequence of another asset's issue, which is reported
+  /// separately. Only meaningful for assets that HasIssue() accepts.
+  static bool IsIndirectIssue(const ezSubAsset* pInfo);
+
   bool m_bFilterTransitive = true;
 };
 
@@ -44,6 +51,12 @@ private Q_SLOTS:
 private:
   void LogWriter(const ezLoggingEventData& e);
   void UpdateIssueInfo();
+  void AssetCuratorEventHandler(const ezAssetCuratorEvent& e);
+
+  /// Recounts the issues that are currently hidden as indirect and shows the number on the
+  /// 'show indirect issues' checkbox, so they are discoverable without ticking it.
+  void UpdateIndirectIssueCount();
+  void ScheduleIndirectIssueCountUpdate();
 
   /// Returns the index of the item the context menu should operate on, which is the current
   /// selection. Returns an invalid index if nothing is selected.
@@ -52,4 +65,5 @@ private:
   QSharedPointer<ezQtAssetBrowserModel> m_Model;
   ezQtAssetCuratorFilter* m_pFilter;
   QPersistentModelIndex m_SelectedIndex;
+  bool m_bIndirectCountScheduled = false;
 };

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -9,6 +9,7 @@
 #include <EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h>
 #include <GuiFoundation/Models/LogModel.moc.h>
 #include <QMenu>
+#include <QTimer>
 
 ezQtAssetCuratorFilter::ezQtAssetCuratorFilter(QObject* pParent)
   : ezQtAssetFilter(pParent)
@@ -20,47 +21,54 @@ void ezQtAssetCuratorFilter::SetFilterTransitive(bool bFilterTransitive)
   m_bFilterTransitive = bFilterTransitive;
 }
 
-bool ezQtAssetCuratorFilter::IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const
+bool ezQtAssetCuratorFilter::HasIssue(const ezSubAsset* pInfo)
 {
   if (!pInfo)
-    return true;
+    return false;
 
   if (!pInfo->m_bMainAsset)
+    return false;
+
+  const ezAssetInfo::TransformState state = pInfo->m_pAssetInfo->m_TransformState;
+
+  return state == ezAssetInfo::MissingTransformDependency || state == ezAssetInfo::CircularDependency || state == ezAssetInfo::MissingThumbnailDependency || state == ezAssetInfo::MissingPackageDependency || state == ezAssetInfo::TransformError;
+}
+
+bool ezQtAssetCuratorFilter::IsIndirectIssue(const ezSubAsset* pInfo)
+{
+  // An issue is 'indirect' when every dependency that this asset is missing resolves to an asset
+  // that the curator still knows about. Those assets are reported with their own issue, so listing
+  // everything downstream of them would only repeat the same root cause.
+  auto allDepsResolve = [](const ezSet<ezString>& deps) -> bool
+  {
+    for (const ezString& ref : deps)
+    {
+      if (!ezAssetCurator::GetSingleton()->FindSubAsset(ref).isValid())
+        return false;
+    }
+    return true;
+  };
+
+  switch (pInfo->m_pAssetInfo->m_TransformState)
+  {
+    case ezAssetInfo::MissingThumbnailDependency:
+      return allDepsResolve(pInfo->m_pAssetInfo->m_MissingThumbnailDeps);
+
+    case ezAssetInfo::MissingPackageDependency:
+      return allDepsResolve(pInfo->m_pAssetInfo->m_MissingPackageDeps);
+
+    default:
+      return false;
+  }
+}
+
+bool ezQtAssetCuratorFilter::IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const
+{
+  if (!HasIssue(pInfo))
     return true;
 
-  if ((pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingTransformDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::CircularDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingThumbnailDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingPackageDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::TransformError))
-  {
+  if (m_bFilterTransitive && IsIndirectIssue(pInfo))
     return true;
-  }
-
-  if (m_bFilterTransitive)
-  {
-    if (pInfo->m_pAssetInfo->m_TransformState == ezAssetInfo::MissingThumbnailDependency)
-    {
-      for (auto& ref : pInfo->m_pAssetInfo->m_MissingThumbnailDeps)
-      {
-        if (!ezAssetCurator::GetSingleton()->FindSubAsset(ref).isValid())
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    if (pInfo->m_pAssetInfo->m_TransformState == ezAssetInfo::MissingPackageDependency)
-    {
-      for (auto& ref : pInfo->m_pAssetInfo->m_MissingPackageDeps)
-      {
-        if (!ezAssetCurator::GetSingleton()->FindSubAsset(ref).isValid())
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-  }
 
   return false;
 }
@@ -119,8 +127,15 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
               {
                 m_SelectedIndex = QPersistentModelIndex();
                 UpdateIssueInfo();
+                UpdateIndirectIssueCount();
               }),
     "signal/slot connection failed");
+
+  // An asset can become (or stop being) an indirect issue without ever entering the list, so the
+  // model's own signals are not enough to keep the count current - listen to the curator instead.
+  ezAssetCurator::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&ezQtAssetCuratorPanel::AssetCuratorEventHandler, this));
+
+  UpdateIndirectIssueCount();
 
   EZ_VERIFY(connect(ClearHistory, &QToolButton::clicked, ProcessorProgress, &ezQtAssetProcessorProgressWidget::ClearHistory), "");
 }
@@ -128,6 +143,39 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
 ezQtAssetCuratorPanel::~ezQtAssetCuratorPanel()
 {
   ezAssetProcessor::GetSingleton()->RemoveLogWriter(ezMakeDelegate(&ezQtAssetCuratorPanel::LogWriter, this));
+  ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetCuratorPanel::AssetCuratorEventHandler, this));
+}
+
+void ezQtAssetCuratorPanel::AssetCuratorEventHandler(const ezAssetCuratorEvent& e)
+{
+  switch (e.m_Type)
+  {
+    case ezAssetCuratorEvent::Type::AssetAdded:
+    case ezAssetCuratorEvent::Type::AssetMoved:
+    case ezAssetCuratorEvent::Type::AssetRemoved:
+    case ezAssetCuratorEvent::Type::AssetUpdated:
+    case ezAssetCuratorEvent::Type::AssetListReset:
+      ScheduleIndirectIssueCountUpdate();
+      break;
+
+    default:
+      break;
+  }
+}
+
+void ezQtAssetCuratorPanel::ScheduleIndirectIssueCountUpdate()
+{
+  // Curator events arrive in bursts, so coalesce them - recounting walks all known assets.
+  if (m_bIndirectCountScheduled)
+    return;
+
+  m_bIndirectCountScheduled = true;
+
+  QTimer::singleShot(200, this, [this]()
+    {
+      m_bIndirectCountScheduled = false;
+      UpdateIndirectIssueCount(); //
+    });
 }
 
 void ezQtAssetCuratorPanel::OnAssetSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
@@ -200,6 +248,37 @@ void ezQtAssetCuratorPanel::onCheckIndirectToggled(bool checked)
 {
   m_pFilter->SetFilterTransitive(!checked);
   m_Model->resetModel();
+  UpdateIndirectIssueCount();
+}
+
+void ezQtAssetCuratorPanel::UpdateIndirectIssueCount()
+{
+  ezUInt32 uiIndirect = 0;
+
+  {
+    ezAssetCurator::ezLockedSubAssetTable allAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
+
+    for (auto it : *allAssetsLocked)
+    {
+      const ezSubAsset* pSubAsset = &it.Value();
+
+      if (ezQtAssetCuratorFilter::HasIssue(pSubAsset) && ezQtAssetCuratorFilter::IsIndirectIssue(pSubAsset))
+      {
+        ++uiIndirect;
+      }
+    }
+  }
+
+  if (uiIndirect == 0)
+  {
+    CheckIndirect->setText("Show Indirect Issues");
+  }
+  else
+  {
+    ezStringBuilder sText;
+    sText.SetFormat(uiIndirect == 1 ? "Show {} Indirect Issue" : "Show {} Indirect Issues", uiIndirect);
+    CheckIndirect->setText(ezMakeQString(sText));
+  }
 }
 
 void ezQtAssetCuratorPanel::LogWriter(const ezLoggingEventData& e)

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -164,6 +164,33 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
     ezString sLabel = pAcc->GetByName<ezString>(pSubObject, "Label");
     EZ_TEST_STRING(sLabel, "initialShadingGroup");
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Verify Failed Transform State")
+  {
+    ezTestLogInterface log;
+    ezTestLogSystemScope logSystemScope(&log, true);
+    // Once while resolving the path for the transform, once while writing the asset's dependencies.
+    log.ExpectMessage("Failed to make path absolute 'Meshes/Missing.obj'", ezLogMsgType::ErrorMsg, 2);
+
+    // Point the asset at a mesh that does not exist, so that transforming it is bound to fail.
+    pAcc->StartTransaction("Set Invalid Mesh");
+    EZ_TEST_BOOL(pAcc->SetValueByName(pMeshAsset, "MeshFile", "Meshes/Missing.obj").Succeeded());
+    pAcc->FinishTransaction();
+    EZ_TEST_BOOL(pDoc->SaveDocument().Succeeded());
+
+    const ezTransformStatus res = ezAssetCurator::GetSingleton()->TransformAsset(pDoc->GetGuid(), ezTransformFlags::ForceTransform | ezTransformFlags::TriggeredManually);
+    EZ_TEST_BOOL(res.Failed());
+    ProcessEvents();
+
+    // A failed manual transform has to leave the asset in the error state, or the asset curator panel
+    // does not list it, and it has to keep the message around, or the panel cannot say what went wrong.
+    const ezAssetCurator::ezLockedSubAsset subAsset = ezAssetCurator::GetSingleton()->GetSubAsset(pDoc->GetGuid());
+    if (EZ_TEST_BOOL(subAsset.isValid()))
+    {
+      EZ_TEST_BOOL(subAsset->m_pAssetInfo->m_TransformState == ezAssetInfo::TransformState::TransformError);
+      EZ_TEST_BOOL(!subAsset->m_pAssetInfo->m_LogEntries.IsEmpty());
+    }
+  }
   pDoc->GetDocumentManager()->CloseDocument(pDoc);
 }
 


### PR DESCRIPTION
See the two commits, which fix different issues:

The first one fixes several stale state issues of the Asset Curator. When assets changed their state (got broken), the curator often didn't properly display them, even though the widget at the bottom did show that there are broken assets. This was mainly an update issue. Similarly, when dependencies broke, the referencing asset wasn't immediately displayed at all times.

Now the curator also shows "Show N indirect issues", making it easier for users to see that there are indirect problems.

The second commit fixes #1970 and is probably a better fix than #2020.