### PR TITLE
Allow invalid default value for volume samplers

### DIFF
--- a/Code/Engine/GameEngine/Volumes/Implementation/VolumeSampler.cpp
+++ b/Code/Engine/GameEngine/Volumes/Implementation/VolumeSampler.cpp
@@ -133,30 +133,40 @@ void ezVolumeSampler::SampleAtPosition(const ezWorld& world, ezSpatialData::Cate
       if (volumeValue.IsValid() == false)
         continue;
 
-      ezResult conversionStatus = EZ_SUCCESS;
-      ezEnum<ezVariantType> targetType = targetValue.GetType();
-      ezVariant newTargetValue = volumeValue.ConvertTo(targetType, &conversionStatus);
-      if (conversionStatus.Failed())
+      if (targetValue.IsValid())
       {
-        ezLog::Error("VolumeSampler: Can't convert volume value '{}' to '{}'.", sName, targetType);
-        continue;
+        ezResult conversionStatus = EZ_SUCCESS;
+        ezEnum<ezVariantType> targetType = targetValue.GetType();
+        ezVariant newTargetValue = volumeValue.ConvertTo(targetType, &conversionStatus);
+        if (conversionStatus.Failed())
+        {
+          ezLog::Error("VolumeSampler: Can't convert volume value '{}' to '{}'.", sName, targetType);
+          continue;
+        }
+
+        targetValue = ezMath::Lerp(targetValue, newTargetValue, double(info.m_fAlpha));
+      }
+      else
+      {
+        targetValue = volumeValue;
       }
 
-      targetValue = ezMath::Lerp(targetValue, newTargetValue, double(info.m_fAlpha));
       fTargetStrength = ezMath::Lerp(fTargetStrength, 1.0f, info.m_fAlpha);
     }
 
-    if (value.m_fInterpolationFactor > 0.0)
+    // When interpolation is disabled, use a factor of 1 so that Lerp simply returns the target value.
+    const double f = value.m_fInterpolationFactor > 0.0
+                       ? 1.0 - ezMath::Pow(value.m_fInterpolationFactor, deltaTime.GetSeconds())
+                       : 1.0;
+
+    // Update current value only if the target value is valid. Otherwise, keep the current value as is.
+    if (targetValue.IsValid())
     {
-      double f = 1.0 - ezMath::Pow(value.m_fInterpolationFactor, deltaTime.GetSeconds());
-      value.m_CurrentValue = ezMath::Lerp(value.m_CurrentValue, targetValue, f);
-      value.m_fCurrentStrength = ezMath::Lerp(value.m_fCurrentStrength, fTargetStrength, f);
+      value.m_CurrentValue = value.m_CurrentValue.IsValid() ? ezMath::Lerp(value.m_CurrentValue, targetValue, f) : targetValue;
     }
-    else
-    {
-      value.m_CurrentValue = targetValue;
-      value.m_fCurrentStrength = fTargetStrength;
-    }
+
+    // Always update strength, even if the value is invalid
+    value.m_fCurrentStrength = ezMath::Lerp(value.m_fCurrentStrength, fTargetStrength, f);
 
     if (pTargetBlackboard != nullptr)
     {

--- a/Code/Engine/GameEngine/Volumes/Implementation/VolumeSamplerComponent.cpp
+++ b/Code/Engine/GameEngine/Volumes/Implementation/VolumeSamplerComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezVolumeSamplerValue, ezNoBase, 1, ezRTTIDefaultA
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Name", m_sName)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
-    EZ_MEMBER_PROPERTY("DefaultValue", m_DefaultValue)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
+    EZ_MEMBER_PROPERTY("DefaultValue", m_DefaultValue),
     EZ_MEMBER_PROPERTY("InterpolationDuration", m_InterpolationDuration),
   }
   EZ_END_PROPERTIES;

--- a/Data/Samples/Testing Chambers/Scenes/DynamicFog.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/DynamicFog.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{10095897394996261,10807132643521334864}}
-		u4 %Hash{7028667606732717512}
+		u4 %Hash{14607950549278587434}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -326,7 +326,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %DefaultValue{0x0000803F}
+		Invalid %DefaultValue{}
 		Time %InterpolationDuration{d{0x0000000000001040}}
 		HashedString %Name{s{"Fog.Density"}}
 	}
@@ -481,7 +481,7 @@ o
 	u3 %v{1}
 	p
 	{
-		Color %DefaultValue{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Invalid %DefaultValue{}
 		Time %InterpolationDuration{d{0x0000000000001040}}
 		HashedString %Name{s{"Fog.Color"}}
 	}


### PR DESCRIPTION
This allows to ignore the default value on the volume sampler component entirely for things like fog volumes. In these cases the default value only led to undesired side effects.