### PR TITLE
Physics simulation for static actors for easier placement

### DIFF
--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -3,6 +3,7 @@
 #include <EnginePluginScene/SceneContext/SceneContext.h>
 #include <EnginePluginScene/SceneView/SceneView.h>
 
+#include <Core/Interfaces/PhysicsWorldModule.h>
 #include <Core/Interfaces/SoundInterface.h>
 #include <Core/Prefabs/PrefabResource.h>
 #include <Core/World/EventMessageHandlerComponent.h>
@@ -1174,6 +1175,24 @@ void ezSceneContext::HandlePullObjectStateMsg(const ezPullObjectStateMsgToEngine
 {
   if (!m_pWorld->GetWorldSimulationEnabled())
     return;
+
+  // Objects that don't move on their own can't be placed physically. Ask them to become simulated for the rest of
+  // this simulation, so that pressing the shortcut again records where they came to rest.
+  {
+    ezWorld* pMutableWorld = GetWorld();
+    EZ_LOCK(pMutableWorld->GetWriteMarker());
+
+    ezMsgPhysicsMakeTemporarilyDynamic makeDynamicMsg;
+
+    for (ezGameObjectHandle hObject : m_SelectionWithChildren)
+    {
+      ezGameObject* pObject = nullptr;
+      if (!pMutableWorld->TryGetObject(hObject, pObject))
+        continue;
+
+      pObject->SendMessage(makeDynamicMsg);
+    }
+  }
 
   const ezWorld* pWorld = GetWorld();
   EZ_LOCK(pWorld->GetReadMarker());

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.cpp
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.cpp
@@ -83,6 +83,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgObjectGrabbed, 1, ezRTTIDefaultAllocator<ez
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgPhysicsMakeTemporarilyDynamic);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgPhysicsMakeTemporarilyDynamic, 1, ezRTTIDefaultAllocator<ezMsgPhysicsMakeTemporarilyDynamic>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgReleaseObjectGrab);
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgReleaseObjectGrab, 1, ezRTTIDefaultAllocator<ezMsgReleaseObjectGrab>)
 {

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -193,6 +193,20 @@ struct EZ_CORE_DLL ezMsgObjectGrabbed : public ezMessage
   bool m_bGotGrabbed = true;
 };
 
+/// Asks physics actors to temporarily become fully simulated, so that they fall down and settle realistically.
+///
+/// This is an editor-only tool: it is sent when the user asks the editor to record object transforms during a
+/// simulation, so that even objects that are normally not simulated can be placed physically.
+/// The change lasts only for the running simulation, nothing needs to be restored, because the runtime world is
+/// discarded when the simulation ends.
+///
+/// Actors that can't be simulated ignore this message. In particular a static actor that only has a concave
+/// (triangle mesh) collider can't become dynamic and stays as it is.
+struct EZ_CORE_DLL ezMsgPhysicsMakeTemporarilyDynamic : public ezMessage
+{
+  EZ_DECLARE_MESSAGE_TYPE(ezMsgPhysicsMakeTemporarilyDynamic, ezMessage);
+};
+
 /// Send this to components such as ezJoltGrabObjectComponent to demand that m_hGrabbedObjectToRelease should no longer be grabbed.
 struct EZ_CORE_DLL ezMsgReleaseObjectGrab : public ezMessage
 {

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
@@ -112,6 +112,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltDynamicActorComponent, 8, ezComponentMode::Dynamic
   EZ_BEGIN_MESSAGEHANDLERS
   {
       EZ_MESSAGE_HANDLER(ezMsgPhysicsAddImpulse, AddLinearImpulseAtPos),
+      EZ_MESSAGE_HANDLER(ezMsgPhysicsMakeTemporarilyDynamic, OnMsgPhysicsMakeTemporarilyDynamic),
   }
   EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_FUNCTIONS
@@ -209,6 +210,17 @@ void ezJoltDynamicActorComponent::DeserializeComponent(ezWorldReader& inout_stre
     s >> f;
     m_fBuoyancyFactor = f;
   }
+}
+
+void ezJoltDynamicActorComponent::OnMsgPhysicsMakeTemporarilyDynamic(ezMsgPhysicsMakeTemporarilyDynamic& msg)
+{
+  EZ_IGNORE_UNUSED(msg);
+
+  // a kinematic actor doesn't fall down, so switch it to a fully simulated one.
+  // Nothing is restored afterwards, because this only ever happens in a simulation whose world gets discarded.
+  SetKinematic(false);
+
+  GetOwner()->MakeDynamic();
 }
 
 void ezJoltDynamicActorComponent::SetKinematic(bool b)

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
@@ -2,10 +2,13 @@
 
 #include <Core/World/WorldLogLink.h>
 
