### PR TITLE
Fix character sliding on tilted surfaces

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -728,6 +728,14 @@ void ezJoltDefaultCharacterComponent::UpdateCharacter()
     vRootVelocity -= vLatDir * fProj;
   }
 
+  // retrieve the actual up velocity
+  float groundVerticalVelocity = GetJoltCharacter()->GetGroundVelocity().GetZ();
+  if (GetJoltCharacter()->GetGroundState() == JPH::CharacterVirtual::EGroundState::OnGround // If on ground
+      && (m_fVelocityUp - groundVerticalVelocity) < 0.1f)                                   // And not moving away from ground
+  {
+    m_fVelocityUp = groundVerticalVelocity;
+  }
+
   ezVec3 vVelocityToApply = cfg.m_vVelocity + vGroundVelocity;
   vVelocityToApply += m_vVelocityLateral.GetAsVec3(0);
   vVelocityToApply += vRootVelocity;
@@ -742,14 +750,6 @@ void ezJoltDefaultCharacterComponent::UpdateCharacter()
       // TODO: sometimes the CC reports contacts with zero normals
       InteractWithSurfaces(groundContact, cfg);
     }
-  }
-
-  // retrieve the actual up velocity
-  float groundVerticalVelocity = GetJoltCharacter()->GetGroundVelocity().GetZ();
-  if (GetJoltCharacter()->GetGroundState() == JPH::CharacterVirtual::EGroundState::OnGround // If on ground
-      && (m_fVelocityUp - groundVerticalVelocity) < 0.1f)                                   // And not moving away from ground
-  {
-    m_fVelocityUp = groundVerticalVelocity;
   }
 
   if (bWasOnGround)


### PR DESCRIPTION
I found the simple solution to the problem that was brought by NicoRTX in the discord channel. 

Previously, the update order was:
1. Stick character to the ground: `m_fVelocityUp = groundVerticalVelocity;`
2. Apply gravity: `m_fVelocityUp += gravity;`
3. Move character with `m_fVelocityUp`

My change make the order slightly different:
1. Stick character to the ground: `m_fVelocityUp = groundVerticalVelocity;`
2. Move character with `m_fVelocityUp`
3. Apply gravity: `m_fVelocityUp += gravity;`

However, even with my change (or the change proposed by NicoRTX) the character still slips when landing on tilted surfaces (for example, after jumping). I can try fixing that but I don't see any robust solution without adding extra sweep tests, that I don't want to add.