### PR TITLE
Fixed material permutation variable handling + extended terrain material

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -55,26 +55,49 @@ namespace
     return EZ_FAILURE;
   }
 
+  /// Adds preprocessor defines for a permutation variable that the shader pinned to a fixed value
+  /// in its [PERMUTATIONS] section, e.g. "BLEND_MODE = BLEND_MODE_OPAQUE".
+  ///
+  /// Such a variable has no material property (it is not listed in [MATERIALPARAMETER]), so
+  /// AddDefines cannot produce its defines. Without this, a [MATERIALCONFIG] section that evaluates
+  /// the variable fails with "Undefined variable is evaluated". Enum variables also need every one
+  /// of their values defined, because the config compares against those names.
+  void AddFixedPermutationVarDefines(ezDynamicArray<ezString>& inout_defines, const ezPermutationVar& permVar)
+  {
+    ezStringBuilder sDefine;
+
+    ezStringBuilder sPath;
+    sPath.SetFormat("Shaders/PermutationVars/{0}.ezPermVar", permVar.m_sName);
+
+    ezString sAbsPath = sPath;
+    ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sAbsPath);
+
+    ezFileReader file;
+    if (file.Open(sAbsPath).Succeeded())
+    {
+      ezStringBuilder sContent;
+      sContent.ReadAll(file);
+
+      ezVariant defaultValue;
+      ezShaderParser::EnumDefinition enumDefinition;
+      ezShaderParser::ParsePermutationVarConfig(sContent, defaultValue, enumDefinition);
+
+      for (const auto& ev : enumDefinition.m_Values)
+      {
+        sDefine.SetFormat("{} {}", ev.m_sValueName, ev.m_iValueValue);
+        inout_defines.PushBack(sDefine);
+      }
+    }
+
+    sDefine.Set(permVar.m_sName.GetView(), " ", permVar.m_sValue.GetView());
+    inout_defines.PushBack(sDefine);
+  }
+
   ezResult ParseMaterialConfig(ezStringView sRelativeFileName, const ezDocumentObject* pShaderPropertyObject, ezVariantDictionary& out_materialConfig)
   {
     ezFileReader file;
     if (file.Open(sRelativeFileName).Failed())
       return EZ_FAILURE;
-
-    ezTempHybridArray<ezString, 16> defines;
-    {
-      ezTempHybridArray<const ezAbstractProperty*, 32> properties;
-      pShaderPropertyObject->GetType()->GetAllProperties(properties);
-
-      for (auto& pProp : properties)
-      {
-        const ezCategoryAttribute* pCategory = pProp->GetAttributeByType<ezCategoryAttribute>();
-        if (pCategory == nullptr || ezStringUtils::IsEqual(pCategory->GetCategory(), "Permutation") == false)
-          continue;
-
-        EZ_SUCCEED_OR_RETURN(AddDefines(defines, pShaderPropertyObject, pProp));
-      }
-    }
 
     ezString sContent;
     sContent.ReadAll(file);
@@ -82,6 +105,56 @@ namespace
     ezShaderHelper::GetShaderSections(sContent, sections);
     ezUInt32 uiFirstLine = 0;
     ezStringView sSectionContent = sections.GetSectionContent(ezShaderHelper::ezShaderSections::MATERIALCONFIG, uiFirstLine);
+
+    ezTempHybridArray<ezString, 16> defines;
+    {
+      ezTempHybridArray<const ezAbstractProperty*, 32> permutationProperties;
+      {
+        ezTempHybridArray<const ezAbstractProperty*, 32> properties;
+        pShaderPropertyObject->GetType()->GetAllProperties(properties);
+
+        for (auto& pProp : properties)
+        {
+          const ezCategoryAttribute* pCategory = pProp->GetAttributeByType<ezCategoryAttribute>();
+          if (pCategory == nullptr || ezStringUtils::IsEqual(pCategory->GetCategory(), "Permutation") == false)
+            continue;
+
+          permutationProperties.PushBack(pProp);
+        }
+      }
+
+      // Permutation variables that the shader pinned to a fixed value in [PERMUTATIONS] are not
+      // exposed as material properties, but [MATERIALCONFIG] may still evaluate them. Define those
+      // as well, skipping any that the material exposes, whose own value takes precedence.
+      {
+        ezHybridArray<ezHashedString, 16> permVars;
+        ezHybridArray<ezPermutationVar, 16> fixedPermVars;
+        ezShaderParser::ParsePermutationSection(sections.GetSectionContent(ezShaderHelper::ezShaderSections::PERMUTATIONS, uiFirstLine), permVars, fixedPermVars);
+
+        for (const auto& permVar : fixedPermVars)
+        {
+          bool bIsMaterialProperty = false;
+          for (auto& pProp : permutationProperties)
+          {
+            if (permVar.m_sName.GetView().IsEqual(pProp->GetPropertyName()))
+            {
+              bIsMaterialProperty = true;
+              break;
+            }
+          }
+
+          if (!bIsMaterialProperty)
+          {
+            AddFixedPermutationVarDefines(defines, permVar);
+          }
+        }
+      }
+
+      for (auto& pProp : permutationProperties)
+      {
+        EZ_SUCCEED_OR_RETURN(AddDefines(defines, pShaderPropertyObject, pProp));
+      }
+    }
 
     ezStringBuilder sOutput;
     EZ_SUCCEED_OR_RETURN(ezShaderParser::PreprocessSection(sSectionContent, defines, sOutput));

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -127,8 +127,8 @@ namespace
       // exposed as material properties, but [MATERIALCONFIG] may still evaluate them. Define those
       // as well, skipping any that the material exposes, whose own value takes precedence.
       {
-        ezHybridArray<ezHashedString, 16> permVars;
-        ezHybridArray<ezPermutationVar, 16> fixedPermVars;
+        ezTempHybridArray<ezHashedString, 16> permVars;
+        ezTempHybridArray<ezPermutationVar, 16> fixedPermVars;
         ezShaderParser::ParsePermutationSection(sections.GetSectionContent(ezShaderHelper::ezShaderSections::PERMUTATIONS, uiFirstLine), permVars, fixedPermVars);
 
         for (const auto& permVar : fixedPermVars)
@@ -1223,7 +1223,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
       if (bEmbedLowResData)
       {
         ezStringBuilder sFilename, sResourceName;
-        ezDynamicArray<ezUInt32> content;
+        ezTempArray<ezUInt32> content;
 
         // embed 2D texture data (not array textures - their lowres data has a different DDS structure)
         for (auto prop : Textures2D)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -45,6 +45,12 @@ namespace
   static ezHashTable<ezString, PermutationVarConfig> s_PermutationVarConfigs;
   static ezHashTable<ezString, const ezRTTI*> s_EnumTypes;
 
+  void ClearCachedTypes()
+  {
+    s_PermutationVarConfigs.Clear();
+    s_EnumTypes.Clear();
+  }
+
   const ezRTTI* GetPermutationType(const ezShaderParser::ParameterDefinition& def)
   {
     EZ_ASSERT_DEV(def.m_sType.IsEqual("Permutation"), "");
@@ -246,6 +252,22 @@ ezShaderTypeRegistry::ezShaderTypeRegistry()
   : m_SingletonRegistrar(this)
 {
   ezShaderTypeRegistry::GetSingleton();
+
+  RegisterBaseType();
+
+  ezPhantomRttiManager::s_Events.AddEventHandler(ezMakeDelegate(&ezShaderTypeRegistry::PhantomTypeRegistryEventHandler, this));
+  ezPlugin::Events().AddEventHandler(ezMakeDelegate(&ezShaderTypeRegistry::PluginEventHandler, this));
+}
+
+
+ezShaderTypeRegistry::~ezShaderTypeRegistry()
+{
+  ezPlugin::Events().RemoveEventHandler(ezMakeDelegate(&ezShaderTypeRegistry::PluginEventHandler, this));
+  ezPhantomRttiManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezShaderTypeRegistry::PhantomTypeRegistryEventHandler, this));
+}
+
+void ezShaderTypeRegistry::RegisterBaseType()
+{
   ezReflectedTypeDescriptor desc;
   desc.m_sTypeName = "ezShaderTypeBase";
   desc.m_sPluginName = "ShaderTypes";
@@ -254,14 +276,24 @@ ezShaderTypeRegistry::ezShaderTypeRegistry()
   desc.m_uiTypeVersion = 2;
 
   m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
-
-  ezPhantomRttiManager::s_Events.AddEventHandler(ezMakeDelegate(&ezShaderTypeRegistry::PhantomTypeRegistryEventHandler, this));
 }
 
-
-ezShaderTypeRegistry::~ezShaderTypeRegistry()
+void ezShaderTypeRegistry::PluginEventHandler(const ezPluginEvent& e)
 {
-  ezPhantomRttiManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezShaderTypeRegistry::PhantomTypeRegistryEventHandler, this));
+  // ezPhantomRttiManager deletes all phantom types on this event, regardless of which plugin unloads,
+  // so every cached type has to go, not just those belonging to e.m_sPluginBinary.
+  if (e.m_EventType == ezPluginEvent::Type::BeforeUnloading)
+  {
+    ClearCachedTypes();
+    m_ShaderTypes.Clear();
+    m_pBaseType = nullptr;
+  }
+
+  // This object outlives the types, so the base type has to be restored before it is used again.
+  if (e.m_EventType == ezPluginEvent::Type::AfterPluginChanges && m_pBaseType == nullptr)
+  {
+    RegisterBaseType();
+  }
 }
 
 const ezRTTI* ezShaderTypeRegistry::GetShaderType(ezStringView sShaderPath0)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.h