+#include <Core/Interfaces/PhysicsWorldModule.h>
 #include <Core/WorldSerializer/WorldReader.h>
 #include <Core/WorldSerializer/WorldWriter.h>
+#include <Foundation/Profiling/Profiling.h>
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyID.h>
+#include <Jolt/Physics/Body/BodyLock.h>
 #include <Jolt/Physics/Collision/Shape/ConvexHullShape.h>
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/PhysicsSystem.h>
@@ -18,6 +21,49 @@
 #include <JoltPlugin/Utilities/JoltConversionUtils.h>
 #include <RendererCore/Meshes/MeshComponent.h>
 #include <RendererCore/Utils/WorldGeoExtractionUtil.h>
+
+ezJoltStaticActorComponentManager::ezJoltStaticActorComponentManager(ezWorld* pWorld)
+  : ezComponentManager<ezJoltStaticActorComponent, ezBlockStorageType::FreeList>(pWorld)
+{
+}
+
+ezJoltStaticActorComponentManager::~ezJoltStaticActorComponentManager() = default;
+
+void ezJoltStaticActorComponentManager::UpdateTemporarilyDynamicActors()
+{
+  if (m_TemporarilyDynamicActors.IsEmpty())
+    return;
+
+  EZ_PROFILE_SCOPE("UpdateTemporarilyDynamicActors");
+
+  ezJoltWorldModule* pModule = GetWorld()->GetOrCreateModule<ezJoltWorldModule>();
+  auto* pSystem = pModule->GetJoltSystem();
+
+  for (ezComponentHandle hActor : m_TemporarilyDynamicActors)
+  {
+    ezJoltStaticActorComponent* pActor = nullptr;
+    if (!TryGetComponent(hActor, pActor))
+      continue;
+
+    JPH::BodyID bodyId(pActor->GetJoltBodyID());
+
+    JPH::BodyLockRead bodyLock(pSystem->GetBodyLockInterface(), bodyId);
+    if (!bodyLock.Succeeded())
+      continue;
+
+    const JPH::Body& body = bodyLock.GetBody();
+
+    if (!body.IsDynamic())
+      continue;
+
+    ezSimdTransform trans = pActor->GetOwner()->GetGlobalTransformSimd();
+
+    trans.m_Position = ezJoltConversionUtils::ToSimdVec3(body.GetPosition());
+    trans.m_Rotation = ezJoltConversionUtils::ToSimdQuat(body.GetRotation());
+
+    pActor->GetOwner()->SetGlobalTransform(trans);
+  }
+}
 
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ezJoltStaticActorComponent, 1, ezComponentMode::Static)
@@ -32,6 +78,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltStaticActorComponent, 1, ezComponentMode::Static)
   EZ_BEGIN_MESSAGEHANDLERS
   {
     EZ_MESSAGE_HANDLER(ezMsgExtractGeometry, OnMsgExtractGeometry),
+    EZ_MESSAGE_HANDLER(ezMsgPhysicsMakeTemporarilyDynamic, OnMsgPhysicsMakeTemporarilyDynamic),
   }
   EZ_END_MESSAGEHANDLERS;
 }
@@ -77,6 +124,114 @@ void ezJoltStaticActorComponent::OnDeactivated()
   m_UsedSurfaces.Clear();
 
   SUPER::OnDeactivated();
