### PR TITLE
Defer asset check rule creation until editor plugins have been loaded

### DIFF
--- a/.github/skills/ez-mcp/SKILL.md
+++ b/.github/skills/ez-mcp/SKILL.md
@@ -1,0 +1,1 @@
+To use the ez-mcp skill refer to the instructions in the .claude/skills/ez-mcp folder.

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -606,6 +606,12 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
     }
   }
 
+  if (!IsInHeadlessMode())
+  {
+    // Now that all plugins have been loaded, populate the asset check rules
+    ezQtAssetCheckPanel::GetSingleton()->FillRuleList();
+  }
+
   connect(m_pTimer, SIGNAL(timeout()), this, SLOT(SlotTimedUpdate()), Qt::QueuedConnection);
   m_pTimer->start(1);
 

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
@@ -31,7 +31,7 @@ protected:
 private:
   void RunButtonClicked();
   void ResultTreeItemDoubleClicked(QTreeWidgetItem* pItem, int iColumn);
-  
+
   void UpdateAssetTypeCombo();
   void DocumentManagerEventHandler(const ezDocumentManager::Event& e);
 

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/AssetCheckPanel.moc.h
@@ -23,14 +23,15 @@ public:
   ezQtAssetCheckPanel(ads::CDockManager* pDockManager);
   ~ezQtAssetCheckPanel();
 
+  void FillRuleList();
+
 protected:
   virtual bool eventFilter(QObject* pWatched, QEvent* pEvent) override;
 
 private:
   void RunButtonClicked();
   void ResultTreeItemDoubleClicked(QTreeWidgetItem* pItem, int iColumn);
-
-  void FillRuleList();
+  
   void UpdateAssetTypeCombo();
   void DocumentManagerEventHandler(const ezDocumentManager::Event& e);
 

--- a/Code/Editor/EditorFramework/Panels/AssetCheckPanel/Implementation/AssetCheckPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCheckPanel/Implementation/AssetCheckPanel.cpp
@@ -37,9 +37,6 @@ ezQtAssetCheckPanel::ezQtAssetCheckPanel(ads::CDockManager* pDockManager)
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezQtAssetCheckPanel::DocumentManagerEventHandler, this));
 
   UpdateAssetTypeCombo();
-
-  ezAssetCheckRule::CreateRules(m_Rules);
-  FillRuleList();
 }
 
 ezQtAssetCheckPanel::~ezQtAssetCheckPanel()