@@ -8,6 +8,7 @@
 #include <Foundation/Time/Timestamp.h>
 
 struct ezPhantomRttiManagerEvent;
+struct ezPluginEvent;
 
 class ezShaderTypeRegistry
 {
@@ -33,8 +34,12 @@ private:
     const ezRTTI* m_pType = nullptr;
   };
   void UpdateShaderType(ShaderData& data);
+
+  void RegisterBaseType();
   void PhantomTypeRegistryEventHandler(const ezPhantomRttiManagerEvent& e);
 
+  void PluginEventHandler(const ezPluginEvent& e);
+
   ezMap<ezString, ShaderData> m_ShaderTypes;
-  const ezRTTI* m_pBaseType;
+  const ezRTTI* m_pBaseType = nullptr;
 };

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldRenderConstants.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldRenderConstants.h
@@ -11,7 +11,7 @@ BEGIN_PUSH_CONSTANTS(HeightfieldRenderConstants)
   UINT1(VertexIdxPitch);       ///< Number of buffer entries per row.
   UINT1(CellsPerSide);         ///< Number of full-resolution quads per side. Used to map rendered cells to baked material/weight cells.
   UINT1(InstanceDataOffset);   ///< Offset into the perInstanceData buffer for this patch (used for editor picking and world transform).
-  UINT1(FallbackMaterialSlot); ///< Material slot index (0–7) used as the implicit fallback layer. Weight = max(0, 1 - w0 - w1 - w2 - w3).
+  UINT1(FallbackMaterialSlot); ///< Material slot index (0–15) used as the implicit fallback layer. Weight = max(0, 1 - w0 - w1 - w2 - w3).
   UINT1(RenderCellsPerSide);   ///< Number of rendered quads per side, including skirt rings. Drives cellIndex decode.
   UINT1(VertexStep);           ///< Stored-buffer index step between adjacent rendered vertices (2^LOD).
   UINT1(SkirtCells);           ///< Number of skirt cell rings rendered on each side (0 = no skirt).

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader
@@ -1,5 +1,9 @@
 /// Renders the heightfield terrain mesh using triplanar texture projection, blending up to four
 /// explicit material layers plus a fallback material based on baked per-vertex weights.
+///
+/// The four layers and the fallback are picked per cell out of a palette of 16 material slots.
+/// Each slot maps to two layers of the base/normal/roughness texture arrays: x for the top
+/// (Z-facing) projection, y for the side (XY-facing) projections.
 
 [PLATFORMS]
 ALL
@@ -19,10 +23,6 @@ MATERIAL_PREVIEW
 
 [MATERIALPARAMETER]
 
-Permutation BLEND_MODE;
-Permutation SHADING_MODE;
-Permutation TWO_SIDED;
-
 Texture2DArray LayerBaseTexture;
 Texture2DArray LayerNormalTexture;
 Texture2DArray LayerRoughnessTexture;
@@ -31,7 +31,6 @@ Texture2DArray LayerRoughnessTexture;
 float TextureScale @Default(0.5) @Clamp(0.001, 100.0);
 
 float RoughnessBias @Default(0.0) @Clamp(-1.0, 1.0);
-float MetallicValue @Default(0.0) @Clamp(0.0, 1.0);
 
 int2 Material0TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material1TextureIndex @Default(0) @Clamp(0, 255);
@@ -41,6 +40,14 @@ int2 Material4TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material5TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material6TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material7TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material8TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material9TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material10TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material11TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material12TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material13TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material14TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material15TextureIndex @Default(0) @Clamp(0, 255);
 
 [MATERIALCONFIG]
 
@@ -54,7 +61,6 @@ int2 Material7TextureIndex @Default(0) @Clamp(0, 255);
 
 FLOAT1(TextureScale);
 FLOAT1(RoughnessBias);
-FLOAT1(MetallicValue);
 
 INT2(Material0TextureIndex);
 INT2(Material1TextureIndex);
@@ -64,6 +70,14 @@ INT2(Material4TextureIndex);
 INT2(Material5TextureIndex);
 INT2(Material6TextureIndex);
 INT2(Material7TextureIndex);
+INT2(Material8TextureIndex);
+INT2(Material9TextureIndex);
+INT2(Material10TextureIndex);
+INT2(Material11TextureIndex);
+INT2(Material12TextureIndex);
+INT2(Material13TextureIndex);
+INT2(Material14TextureIndex);
+INT2(Material15TextureIndex);
 
 [SHADER]
 
@@ -171,13 +185,13 @@ void SampleTerrainMask()
   const float w2 = G.Input.MatWeightsHi.x;
   const float w3 = G.Input.MatWeightsHi.y;
 
-  int2 MatTextureIndices[8] = { GetMaterialData(Material0TextureIndex), GetMaterialData(Material1TextureIndex), GetMaterialData(Material2TextureIndex), GetMaterialData(Material3TextureIndex), GetMaterialData(Material4TextureIndex), GetMaterialData(Material5TextureIndex), GetMaterialData(Material6TextureIndex), GetMaterialData(Material7TextureIndex) };
+  int2 MatTextureIndices[16] = { GetMaterialData(Material0TextureIndex), GetMaterialData(Material1TextureIndex), GetMaterialData(Material2TextureIndex), GetMaterialData(Material3TextureIndex), GetMaterialData(Material4TextureIndex), GetMaterialData(Material5TextureIndex), GetMaterialData(Material6TextureIndex), GetMaterialData(Material7TextureIndex), GetMaterialData(Material8TextureIndex), GetMaterialData(Material9TextureIndex), GetMaterialData(Material10TextureIndex), GetMaterialData(Material11TextureIndex), GetMaterialData(Material12TextureIndex), GetMaterialData(Material13TextureIndex), GetMaterialData(Material14TextureIndex), GetMaterialData(Material15TextureIndex) };
 
-  G.TexIndices1 = MatTextureIndices[clamp(matIdx0, 0u, 7u)];
-  G.TexIndices2 = MatTextureIndices[clamp(matIdx1, 0u, 7u)];
-  G.TexIndices3 = MatTextureIndices[clamp(matIdx2, 0u, 7u)];
-  G.TexIndices4 = MatTextureIndices[clamp(matIdx3, 0u, 7u)];
-  G.TexIndicesFallback = MatTextureIndices[clamp(fallbackIdx, 0u, 7u)];
+  G.TexIndices1 = MatTextureIndices[clamp(matIdx0, 0u, 15u)];
+  G.TexIndices2 = MatTextureIndices[clamp(matIdx1, 0u, 15u)];
+  G.TexIndices3 = MatTextureIndices[clamp(matIdx2, 0u, 15u)];
+  G.TexIndices4 = MatTextureIndices[clamp(matIdx3, 0u, 15u)];
+  G.TexIndicesFallback = MatTextureIndices[clamp(fallbackIdx, 0u, 15u)];
 
   G.MatWeight0 = w0;
   G.MatWeight1 = w1;
@@ -273,6 +287,6 @@ float GetRoughness()
   return result + GetMaterialData(RoughnessBias);
 }
 