+}
+
+bool ezJoltStaticActorComponent::CanBeMadeDynamic()
+{
+  // a triangle mesh can only ever be part of a static body
+  if (m_hCollisionMesh.IsValid())
+  {
+    ezResourceLock<ezJoltMeshResource> pMesh(m_hCollisionMesh, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
+
+    if (pMesh.GetAcquireResult() != ezResourceAcquireResult::Final)
+      return false;
+
+    if (pMesh->HasTriangleMesh())
+      return false;
+
+    if (pMesh->GetNumConvexParts() > 0)
+      return true;
+  }
+
+  // otherwise the sub-shape components attached to this object have to provide the geometry,
+  // and those are all convex
+  ezTempHybridArray<ezJoltSubShape, 16> shapes;
+  ezTransform towner = GetOwner()->GetGlobalTransform();
+  towner.m_vScale.Set(1.0f);
+
+  GatherShapes(shapes, GetOwner(), towner, 1.0f, nullptr);
+
+  const bool bHasShapes = !shapes.IsEmpty();
+
+  for (auto& sub : shapes)
+  {
+    if (sub.m_pShape)
+    {
+      sub.m_pShape->Release();
+    }
+  }
+
+  return bHasShapes;
+}
+
+void ezJoltStaticActorComponent::OnMsgPhysicsMakeTemporarilyDynamic(ezMsgPhysicsMakeTemporarilyDynamic& msg)
+{
+  EZ_IGNORE_UNUSED(msg);
+
+  if (m_uiJoltBodyID == JPH::BodyID::cInvalidBodyID)
+    return;
+
+  ezJoltStaticActorComponentManager* pManager = GetWorld()->GetOrCreateComponentManager<ezJoltStaticActorComponentManager>();
+
+  if (pManager->m_TemporarilyDynamicActors.Contains(GetHandle()))
+    return;
+
+  if (!CanBeMadeDynamic())
+    return;
+
+  ezJoltWorldModule* pModule = GetWorld()->GetOrCreateModule<ezJoltWorldModule>();
+  auto* pBodies = &pModule->GetJoltSystem()->GetBodyInterface();
+
+  auto* pMaterial = GetJoltMaterial();
+
+  JPH::BodyCreationSettings bodyCfg;
+  if (CreateShape(&bodyCfg, 1.0f, pMaterial).Failed())
+    return;
+
+  if (pMaterial == nullptr)
+    pMaterial = ezJoltCore::GetDefaultMaterial();
+
+  // A static Jolt body has no motion properties and can't be switched to a dynamic motion type, so the existing body
+  // is thrown away and a dynamic one is created in its place. The user data and the object filter ID are kept, so
+  // that everything that refers to this actor keeps working.
+  {
+    const JPH::BodyID oldBodyId(m_uiJoltBodyID);
+
+    if (pBodies->IsAdded(oldBodyId))
+      pBodies->RemoveBody(oldBodyId);
+    else
+      pModule->RemoveBodyFromQueue(oldBodyId);
+
+    pBodies->DestroyBody(oldBodyId);
+    m_uiJoltBodyID = JPH::BodyID::cInvalidBodyID;
+  }
+
+  const ezSimdTransform trans = GetOwner()->GetGlobalTransformSimd();
+
+  bodyCfg.mPosition = ezJoltConversionUtils::ToVec3(trans.m_Position);
+  bodyCfg.mRotation = ezJoltConversionUtils::ToQuat(trans.m_Rotation).Normalized();
+  bodyCfg.mMotionType = JPH::EMotionType::Dynamic;
+  bodyCfg.mObjectLayer = ezJoltCollisionFiltering::ConstructObjectLayer(m_uiCollisionLayer, ezJoltBroadphaseLayer::Dynamic);
+  bodyCfg.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateMassAndInertia;
+  bodyCfg.mRestitution = pMaterial->m_fRestitution;
+  bodyCfg.mFriction = pMaterial->m_fFriction;
+  bodyCfg.mCollisionGroup.SetGroupID(m_uiObjectFilterID);
+  bodyCfg.mCollisionGroup.SetGroupFilter(pModule->GetGroupFilter());
+  bodyCfg.mUserData = reinterpret_cast<ezUInt64>(GetUserData());
+
+  JPH::Body* pBody = pBodies->CreateBody(bodyCfg);
+  if (pBody == nullptr)
+  {
+    ezLog::Error("Jolt body creation failed. You need to increase the maximum number of bodies.");
+    return;
+  }
+
+  m_uiJoltBodyID = pBody->GetID().GetIndexAndSequenceNumber();
+  pModule->QueueBodyToAdd(pBody, true);
+
+  GetOwner()->MakeDynamic();
+
+  pManager->m_TemporarilyDynamicActors.PushBack(GetHandle());
 }
 
 void ezJoltStaticActorComponent::OnSimulationStarted()

--- a/Code/EnginePlugins/JoltPlugin/Actors/JoltDynamicActorComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Actors/JoltDynamicActorComponent.h
@@ -3,6 +3,8 @@
 #include <Foundation/Math/Float16.h>
 #include <JoltPlugin/Actors/JoltActorComponent.h>
 
+struct ezMsgPhysicsMakeTemporarilyDynamic;
+
 //////////////////////////////////////////////////////////////////////////
 
 class EZ_JOLTPLUGIN_DLL ezJoltDynamicActorComponentManager : public ezComponentManager<class ezJoltDynamicActorComponent, ezBlockStorageType::FreeList>
@@ -159,6 +161,8 @@ public:
   void ClearForce(ezUInt32 uiForceID);
 
 protected:
+  void OnMsgPhysicsMakeTemporarilyDynamic(ezMsgPhysicsMakeTemporarilyDynamic& msg);
+
   const ezJoltMaterial* GetJoltMaterial() const;
 
   float GetWeight_Scale() const { return m_fWeightScale; }

--- a/Code/EnginePlugins/JoltPlugin/Actors/JoltStaticActorComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Actors/JoltStaticActorComponent.h
@@ -5,7 +5,26 @@
 
 struct ezMsgExtractGeometry;
 
-using ezJoltStaticActorComponentManager = ezComponentManager<class ezJoltStaticActorComponent, ezBlockStorageType::FreeList>;
+struct ezMsgPhysicsMakeTemporarilyDynamic;
+
+/// Manager for ezJoltStaticActorComponent.
+///
+/// Beyond the default component management it keeps track of the static actors that were temporarily turned into
+/// dynamic ones, and copies their simulated transform back onto their owner objects.
+class EZ_JOLTPLUGIN_DLL ezJoltStaticActorComponentManager : public ezComponentManager<class ezJoltStaticActorComponent, ezBlockStorageType::FreeList>
+{
+public:
+  ezJoltStaticActorComponentManager(ezWorld* pWorld);
+  ~ezJoltStaticActorComponentManager();
+
+private:
+  friend class ezJoltWorldModule;
+  friend class ezJoltStaticActorComponent;
+
+  void UpdateTemporarilyDynamicActors();
+
+  ezDynamicArray<ezComponentHandle> m_TemporarilyDynamicActors;
+};
 
 /// Turns an object into an immovable obstacle in the physics simulation.
 ///
@@ -27,6 +46,8 @@ public:
 protected:
   virtual void OnDeactivated() override;
   virtual void OnSimulationStarted() override;
+
+  void OnMsgPhysicsMakeTemporarilyDynamic(ezMsgPhysicsMakeTemporarilyDynamic& msg);
 
   //////////////////////////////////////////////////////////////////////////
   // ezJoltActorComponent
@@ -55,6 +76,9 @@ public:
 protected:
   void OnMsgExtractGeometry(ezMsgExtractGeometry& msg) const;
   const ezJoltMaterial* GetJoltMaterial() const;
+
+  /// Whether the shapes of this actor could be used for a dynamic body. Triangle meshes can't.
+  bool CanBeMadeDynamic();
 
   ezJoltMeshResourceHandle m_hCollisionMesh;
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -818,6 +818,11 @@ void ezJoltWorldModule::FetchResults(const ezWorldModule::UpdateContext& context
     pDynamicActorManager->UpdateDynamicActors();
   }
 
+  if (ezJoltStaticActorComponentManager* pStaticActorManager = GetWorld()->GetComponentManager<ezJoltStaticActorComponentManager>())
+  {
+    pStaticActorManager->UpdateTemporarilyDynamicActors();
+  }
+
   for (auto pCharacter : m_ActiveCharacters)
   {
     pCharacter->Update(m_SimulatedTimeStep);


### PR DESCRIPTION
In the editor, run the simulation, select an object that uses a static Jolt actor, then press "K" (keep current transform). The first time, this will turn the static actor into a dynamic actor and physically simulate it, so it will fall down etc. When it settled, and you like the position, press "K" again, this time to record the transform. When the simulation is stopped, the editor will automatically move the object to the recorded location.

This was already working for dynamic physics objects before, now it also works for static and kinematic objects, as long as they have convex shapes.

Video below shows this: 
* Start simulation
* Press "K" to simulate the otherwise static rock
* Press "K" again to record location
* Stop simulation -> rock stays where it was

https://github.com/user-attachments/assets/6d32f90d-4c73-43e3-b6c5-27247f871b7e