@@ -102,6 +99,9 @@ void ezQtAssetCheckPanel::UpdateAssetTypeCombo()
 
 void ezQtAssetCheckPanel::FillRuleList()
 {
+  m_Rules.Clear();
+  ezAssetCheckRule::CreateRules(m_Rules);
+
   RuleList->clear();
 
   for (ezUInt32 i = 0; i < m_Rules.GetCount(); ++i)

--- a/Code/Engine/Foundation/IO/Implementation/JSONParser.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/JSONParser.cpp
@@ -43,7 +43,7 @@ void ezJSONParser::SetInputStream(ezStreamReader& stream, ezUInt32 uiFirstLineOf
 void ezJSONParser::StartParsing()
 {
   // remove the NotStarted state
-  m_StateStack.PopBack();
+  PopStack();
 
   // put the Finished state onto the stack
   {
@@ -154,6 +154,13 @@ void ezJSONParser::SkipStack(State s)
   m_bSkippingMode = false;
 }
 
+void ezJSONParser::PopStack()
+{
+  // The stack can be empty if the parser encountered a fatal error before
+  if (!m_StateStack.IsEmpty())
+    m_StateStack.PopBack();
+}
+
 bool ezJSONParser::ContinueParsing()
 {
   if (m_uiCurByte == '\0')
@@ -219,7 +226,7 @@ void ezJSONParser::ContinueObject()
     case '}':
       SkipWhitespace();
 
-      m_StateStack.PopBack();
+      PopStack();
 
       if (!m_bSkippingMode)
         OnEndObject();
@@ -247,7 +254,7 @@ void ezJSONParser::ContinueArray()
     {
       SkipWhitespace();
 
-      m_StateStack.PopBack();
+      PopStack();
 
       if (!m_bSkippingMode)
         OnEndArray();
@@ -287,7 +294,7 @@ void ezJSONParser::ContinueVariable()
     SkipWhitespace();
 
   // remove ReadingVariable from the stack
-  m_StateStack.PopBack();
+  PopStack();
 
   JSONState s;
 
@@ -322,7 +329,7 @@ void ezJSONParser::ContinueValue()
       SkipWhitespace();
 
       // remove ReadingValue from the stack
-      m_StateStack.PopBack();
+      PopStack();
 
       if (!m_bSkippingMode)
         OnReadValue(ezStringView((const char*)&m_TempString[0]));
@@ -346,7 +353,7 @@ void ezJSONParser::ContinueValue()
       const double fValue = ReadNumber();
 
       // remove ReadingValue from the stack
-      m_StateStack.PopBack();
+      PopStack();
 
       if (!m_bSkippingMode)
         OnReadValue(fValue);
@@ -357,7 +364,7 @@ void ezJSONParser::ContinueValue()
     case 'f':
     {
       // remove ReadingValue from the stack
-      m_StateStack.PopBack();
+      PopStack();
 
       ReadWord();
 
@@ -378,7 +385,7 @@ void ezJSONParser::ContinueValue()
     case 'N':
     {
       // remove ReadingValue from the stack
-      m_StateStack.PopBack();
+      PopStack();
 
       ReadWord();
 
@@ -403,7 +410,7 @@ void ezJSONParser::ContinueValue()
     case '[':
     {
       // remove ReadingValue from the stack
-      m_StateStack.PopBack();
+      PopStack();
 
       JSONState s;
       s.m_State = ReadingArray;
@@ -419,7 +426,7 @@ void ezJSONParser::ContinueValue()
     case '{':
     {
       // remove ReadingValue from the stack
-      m_StateStack.PopBack();
+      PopStack();
 
       JSONState s;
       s.m_State = ReadingObject;
@@ -448,7 +455,7 @@ void ezJSONParser::ContinueSeparator()
     SkipWhitespace();
 
   // remove ExpectSeparator from the stack
-  m_StateStack.PopBack();
+  PopStack();
 
   switch (m_uiCurByte)
   {

--- a/Code/Engine/Foundation/IO/JSONParser.h
+++ b/Code/Engine/Foundation/IO/JSONParser.h
@@ -139,6 +139,7 @@ private:
   void ReadNextByte();
 
   void SkipStack(State s);
+  void PopStack();
 
   ezUInt8 m_uiCurByte;
   ezUInt8 m_uiNextByte;

--- a/Code/UnitTests/FoundationTest/IO/JSONParserTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/JSONParserTest.cpp
@@ -683,4 +683,25 @@ EZ_CREATE_SIMPLE_TEST(IO, JSONParser)
 
     EZ_TEST_INT(reader.m_iExpectedParsingErrors, 0);
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Malformed")
+  {
+    const char* szTestData = "{\"a\":{\"b\":\" {";
+
+    StringStream stream(szTestData);
+
+    TestReader reader;
+
+    reader.Add(ParseResult(BeginObject));
+    reader.Add(ParseResult(Variable, "a"));
+
+    reader.Add(ParseResult(BeginObject));
+    reader.Add(ParseResult(Variable, "b"));
+    reader.Add(ParseResult(" {"));
+
+    reader.m_iExpectedParsingErrors = 1;
+    reader.ParseStream(stream);
+
+    EZ_TEST_INT(reader.m_iExpectedParsingErrors, 0);
+  }
 }


### PR DESCRIPTION
* This allows other editor plugins to define their own asset check rules
* Also added a crash fix in the json parser for malformed documents (encountered when using the mcp server)