-float GetMetallic()    { return GetMaterialData(MetallicValue); }
+float GetMetallic()    { return 0.0f; }
 float GetReflectance() { return 0.5f; }
 float GetOpacity()     { return 1.0f; }

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/VoxelMeshMaterial.ezShader
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/VoxelMeshMaterial.ezShader
@@ -1,5 +1,9 @@
 /// Renders the voxel terrain mesh using triplanar texture projection, blending between a base
 /// material and a brush-painted override material per vertex.
+///
+/// Both materials are picked out of a palette of 16 material slots. Each slot maps to two layers
+/// of the base/normal/roughness texture arrays: x for the top (Z-facing) projection, y for the
+/// side (XY-facing) projections.
 
 [PLATFORMS]
 ALL
@@ -19,10 +23,6 @@ MATERIAL_PREVIEW
 
 [MATERIALPARAMETER]
 
-Permutation BLEND_MODE;
-Permutation SHADING_MODE;
-Permutation TWO_SIDED;
-
 Texture2DArray LayerBaseTexture;
 Texture2DArray LayerNormalTexture;
 Texture2DArray LayerRoughnessTexture;
@@ -31,7 +31,6 @@ Texture2DArray LayerRoughnessTexture;
 float TextureScale @Default(0.5) @Clamp(0.001, 100.0);
 
 float RoughnessBias @Default(0.0) @Clamp(-1.0, 1.0);
-float MetallicValue  @Default(0.0) @Clamp(0.0, 1.0);
 
 int2 Material0TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material1TextureIndex @Default(0) @Clamp(0, 255);
@@ -41,6 +40,14 @@ int2 Material4TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material5TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material6TextureIndex @Default(0) @Clamp(0, 255);
 int2 Material7TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material8TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material9TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material10TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material11TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material12TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material13TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material14TextureIndex @Default(0) @Clamp(0, 255);
+int2 Material15TextureIndex @Default(0) @Clamp(0, 255);
 
 [MATERIALCONFIG]
 
@@ -54,7 +61,6 @@ int2 Material7TextureIndex @Default(0) @Clamp(0, 255);
 
 FLOAT1(TextureScale);
 FLOAT1(RoughnessBias);
-FLOAT1(MetallicValue);
 
 INT2(Material0TextureIndex);
 INT2(Material1TextureIndex);
@@ -64,6 +70,14 @@ INT2(Material4TextureIndex);
 INT2(Material5TextureIndex);
 INT2(Material6TextureIndex);
 INT2(Material7TextureIndex);
+INT2(Material8TextureIndex);
+INT2(Material9TextureIndex);
+INT2(Material10TextureIndex);
+INT2(Material11TextureIndex);
+INT2(Material12TextureIndex);
+INT2(Material13TextureIndex);
+INT2(Material14TextureIndex);
+INT2(Material15TextureIndex);
 
 [SHADER]
 
@@ -129,8 +143,8 @@ SamplerState LayerRoughnessTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
 
 uint2 LookupTexIndices(uint matSlot)
 {
-  int2 MatTextureIndices[8] = { GetMaterialData(Material0TextureIndex), GetMaterialData(Material1TextureIndex), GetMaterialData(Material2TextureIndex), GetMaterialData(Material3TextureIndex), GetMaterialData(Material4TextureIndex), GetMaterialData(Material5TextureIndex), GetMaterialData(Material6TextureIndex), GetMaterialData(Material7TextureIndex) };
-  return MatTextureIndices[clamp(matSlot, 0u, 7u)];
+  int2 MatTextureIndices[16] = { GetMaterialData(Material0TextureIndex), GetMaterialData(Material1TextureIndex), GetMaterialData(Material2TextureIndex), GetMaterialData(Material3TextureIndex), GetMaterialData(Material4TextureIndex), GetMaterialData(Material5TextureIndex), GetMaterialData(Material6TextureIndex), GetMaterialData(Material7TextureIndex), GetMaterialData(Material8TextureIndex), GetMaterialData(Material9TextureIndex), GetMaterialData(Material10TextureIndex), GetMaterialData(Material11TextureIndex), GetMaterialData(Material12TextureIndex), GetMaterialData(Material13TextureIndex), GetMaterialData(Material14TextureIndex), GetMaterialData(Material15TextureIndex) };
+  return MatTextureIndices[clamp(matSlot, 0u, 15u)];
 }
 
 void FillCustomGlobals()
@@ -187,6 +201,6 @@ float GetRoughness()
   return lerp(mainRoughness, overrideRoughness, matStrength) + GetMaterialData(RoughnessBias);
 }
 
-float  GetMetallic()    { return GetMaterialData(MetallicValue); }
+float  GetMetallic()    { return 0.0f; }
 float  GetReflectance() { return 0.5f; }
 float  GetOpacity()     { return 1.0f; }

--- a/Data/Samples/Testing Chambers/Materials/HeightfieldTerrain.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/HeightfieldTerrain.ezMaterialAsset
@@ -14,7 +14,7 @@ o
 			s{"Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader"}
 		}
 		Uuid %DocumentID{u4{2939980432966898598,5123535222320404264}}
-		u4 %Hash{1706203791133551815}
+		u4 %Hash{2175574400443948647}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -44,11 +44,16 @@ o
 	u3 %v{2}
 	p
 	{
-		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_OPAQUE"}
 		s %LayerBaseTexture{"{ c658f867-d3f8-43a8-b32d-55326fac60b8 }"}
 		s %LayerNormalTexture{"{ 6ce1da02-2df2-45b2-b832-05f2ca1c58b0 }"}
 		s %LayerRoughnessTexture{"{ fad8ea85-dca7-471c-8ed2-2aa362a6e98a }"}
 		Vec2i %Material0TextureIndex{i3{0,3}}
+		Vec2i %Material10TextureIndex{i3{0,0}}
+		Vec2i %Material11TextureIndex{i3{0,0}}
+		Vec2i %Material12TextureIndex{i3{0,0}}
+		Vec2i %Material13TextureIndex{i3{0,0}}
+		Vec2i %Material14TextureIndex{i3{0,0}}
+		Vec2i %Material15TextureIndex{i3{0,0}}
 		Vec2i %Material1TextureIndex{i3{1,1}}
 		Vec2i %Material2TextureIndex{i3{2,2}}
 		Vec2i %Material3TextureIndex{i3{3,3}}
@@ -56,10 +61,9 @@ o
 		Vec2i %Material5TextureIndex{i3{5,5}}
 		Vec2i %Material6TextureIndex{i3{0,0}}
 		Vec2i %Material7TextureIndex{i3{0,0}}
-		f %MetallicValue{0}
+		Vec2i %Material8TextureIndex{i3{0,0}}
+		Vec2i %Material9TextureIndex{i3{0,0}}
 		f %RoughnessBias{0x9A99993E}
-		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_LIT"}
-		b %TWO_SIDED{0}
 		f %TextureScale{0x0000803E}
 	}
 }
@@ -97,12 +101,24 @@ Types
 {
 o
 {
+	Uuid %id{u4{7369592584561371515,150400655728789348}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
+	}
+}
+o
+{
 	Uuid %id{u4{9205541992466402666,186874392873755262}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %Category{"Texture 2D Array"}
+		s %Category{"Constant"}
 	}
 }
 o
@@ -112,12 +128,23 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Texture 2D Array"}
+		s %Category{"Constant"}
 	}
 }
 o
 {
 	Uuid %id{u4{7375760425615014769,776814191830295447}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13750787062836360912,820090670570344089}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
@@ -137,12 +164,33 @@ o
 		{
 			Uuid{u4{7250675865458471679,14531238039950568399}}
 			Uuid{u4{9913575226874912632,15347216907554822691}}
+			Uuid{u4{14248664697253576779,2873200965269304292}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"LayerRoughnessTexture"}
-		s %Type{"ezString"}
+		s %Name{"Material0TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1066227368750480836,1319258971650982774}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1605908775964868477,1462251756029799288}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
 	}
 }
 o
@@ -161,61 +209,38 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material0TextureIndex"}
+		s %Name{"Material4TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{8990274543164517455,1581340151129969481}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{15980385534437764467,5641556142405670149}}
+			Uuid{u4{13439113526215659173,9459423013571879690}}
+			Uuid{u4{8786693610079593513,4230286972836487770}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material14TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
 o
 {
 	Uuid %id{u4{8820087521711943202,1773338324845188565}}
-	s %t{"ezAssetBrowserAttribute"}
+	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
-		s %Filter{";CompatibleAsset_Texture_2D;"}
-		s %RequiredTag{""}
-	}
-}
-o
-{
-	Uuid %id{u4{18311245008988910186,1895067994934075466}}
-	s %t{"ezReflectedTypeDescriptor"}
-	u3 %v{1}
-	p
-	{
-		VarArray %Attributes{}
-		s %Flags{"ezTypeFlags::IsEnum"}
-		VarArray %Functions{}
-		s %ParentTypeName{"ezEnumBase"}
-		s %PluginName{"ShaderTypes"}
-		VarArray %Properties
-		{
-			Uuid{u4{773668148553828920,15966949596821666881}}
-			Uuid{u4{540429536914844576,8213819539779215949}}
-			Uuid{u4{15543418230834458689,5548684801941186544}}
-			Uuid{u4{16393153594407016602,3744118329769567614}}
-			Uuid{u4{7757084663128585029,8011669779036733373}}
-			Uuid{u4{5650026407490086663,5768478847879086899}}
-			Uuid{u4{3687164412847300807,16605290275319987562}}
-		}
-		s %TypeName{"BLEND_MODE"}
-		u3 %TypeVersion{1}
-	}
-}
-o
-{
-	Uuid %id{u4{9182498974977327514,2041274447054354959}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
-		s %Type{"ezInt32"}
+		d %Value{0x000000000000E03F}
 	}
 }
 o
@@ -241,6 +266,17 @@ o
 }
 o
 {
+	Uuid %id{u4{14248664697253576779,2873200965269304292}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
 	Uuid %id{u4{6098724890029632441,2909460956273632158}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -249,12 +285,13 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{13190717143765194437,8548150097298246046}}
+			Uuid{u4{5464329951760534644,12906048599693856869}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::IsEnum"}
-		s %Name{"BLEND_MODE"}
-		s %Type{"BLEND_MODE"}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"LayerBaseTexture"}
+		s %Type{"ezString"}
 	}
 }
 o
@@ -264,7 +301,7 @@ o
 	u3 %v{1}
 	p
 	{
-		d %Value{0}
+		i4 %Value{0}
 	}
 }
 o
@@ -289,27 +326,23 @@ o
 }
 o
 {
-	Uuid %id{u4{16393153594407016602,3744118329769567614}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{2}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_DITHERED"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{14482027418197774581,3897157559427934700}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
 	p
 	{
 		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{8786693610079593513,4230286972836487770}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -328,7 +361,27 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material5TextureIndex"}
+		s %Name{"Material9TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{16958132923163242020,4502293605212118720}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1605908775964868477,1462251756029799288}}
+			Uuid{u4{1066227368750480836,1319258971650982774}}
+			Uuid{u4{13750787062836360912,820090670570344089}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material15TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -369,38 +422,38 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"TextureScale"}
-		s %Type{"float"}
+		s %Name{"Material1TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
 {
-	Uuid %id{u4{15543418230834458689,5548684801941186544}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
+	Uuid %id{u4{15980385534437764467,5641556142405670149}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
 	p
 	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{1}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
-		s %Type{"ezInt32"}
+		s %Category{"Constant"}
 	}
 }
 o
 {
-	Uuid %id{u4{5650026407490086663,5768478847879086899}}
+	Uuid %id{u4{13230568613233192648,5839213481211360139}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
 	p
 	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{4}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
-		s %Type{"ezInt32"}
+		VarArray %Attributes
+		{
+			Uuid{u4{14680370327792306434,9514339943453094358}}
+			Uuid{u4{7257163787433436343,15584596201258965567}}
+			Uuid{u4{10891478436022773169,14252926653781148477}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material12TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -410,8 +463,8 @@ o
 	u3 %v{1}
 	p
 	{
-		d %Max{0x000000000000F03F}
-		d %Min{0}
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -441,30 +494,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material1TextureIndex"}
+		s %Name{"Material5TextureIndex"}
 		s %Type{"ezVec2I32"}
-	}
-}
-o
-{
-	Uuid %id{u4{11695727463527673381,6549777581474058039}}
-	s %t{"ezReflectedTypeDescriptor"}
-	u3 %v{1}
-	p
-	{
-		VarArray %Attributes{}
-		s %Flags{"ezTypeFlags::IsEnum"}
-		VarArray %Functions{}
-		s %ParentTypeName{"ezEnumBase"}
-		s %PluginName{"ShaderTypes"}
-		VarArray %Properties
-		{
-			Uuid{u4{1155205217496153151,16062411953539633064}}
-			Uuid{u4{9182498974977327514,2041274447054354959}}
-			Uuid{u4{14201946371216656691,8983156218640221597}}
-		}
-		s %TypeName{"SHADING_MODE"}
-		u3 %TypeVersion{1}
 	}
 }
 o
@@ -498,9 +529,23 @@ o
 			Uuid{u4{4772713794504437043,4317036598946666318}}
 			Uuid{u4{13743590550702643666,8241007314466480953}}
 			Uuid{u4{14836032075756677554,10980740147446260452}}
+			Uuid{u4{13230568613233192648,5839213481211360139}}
+			Uuid{u4{16331638923269598771,9456887736781520849}}
+			Uuid{u4{8990274543164517455,1581340151129969481}}
+			Uuid{u4{16958132923163242020,4502293605212118720}}
 		}
 		s %TypeName{"Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader"}
 		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{3735683366774608117,6998081870867814184}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
 	}
 }
 o
@@ -510,8 +555,8 @@ o
 	u3 %v{1}
 	p
 	{
-		d %Max{0x0000000000005940}
-		d %Min{0xFCA9F1D24D62503F}
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -537,42 +582,12 @@ o
 }
 o
 {
-	Uuid %id{u4{7757084663128585029,8011669779036733373}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{3}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{4273985487277802153,8188963493360447760}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		d %Value{0}
-	}
-}
-o
-{
-	Uuid %id{u4{540429536914844576,8213819539779215949}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
-		s %Type{"ezInt32"}
+		i4 %Value{0}
 	}
 }
 o
@@ -591,7 +606,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material6TextureIndex"}
+		s %Name{"Material10TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -611,8 +626,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"MetallicValue"}
-		s %Type{"float"}
+		s %Name{"Material3TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -622,7 +637,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Permutation"}
+		s %Category{"Texture 2D Array"}
 	}
 }
 o
@@ -663,12 +678,13 @@ o
 		{
 			Uuid{u4{9205541992466402666,186874392873755262}}
 			Uuid{u4{8820087521711943202,1773338324845188565}}
+			Uuid{u4{17749391292166086983,15577698135042086177}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"LayerBaseTexture"}
-		s %Type{"ezString"}
+		s %Name{"TextureScale"}
+		s %Type{"float"}
 	}
 }
 o
@@ -687,23 +703,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material2TextureIndex"}
+		s %Name{"Material6TextureIndex"}
 		s %Type{"ezVec2I32"}
-	}
-}
-o
-{
-	Uuid %id{u4{14201946371216656691,8983156218640221597}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{1}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
-		s %Type{"ezInt32"}
 	}
 }
 o
@@ -725,14 +726,52 @@ o
 }
 o
 {
-	Uuid %id{u4{5957660404394561304,9515383668883416018}}
-	s %t{"ezAssetBrowserAttribute"}
+	Uuid %id{u4{16331638923269598771,9456887736781520849}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1381642236215340416,16274513656586865346}}
+			Uuid{u4{3735683366774608117,6998081870867814184}}
+			Uuid{u4{12049119814056973222,11983665463147157347}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material13TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{13439113526215659173,9459423013571879690}}
+	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
-		s %Filter{";CompatibleAsset_Texture_2D;"}
-		s %RequiredTag{""}
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14680370327792306434,9514339943453094358}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{5957660404394561304,9515383668883416018}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0}
 	}
 }
 o
@@ -745,12 +784,13 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{16907322887811790051,13687322136943272676}}
+			Uuid{u4{4251194945262961408,11821115039431085430}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::IsEnum"}
-		s %Name{"SHADING_MODE"}
-		s %Type{"SHADING_MODE"}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"LayerNormalTexture"}
+		s %Type{"ezString"}
 	}
 }
 o
@@ -760,7 +800,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Permutation"}
+		s %Category{"Texture 2D Array"}
 	}
 }
 o
@@ -779,7 +819,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material7TextureIndex"}
+		s %Name{"Material11TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -794,12 +834,13 @@ o
 		{
 			Uuid{u4{16890735475343751395,438795542531386630}}
 			Uuid{u4{5957660404394561304,9515383668883416018}}
+			Uuid{u4{5916727006005447353,16807514780976745976}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"LayerNormalTexture"}
-		s %Type{"ezString"}
+		s %Name{"RoughnessBias"}
+		s %Type{"float"}
 	}
 }
 o
@@ -825,6 +866,18 @@ o
 }
 o
 {
+	Uuid %id{u4{4251194945262961408,11821115039431085430}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
+	}
+}
+o
+{
 	Uuid %id{u4{3331401452160560417,11930522611801557628}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -833,12 +886,24 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{499319436976392232,9853897765426303500}}
+			Uuid{u4{7369592584561371515,150400655728789348}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"TWO_SIDED"}
-		s %Type{"bool"}
+		s %Name{"LayerRoughnessTexture"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{12049119814056973222,11983665463147157347}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -857,8 +922,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"RoughnessBias"}
-		s %Type{"float"}
+		s %Name{"Material2TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -869,6 +934,18 @@ o
 	p
 	{
 		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{5464329951760534644,12906048599693856869}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
 	}
 }
 o
@@ -888,7 +965,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Permutation"}
+		s %Category{"Texture 2D Array"}
 	}
 }
 o
@@ -898,7 +975,18 @@ o
 	u3 %v{1}
 	p
 	{
-		d %Value{0x000000000000E03F}
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10891478436022773169,14252926653781148477}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -908,7 +996,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Texture 2D Array"}
+		s %Category{"Constant"}
 	}
 }
 o
@@ -951,13 +1039,32 @@ o
 o
 {
 	Uuid %id{u4{9913575226874912632,15347216907554822691}}
-	s %t{"ezAssetBrowserAttribute"}
+	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
-		s %Filter{";CompatibleAsset_Texture_2D;"}
-		s %RequiredTag{""}
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17749391292166086983,15577698135042086177}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Max{0x0000000000005940}
+		d %Min{0xFCA9F1D24D62503F}
+	}
+}
+o
+{
+	Uuid %id{u4{7257163787433436343,15584596201258965567}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
 	}
 }
 o
@@ -983,37 +1090,17 @@ o
 }
 o
 {
-	Uuid %id{u4{773668148553828920,15966949596821666881}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		u3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::Default"}
-		s %Type{"ezUInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{1155205217496153151,16062411953539633064}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		u3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"SHADING_MODE::Default"}
-		s %Type{"ezUInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{14297226360694353542,16207531894137367306}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{1381642236215340416,16274513656586865346}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
 	p
@@ -1043,17 +1130,13 @@ o
 }
 o
 {
-	Uuid %id{u4{3687164412847300807,16605290275319987562}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
+	Uuid %id{u4{5916727006005447353,16807514780976745976}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
 	p
 	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{5}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
-		s %Type{"ezInt32"}
+		d %Max{0x000000000000F03F}
+		d %Min{0x000000000000F0BF}
 	}
 }
 o
@@ -1073,8 +1156,8 @@ o
 	u3 %v{1}
 	p
 	{
-		d %Max{0x000000000000F03F}
-		d %Min{0x000000000000F0BF}
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -1093,7 +1176,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material4TextureIndex"}
+		s %Name{"Material8TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -1161,7 +1244,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material3TextureIndex"}
+		s %Name{"Material7TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }

--- a/Data/Samples/Testing Chambers/Materials/TerrainTexture.ezTextureAsset
+++ b/Data/Samples/Testing Chambers/Materials/TerrainTexture.ezTextureAsset
@@ -19,7 +19,7 @@ o
 			s{"Textures/cc0Textures.com/Rock01/Rock01_col.jpg"}
 		}
 		Uuid %DocumentID{u4{13285808494328753587,4875379662061631591}}
-		u4 %Hash{6389783012512281142}
+		u4 %Hash{15339336046977523516}
 		VarArray %MetaInfo{}
 		VarArray %Outputs
 		{
@@ -45,13 +45,14 @@ o
 {
 	Uuid %id{u4{15109180656962947499,5567490920422787347}}
 	s %t{"ezTextureAssetProperties"}
-	u3 %v{5}
+	u3 %v{6}
 	p
 	{
 		s %AddressModeU{"ezImageAddressMode::Repeat"}
 		s %AddressModeV{"ezImageAddressMode::Repeat"}
 		s %AddressModeW{"ezImageAddressMode::Repeat"}
 		f %AlphaThreshold{0x0000003F}
+		s %ArrayChannelMapping{"ezTextureArrayChannelMappingEnum::RGB"}
 		VarArray %ArraySlices
 		{
 			s{"Textures/cc0Textures.com/Ground03/Ground03_col.jpg"}
@@ -130,7 +131,7 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezTextureAssetProperties"}
-		u3 %TypeVersion{5}
+		u3 %TypeVersion{6}
 	}
 }
 o
@@ -164,6 +165,23 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezRenderTargetFormat"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4439624141160076334,7137082278828783315}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezTextureArrayChannelMappingEnum"}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Samples/Testing Chambers/Materials/TerrainTextureN.ezTextureAsset
+++ b/Data/Samples/Testing Chambers/Materials/TerrainTextureN.ezTextureAsset
@@ -19,7 +19,7 @@ o
 			s{"Textures/cc0Textures.com/Rock01/Rock01_nrm.jpg"}
 		}
 		Uuid %DocumentID{u4{12706938006595252920,5022127053703600642}}
-		u4 %Hash{9219218954820758100}
+		u4 %Hash{5907443088171827281}
 		VarArray %MetaInfo{}
 		VarArray %Outputs
 		{
@@ -45,13 +45,14 @@ o
 {
 	Uuid %id{u4{14530310169229446832,5714238312064756398}}
 	s %t{"ezTextureAssetProperties"}
-	u3 %v{5}
+	u3 %v{6}
 	p
 	{
 		s %AddressModeU{"ezImageAddressMode::Repeat"}
 		s %AddressModeV{"ezImageAddressMode::Repeat"}
 		s %AddressModeW{"ezImageAddressMode::Repeat"}
 		f %AlphaThreshold{0x0000003F}
+		s %ArrayChannelMapping{"ezTextureArrayChannelMappingEnum::RGBA"}
 		VarArray %ArraySlices
 		{
 			s{"Textures/cc0Textures.com/Ground03/Ground03_nrm.jpg"}
@@ -130,7 +131,7 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezTextureAssetProperties"}
-		u3 %TypeVersion{5}
+		u3 %TypeVersion{6}
 	}
 }
 o
@@ -164,6 +165,23 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezRenderTargetFormat"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4439624141160076334,7137082278828783315}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezTextureArrayChannelMappingEnum"}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Samples/Testing Chambers/Materials/TerrainTextureR.ezTextureAsset
+++ b/Data/Samples/Testing Chambers/Materials/TerrainTextureR.ezTextureAsset
@@ -19,7 +19,7 @@ o
 			s{"Textures/cc0Textures.com/Rock01/Rock01_rgh.jpg"}
 		}
 		Uuid %DocumentID{u4{10009714589382136462,5124213090066950789}}
-		u4 %Hash{2304940491507891292}
+		u4 %Hash{7852327512529996502}
 		VarArray %MetaInfo{}
 		VarArray %Outputs
 		{
@@ -45,13 +45,14 @@ o
 {
 	Uuid %id{u4{11833086752016330374,5816324348428106545}}
 	s %t{"ezTextureAssetProperties"}
-	u3 %v{5}
+	u3 %v{6}
 	p
 	{
 		s %AddressModeU{"ezImageAddressMode::Repeat"}
 		s %AddressModeV{"ezImageAddressMode::Repeat"}
 		s %AddressModeW{"ezImageAddressMode::Repeat"}
 		f %AlphaThreshold{0x0000003F}
+		s %ArrayChannelMapping{"ezTextureArrayChannelMappingEnum::R_Red"}
 		VarArray %ArraySlices
 		{
 			s{"Textures/cc0Textures.com/Ground03/Ground03_rgh.jpg"}
@@ -130,7 +131,7 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezTextureAssetProperties"}
-		u3 %TypeVersion{5}
+		u3 %TypeVersion{6}
 	}
 }
 o
@@ -164,6 +165,23 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezRenderTargetFormat"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4439624141160076334,7137082278828783315}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezTextureArrayChannelMappingEnum"}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Samples/Testing Chambers/Materials/VoxelTerrain.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/VoxelTerrain.ezMaterialAsset
@@ -43,7 +43,6 @@ o
 	u3 %v{2}
 	p
 	{
-		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_OPAQUE"}
 		s %LayerBaseTexture{"{ c658f867-d3f8-43a8-b32d-55326fac60b8 }"}
 		s %LayerNormalTexture{"{ 6ce1da02-2df2-45b2-b832-05f2ca1c58b0 }"}
 		s %LayerRoughnessTexture{"{ fad8ea85-dca7-471c-8ed2-2aa362a6e98a }"}
@@ -55,10 +54,16 @@ o
 		Vec2i %Material5TextureIndex{i3{5,5}}
 		Vec2i %Material6TextureIndex{i3{0,0}}
 		Vec2i %Material7TextureIndex{i3{0,0}}
-		f %MetallicValue{0}
+		Vec2i %Material8TextureIndex{i3{0,0}}
+		Vec2i %Material9TextureIndex{i3{0,0}}
+		Vec2i %Material10TextureIndex{i3{0,0}}
+		Vec2i %Material11TextureIndex{i3{0,0}}
+		Vec2i %Material12TextureIndex{i3{0,0}}
+		Vec2i %Material13TextureIndex{i3{0,0}}
+		Vec2i %Material14TextureIndex{i3{0,0}}
+		Vec2i %Material15TextureIndex{i3{0,0}}
 		f %RoughnessBias{0x9A99993E}
 		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_LIT"}
-		b %TWO_SIDED{0}
 		f %TextureScale{0x0000803E}
 	}
 }
@@ -166,16 +171,6 @@ o
 }
 o
 {
-	Uuid %id{u4{1332604799681178783,1405895461207218641}}
-	s %t{"ezCategoryAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %Category{"Constant"}
-	}
-}
-o
-{
 	Uuid %id{u4{17827115875410736488,1585316841407967011}}
 	s %t{"ezAssetBrowserAttribute"}
 	u3 %v{1}
@@ -198,50 +193,6 @@ o
 }
 o
 {
-	Uuid %id{u4{9141801701097690514,1818856055331208923}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes
-		{
-			Uuid{u4{5464294602639393665,14334231704114327318}}
-		}
-		s %Category{"ezPropertyCategory::Member"}
-		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::IsEnum"}
-		s %Name{"BLEND_MODE"}
-		s %Type{"BLEND_MODE"}
-	}
-}
-o
-{
-	Uuid %id{u4{18311245008988910186,1895067994934075466}}
-	s %t{"ezReflectedTypeDescriptor"}
-	u3 %v{1}
-	p
-	{
-		VarArray %Attributes{}
-		s %Flags{"ezTypeFlags::IsEnum"}
-		VarArray %Functions{}
-		s %ParentTypeName{"ezEnumBase"}
-		s %PluginName{"ShaderTypes"}
-		VarArray %Properties
-		{
-			Uuid{u4{773668148553828920,15966949596821666881}}
-			Uuid{u4{540429536914844576,8213819539779215949}}
-			Uuid{u4{15543418230834458689,5548684801941186544}}
-			Uuid{u4{16393153594407016602,3744118329769567614}}
-			Uuid{u4{7757084663128585029,8011669779036733373}}
-			Uuid{u4{5650026407490086663,5768478847879086899}}
-			Uuid{u4{3687164412847300807,16605290275319987562}}
-		}
-		s %TypeName{"BLEND_MODE"}
-		u3 %TypeVersion{1}
-	}
-}
-o
-{
 	Uuid %id{u4{9182498974977327514,2041274447054354959}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -253,16 +204,6 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
 		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
 		s %Type{"ezInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{17034071263459828052,2782400576322051984}}
-	s %t{"ezDefaultValueAttribute"}
-	u3 %v{1}
-	p
-	{
-		d %Value{0}
 	}
 }
 o
@@ -318,21 +259,6 @@ o
 }
 o
 {
-	Uuid %id{u4{16393153594407016602,3744118329769567614}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{2}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_DITHERED"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{12112946480051241324,3795555419550579250}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -366,15 +292,12 @@ o
 		s %PluginName{"ShaderTypes"}
 		VarArray %Properties
 		{
-			Uuid{u4{9141801701097690514,1818856055331208923}}
 			Uuid{u4{5409814580796781886,9344055732743872460}}
-			Uuid{u4{10517831128859966838,11064712143935259415}}
 			Uuid{u4{8386681320953369572,12688127805794414923}}
 			Uuid{u4{179742440666354457,17903336386926422362}}
 			Uuid{u4{13247499607119692227,13764209986341690084}}
 			Uuid{u4{16879779125206579807,8442529159388631379}}
 			Uuid{u4{12478590686938027661,3137944321073572663}}
-			Uuid{u4{15547607822254496538,12025531138140177057}}
 			Uuid{u4{4311101479583114583,7312508370627651311}}
 			Uuid{u4{8910883084663966805,12276956813076541887}}
 			Uuid{u4{9228808152319478384,18132029967726531422}}
@@ -383,6 +306,14 @@ o
 			Uuid{u4{4255544553178940297,6255077598196679847}}
 			Uuid{u4{17405378268953882008,17077458338079794624}}
 			Uuid{u4{9302531237010587327,5429675742070542429}}
+			Uuid{u4{10212883319673636072,7029469995950341828}}
+			Uuid{u4{76082036060030549,3660305747601881661}}
+			Uuid{u4{2645348481233393686,6973033915625428822}}
+			Uuid{u4{13552043609910101118,3749773338159862549}}
+			Uuid{u4{800914498052136125,9542732694053571525}}
+			Uuid{u4{9077212426297071627,2584903012117368631}}
+			Uuid{u4{1414690500036783875,6125538913279429156}}
+			Uuid{u4{13139045096448405432,473073687436901809}}
 		}
 		s %TypeName{"Shaders/Terrain/Rendering/VoxelMeshMaterial.ezShader"}
 		u3 %TypeVersion{2}
@@ -443,36 +374,6 @@ o
 }
 o
 {
-	Uuid %id{u4{15543418230834458689,5548684801941186544}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{1}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{5650026407490086663,5768478847879086899}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{4}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{7271999579057768383,5840349001256652528}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
@@ -525,16 +426,6 @@ o
 }
 o
 {
-	Uuid %id{u4{13273282671864098690,7073242134369230105}}
-	s %t{"ezCategoryAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %Category{"Permutation"}
-	}
-}
-o
-{
 	Uuid %id{u4{4311101479583114583,7312508370627651311}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -562,36 +453,6 @@ o
 	{
 		i4 %Max{255}
 		i4 %Min{0}
-	}
-}
-o
-{
-	Uuid %id{u4{7757084663128585029,8011669779036733373}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{3}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{540429536914844576,8213819539779215949}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
-		s %Type{"ezInt32"}
 	}
 }
 o
@@ -713,24 +574,6 @@ o
 }
 o
 {
-	Uuid %id{u4{10517831128859966838,11064712143935259415}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes
-		{
-			Uuid{u4{13273282671864098690,7073242134369230105}}
-		}
-		s %Category{"ezPropertyCategory::Member"}
-		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"TWO_SIDED"}
-		s %Type{"bool"}
-	}
-}
-o
-{
 	Uuid %id{u4{11895449017445965276,11733598302241216248}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -758,26 +601,6 @@ o
 	p
 	{
 		i4 %Value{0}
-	}
-}
-o
-{
-	Uuid %id{u4{15547607822254496538,12025531138140177057}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes
-		{
-			Uuid{u4{1332604799681178783,1405895461207218641}}
-			Uuid{u4{17034071263459828052,2782400576322051984}}
-			Uuid{u4{381769352279539939,12800711645150781831}}
-		}
-		s %Category{"ezPropertyCategory::Member"}
-		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"MetallicValue"}
-		s %Type{"float"}
 	}
 }
 o
@@ -838,17 +661,6 @@ o
 		s %Flags{"ezPropertyFlags::StandardType"}
 		s %Name{"LayerBaseTexture"}
 		s %Type{"ezString"}
-	}
-}
-o
-{
-	Uuid %id{u4{381769352279539939,12800711645150781831}}
-	s %t{"ezClampValueAttribute"}
-	u3 %v{1}
-	p
-	{
-		d %Max{0x000000000000F03F}
-		d %Min{0}
 	}
 }
 o
@@ -923,16 +735,6 @@ o
 }
 o
 {
-	Uuid %id{u4{5464294602639393665,14334231704114327318}}
-	s %t{"ezCategoryAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %Category{"Permutation"}
-	}
-}
-o
-{
 	Uuid %id{u4{16608059164795256034,14788482193739877470}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -981,21 +783,6 @@ o
 }
 o
 {
-	Uuid %id{u4{773668148553828920,15966949596821666881}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		u3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::Default"}
-		s %Type{"ezUInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{1155205217496153151,16062411953539633064}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -1028,21 +815,6 @@ o
 	p
 	{
 		s %Category{"Constant"}
-	}
-}
-o
-{
-	Uuid %id{u4{3687164412847300807,16605290275319987562}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{5}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
-		s %Type{"ezInt32"}
 	}
 }
 o
@@ -1196,6 +968,414 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezMaterialAssetProperties"}
 		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{18042325484223757135,5862705070969500806}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{9663793821948878134,862348967985430176}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3730227124365795850,2558839702142284096}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10212883319673636072,7029469995950341828}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{18042325484223757135,5862705070969500806}}
+			Uuid{u4{9663793821948878134,862348967985430176}}
+			Uuid{u4{3730227124365795850,2558839702142284096}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material8TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17312179767623694049,10038198936038417573}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{3721130130712249746,8818287051630490505}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16884958509034200730,5681790450358835259}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{76082036060030549,3660305747601881661}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{17312179767623694049,10038198936038417573}}
+			Uuid{u4{3721130130712249746,8818287051630490505}}
+			Uuid{u4{16884958509034200730,5681790450358835259}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material9TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{12600807374668556836,8197303546792525109}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{10071845598845767538,1843145643046501987}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17779853608185678103,7880870594059778336}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2645348481233393686,6973033915625428822}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12600807374668556836,8197303546792525109}}
+			Uuid{u4{10071845598845767538,1843145643046501987}}
+			Uuid{u4{17779853608185678103,7880870594059778336}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material10TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{9598746007369957913,17324662343394273616}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{15058804141421608648,4348703227184878970}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{12225366788979900635,192265189073413070}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13552043609910101118,3749773338159862549}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9598746007369957913,17324662343394273616}}
+			Uuid{u4{15058804141421608648,4348703227184878970}}
+			Uuid{u4{12225366788979900635,192265189073413070}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material11TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{12955030671548067706,12551577596351522432}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{16960963029452693172,11221545530105175174}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4168366348649251362,6657988150206029809}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{800914498052136125,9542732694053571525}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12955030671548067706,12551577596351522432}}
+			Uuid{u4{16960963029452693172,11221545530105175174}}
+			Uuid{u4{4168366348649251362,6657988150206029809}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material12TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{11747534779576531495,4643036714524876415}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{6066440055495172165,17292464767232349944}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4072026080995138197,15475023476167811791}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9077212426297071627,2584903012117368631}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11747534779576531495,4643036714524876415}}
+			Uuid{u4{6066440055495172165,17292464767232349944}}
+			Uuid{u4{4072026080995138197,15475023476167811791}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material13TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{6604986624134609782,541182478307031646}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{17116719972233118374,4732254493472526506}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{3775170416160947051,438576634551550584}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1414690500036783875,6125538913279429156}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6604986624134609782,541182478307031646}}
+			Uuid{u4{17116719972233118374,4732254493472526506}}
+			Uuid{u4{3775170416160947051,438576634551550584}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material14TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{10635623154707427035,2949897858833992644}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{5482355976478417225,2980980005307510079}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13543459685163538460,8446976553004422694}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13139045096448405432,473073687436901809}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{10635623154707427035,2949897858833992644}}
+			Uuid{u4{5482355976478417225,2980980005307510079}}
+			Uuid{u4{13543459685163538460,8446976553004422694}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material15TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 }

--- a/Data/UnitTests/GameEngineTest/Terrain/TerrainData/VoxelTerrain.ezMaterialAsset
+++ b/Data/UnitTests/GameEngineTest/Terrain/TerrainData/VoxelTerrain.ezMaterialAsset
@@ -43,7 +43,6 @@ o
 	u3 %v{2}
 	p
 	{
-		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_OPAQUE"}
 		s %LayerBaseTexture{"{ c658f867-d3f8-43a8-b32d-55326fac60b8 }"}
 		s %LayerNormalTexture{"{ 6ce1da02-2df2-45b2-b832-05f2ca1c58b0 }"}
 		s %LayerRoughnessTexture{"{ fad8ea85-dca7-471c-8ed2-2aa362a6e98a }"}
@@ -55,10 +54,16 @@ o
 		Vec2i %Material5TextureIndex{i3{5,5}}
 		Vec2i %Material6TextureIndex{i3{0,0}}
 		Vec2i %Material7TextureIndex{i3{0,0}}
-		f %MetallicValue{0}
+		Vec2i %Material8TextureIndex{i3{0,0}}
+		Vec2i %Material9TextureIndex{i3{0,0}}
+		Vec2i %Material10TextureIndex{i3{0,0}}
+		Vec2i %Material11TextureIndex{i3{0,0}}
+		Vec2i %Material12TextureIndex{i3{0,0}}
+		Vec2i %Material13TextureIndex{i3{0,0}}
+		Vec2i %Material14TextureIndex{i3{0,0}}
+		Vec2i %Material15TextureIndex{i3{0,0}}
 		f %RoughnessBias{0x9A99993E}
 		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_LIT"}
-		b %TWO_SIDED{0}
 		f %TextureScale{0x0000803E}
 	}
 }
@@ -166,16 +171,6 @@ o
 }
 o
 {
-	Uuid %id{u4{1332604799681178783,1405895461207218641}}
-	s %t{"ezCategoryAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %Category{"Constant"}
-	}
-}
-o
-{
 	Uuid %id{u4{17827115875410736488,1585316841407967011}}
 	s %t{"ezAssetBrowserAttribute"}
 	u3 %v{1}
@@ -198,50 +193,6 @@ o
 }
 o
 {
-	Uuid %id{u4{9141801701097690514,1818856055331208923}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes
-		{
-			Uuid{u4{5464294602639393665,14334231704114327318}}
-		}
-		s %Category{"ezPropertyCategory::Member"}
-		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::IsEnum"}
-		s %Name{"BLEND_MODE"}
-		s %Type{"BLEND_MODE"}
-	}
-}
-o
-{
-	Uuid %id{u4{18311245008988910186,1895067994934075466}}
-	s %t{"ezReflectedTypeDescriptor"}
-	u3 %v{1}
-	p
-	{
-		VarArray %Attributes{}
-		s %Flags{"ezTypeFlags::IsEnum"}
-		VarArray %Functions{}
-		s %ParentTypeName{"ezEnumBase"}
-		s %PluginName{"ShaderTypes"}
-		VarArray %Properties
-		{
-			Uuid{u4{773668148553828920,15966949596821666881}}
-			Uuid{u4{540429536914844576,8213819539779215949}}
-			Uuid{u4{15543418230834458689,5548684801941186544}}
-			Uuid{u4{16393153594407016602,3744118329769567614}}
-			Uuid{u4{7757084663128585029,8011669779036733373}}
-			Uuid{u4{5650026407490086663,5768478847879086899}}
-			Uuid{u4{3687164412847300807,16605290275319987562}}
-		}
-		s %TypeName{"BLEND_MODE"}
-		u3 %TypeVersion{1}
-	}
-}
-o
-{
 	Uuid %id{u4{9182498974977327514,2041274447054354959}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -253,16 +204,6 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
 		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
 		s %Type{"ezInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{17034071263459828052,2782400576322051984}}
-	s %t{"ezDefaultValueAttribute"}
-	u3 %v{1}
-	p
-	{
-		d %Value{0}
 	}
 }
 o
@@ -318,21 +259,6 @@ o
 }
 o
 {
-	Uuid %id{u4{16393153594407016602,3744118329769567614}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{2}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_DITHERED"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{12112946480051241324,3795555419550579250}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -366,15 +292,12 @@ o
 		s %PluginName{"ShaderTypes"}
 		VarArray %Properties
 		{
-			Uuid{u4{9141801701097690514,1818856055331208923}}
 			Uuid{u4{5409814580796781886,9344055732743872460}}
-			Uuid{u4{10517831128859966838,11064712143935259415}}
 			Uuid{u4{8386681320953369572,12688127805794414923}}
 			Uuid{u4{179742440666354457,17903336386926422362}}
 			Uuid{u4{13247499607119692227,13764209986341690084}}
 			Uuid{u4{16879779125206579807,8442529159388631379}}
 			Uuid{u4{12478590686938027661,3137944321073572663}}
-			Uuid{u4{15547607822254496538,12025531138140177057}}
 			Uuid{u4{4311101479583114583,7312508370627651311}}
 			Uuid{u4{8910883084663966805,12276956813076541887}}
 			Uuid{u4{9228808152319478384,18132029967726531422}}
@@ -383,6 +306,14 @@ o
 			Uuid{u4{4255544553178940297,6255077598196679847}}
 			Uuid{u4{17405378268953882008,17077458338079794624}}
 			Uuid{u4{9302531237010587327,5429675742070542429}}
+			Uuid{u4{4496948063835937765,2707638318670392135}}
+			Uuid{u4{11004297157256196698,5522339163427738794}}
+			Uuid{u4{8806673106093756393,10616459756555306210}}
+			Uuid{u4{6613758981624084093,9002194832525891305}}
+			Uuid{u4{1246128700527001693,13234900316423435469}}
+			Uuid{u4{447790682552770724,6919083719563251570}}
+			Uuid{u4{2278789545051072539,14059301651726354164}}
+			Uuid{u4{4212018648156371159,3320387462288190472}}
 		}
 		s %TypeName{"Shaders/Terrain/Rendering/VoxelMeshMaterial.ezShader"}
 		u3 %TypeVersion{2}
@@ -443,36 +374,6 @@ o
 }
 o
 {
-	Uuid %id{u4{15543418230834458689,5548684801941186544}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{1}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{5650026407490086663,5768478847879086899}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{4}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{7271999579057768383,5840349001256652528}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
@@ -525,16 +426,6 @@ o
 }
 o
 {
-	Uuid %id{u4{13273282671864098690,7073242134369230105}}
-	s %t{"ezCategoryAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %Category{"Permutation"}
-	}
-}
-o
-{
 	Uuid %id{u4{4311101479583114583,7312508370627651311}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -562,36 +453,6 @@ o
 	{
 		i4 %Max{255}
 		i4 %Min{0}
-	}
-}
-o
-{
-	Uuid %id{u4{7757084663128585029,8011669779036733373}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{3}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
-		s %Type{"ezInt32"}
-	}
-}
-o
-{
-	Uuid %id{u4{540429536914844576,8213819539779215949}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
-		s %Type{"ezInt32"}
 	}
 }
 o
@@ -713,24 +574,6 @@ o
 }
 o
 {
-	Uuid %id{u4{10517831128859966838,11064712143935259415}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes
-		{
-			Uuid{u4{13273282671864098690,7073242134369230105}}
-		}
-		s %Category{"ezPropertyCategory::Member"}
-		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"TWO_SIDED"}
-		s %Type{"bool"}
-	}
-}
-o
-{
 	Uuid %id{u4{11895449017445965276,11733598302241216248}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -758,26 +601,6 @@ o
 	p
 	{
 		i4 %Value{0}
-	}
-}
-o
-{
-	Uuid %id{u4{15547607822254496538,12025531138140177057}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes
-		{
-			Uuid{u4{1332604799681178783,1405895461207218641}}
-			Uuid{u4{17034071263459828052,2782400576322051984}}
-			Uuid{u4{381769352279539939,12800711645150781831}}
-		}
-		s %Category{"ezPropertyCategory::Member"}
-		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"MetallicValue"}
-		s %Type{"float"}
 	}
 }
 o
@@ -838,17 +661,6 @@ o
 		s %Flags{"ezPropertyFlags::StandardType"}
 		s %Name{"LayerBaseTexture"}
 		s %Type{"ezString"}
-	}
-}
-o
-{
-	Uuid %id{u4{381769352279539939,12800711645150781831}}
-	s %t{"ezClampValueAttribute"}
-	u3 %v{1}
-	p
-	{
-		d %Max{0x000000000000F03F}
-		d %Min{0}
 	}
 }
 o
@@ -923,16 +735,6 @@ o
 }
 o
 {
-	Uuid %id{u4{5464294602639393665,14334231704114327318}}
-	s %t{"ezCategoryAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %Category{"Permutation"}
-	}
-}
-o
-{
 	Uuid %id{u4{16608059164795256034,14788482193739877470}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -981,21 +783,6 @@ o
 }
 o
 {
-	Uuid %id{u4{773668148553828920,15966949596821666881}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		u3 %ConstantValue{0}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::Default"}
-		s %Type{"ezUInt32"}
-	}
-}
-o
-{
 	Uuid %id{u4{1155205217496153151,16062411953539633064}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -1028,21 +815,6 @@ o
 	p
 	{
 		s %Category{"Constant"}
-	}
-}
-o
-{
-	Uuid %id{u4{3687164412847300807,16605290275319987562}}
-	s %t{"ezReflectedPropertyDescriptor"}
-	u3 %v{2}
-	p
-	{
-		VarArray %Attributes{}
-		s %Category{"ezPropertyCategory::Constant"}
-		i3 %ConstantValue{5}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
-		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
-		s %Type{"ezInt32"}
 	}
 }
 o
@@ -1196,6 +968,414 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezMaterialAssetProperties"}
 		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{4803863608740140353,9676843720674511846}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{17281984797905143529,12710473062079407154}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13063152239061407912,5230521805589402377}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4496948063835937765,2707638318670392135}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{4803863608740140353,9676843720674511846}}
+			Uuid{u4{17281984797905143529,12710473062079407154}}
+			Uuid{u4{13063152239061407912,5230521805589402377}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material8TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{12928502885552316538,1768655087190374748}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{7496775825935457702,13602965696127084819}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8474865438317343514,3574590434559897451}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11004297157256196698,5522339163427738794}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12928502885552316538,1768655087190374748}}
+			Uuid{u4{7496775825935457702,13602965696127084819}}
+			Uuid{u4{8474865438317343514,3574590434559897451}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material9TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{10551291666008678704,15364225026150806765}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{12085195566240495182,15105935683137401010}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{9887016013631993126,13911469441618561882}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8806673106093756393,10616459756555306210}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{10551291666008678704,15364225026150806765}}
+			Uuid{u4{12085195566240495182,15105935683137401010}}
+			Uuid{u4{9887016013631993126,13911469441618561882}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material10TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{13811130814056539385,15245835301568979617}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{7373120233932431961,3788481180487197648}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{14813622448124458524,5952117793502101889}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{6613758981624084093,9002194832525891305}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{13811130814056539385,15245835301568979617}}
+			Uuid{u4{7373120233932431961,3788481180487197648}}
+			Uuid{u4{14813622448124458524,5952117793502101889}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material11TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{14098655646530192607,15182912646746782912}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{15568410248338107941,4285490166111425343}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{7949580292664268821,5174853753939037358}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1246128700527001693,13234900316423435469}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{14098655646530192607,15182912646746782912}}
+			Uuid{u4{15568410248338107941,4285490166111425343}}
+			Uuid{u4{7949580292664268821,5174853753939037358}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material12TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{13756843891180101459,5936305884680164211}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{1065858688303747038,12736647595969134315}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8996735262702857022,17498516564740927368}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{447790682552770724,6919083719563251570}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{13756843891180101459,5936305884680164211}}
+			Uuid{u4{1065858688303747038,12736647595969134315}}
+			Uuid{u4{8996735262702857022,17498516564740927368}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material13TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{2875714667991991232,464424255977221567}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{6350975240094520141,12860840049160111812}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16008573890739634048,16758296066416900053}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2278789545051072539,14059301651726354164}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{2875714667991991232,464424255977221567}}
+			Uuid{u4{6350975240094520141,12860840049160111812}}
+			Uuid{u4{16008573890739634048,16758296066416900053}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material14TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17230886766129893515,5598009744802737710}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{3795805088974750705,16926407781997336765}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{513993566496042085,4317287544667640020}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4212018648156371159,3320387462288190472}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{17230886766129893515,5598009744802737710}}
+			Uuid{u4{3795805088974750705,16926407781997336765}}
+			Uuid{u4{513993566496042085,4317287544667640020}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material15TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 }


### PR DESCRIPTION
If a material sets a permutation variable to a fixed value, e.g. "BLEND_MODE = OPAQUE", but the shader reads that somewhere other than the shader code (e.g. the material config section), it would not work so far. The work around was to still expose the variable to the UI. This change fixes that.

Also extended the terrain material list.