### PR TITLE
Terrain shader optimiations

### DIFF
--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -453,6 +453,34 @@ namespace
       ++s;
     }
   }
+
+  void SkipWhitespaceAndComments(ezStringView& s)
+  {
+    while (true)
+    {
+      SkipWhitespace(s);
+
+      if (s.StartsWith("//"))
+      {
+        while (s.IsValid() && s.GetCharacter() != '\n')
+          ++s;
+      }
+      else if (s.StartsWith("/*"))
+      {
+        s.Shrink(2, 0);
+
+        while (s.IsValid() && !s.StartsWith("*/"))
+          ++s;
+
+        if (s.StartsWith("*/"))
+          s.Shrink(2, 0);
+      }
+      else
+      {
+        return;
+      }
+    }
+  }
 } // namespace
 
 ezResult ezShaderParser::PreprocessSection(ezStringView sSectionContent, ezArrayPtr<ezString> customDefines, ezStringBuilder& out_sResult)
@@ -826,7 +854,7 @@ void ezShaderParser::LayoutMaterialConstants(ezShaderConstantBufferLayout& ref_m
 // static
 void ezShaderParser::ParsePermutationVarConfig(ezStringView s, ezVariant& out_defaultValue, EnumDefinition& out_enumDefinition)
 {
-  SkipWhitespace(s);
+  SkipWhitespaceAndComments(s);
 
   ezStringBuilder name;
 

--- a/Data/Plugins/TerrainPlugin/Shaders/PermutationVars/TERRAIN_LAYER_COUNT.ezPermVar
+++ b/Data/Plugins/TerrainPlugin/Shaders/PermutationVars/TERRAIN_LAYER_COUNT.ezPermVar
@@ -1,0 +1,9 @@
+// How many baked material layers the terrain shaders blend, counting the implicit fallback.
+enum TERRAIN_LAYER_COUNT
+{
+  TERRAIN_LAYER_COUNT_2,
+  TERRAIN_LAYER_COUNT_3,
+  TERRAIN_LAYER_COUNT_4,
+  TERRAIN_LAYER_COUNT_5,
+  default = 1
+};

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader
@@ -21,11 +21,17 @@ CAMERA_MODE
 SHADING_QUALITY
 MATERIAL_PREVIEW
 TERRAIN_HEIGHT_BLEND
+TERRAIN_LAYER_COUNT
 
 [MATERIALPARAMETER]
 
 /// Enables height-based blending between layers. Requires LayerHeightTexture to be set.
 Permutation TERRAIN_HEIGHT_BLEND;
+
+/// How many of the baked per-cell material layers are blended, counting the implicit fallback.
+/// The bake always produces 4 explicit layers plus the fallback; lowering this drops the weakest
+/// ones (which carry the least coverage) and removes 3 texture fetches per dropped layer per map.
+Permutation TERRAIN_LAYER_COUNT;
 
 Texture2DArray LayerBaseTexture;
 Texture2DArray LayerNormalTexture;
@@ -39,6 +45,28 @@ Texture2DArray LayerHeightTexture;
 float TextureScale @Default(0.5) @Clamp(0.001, 100.0);
 
 float RoughnessBias @Default(0.0) @Clamp(-1.0, 1.0);
+
+/// Distance at which the distance-driven quality reductions begin, in world units.
+float DetailFadeStart @Default(50.0) @Clamp(0.0, 100000.0);
+
+/// Distance at which they reach full strength. Must be greater than DetailFadeStart,
+/// otherwise every distance-driven effect is disabled.
+float DetailFadeEnd @Default(150.0) @Clamp(0.0, 100000.0);
+
+/// How far roughness is pushed toward 1 at DetailFadeEnd. Dims distant reflections to stop
+/// specular flickering. 0 disables it.
+float DistanceRoughness @Default(0.3) @Clamp(0.0, 1.0);
+
+/// Turns sub-pixel normal variance into roughness, which removes specular shimmer on
+/// high-frequency terrain at any distance. 0 disables it.
+float NormalVarianceRoughness @Default(0.5) @Clamp(0.0, 4.0);
+
+/// Fades the weaker material layers out with distance, so far terrain blends fewer of them.
+/// The weakest layer is gone by DetailFadeEnd, and each further layer one more DetailFadeEnd
+/// minus DetailFadeStart beyond that; the strongest explicit layer and the fallback are never
+/// dropped. Each layer fades smoothly and its weight passes to the fallback, so there is no pop.
+/// 0 disables it.
+float LayerDistanceFade @Default(1.0) @Clamp(0.0, 1.0);
 
 /// Width of the transition between two height-blended layers. Small values give hard,
 /// per-stone edges, large values approach a plain linear blend. TERRAIN_HEIGHT_BLEND only.
@@ -77,6 +105,11 @@ int2 Material15TextureIndex @Default(0) @Clamp(0, 255);
 
 FLOAT1(TextureScale);
 FLOAT1(RoughnessBias);
+FLOAT1(DetailFadeStart);
+FLOAT1(DetailFadeEnd);
+FLOAT1(DistanceRoughness);
+FLOAT1(NormalVarianceRoughness);
+FLOAT1(LayerDistanceFade);
 FLOAT1(HeightBlendDepth);
 FLOAT1(HeightBlendStrength);
 
@@ -99,18 +132,35 @@ INT2(Material15TextureIndex);
 
 [SHADER]
 
-#define USE_NORMAL
-#define USE_TANGENT
-#define USE_TEXCOORD0
 #define USE_SIMPLE_MATERIAL_MODEL
 #define USE_FOG
 #define USE_DECALS
 #define NO_SCREEN_SPACE_TECHNIQUES // deactivate AO on terrain geometry
-#define TERRAIN_LAYER_COUNT 5
+
+/// TERRAIN_LAYER_COUNT is an enumerator index, not a layer count, so translate it into the number
+/// the code below compares against. Every enumerator is listed explicitly: a catch-all #else would
+/// silently pick a count for any value that stopped matching.
+#if TERRAIN_LAYER_COUNT == TERRAIN_LAYER_COUNT_2
+#  define TERRAIN_ACTIVE_LAYERS 2
+#elif TERRAIN_LAYER_COUNT == TERRAIN_LAYER_COUNT_3
+#  define TERRAIN_ACTIVE_LAYERS 3
+#elif TERRAIN_LAYER_COUNT == TERRAIN_LAYER_COUNT_4
+#  define TERRAIN_ACTIVE_LAYERS 4
+#elif TERRAIN_LAYER_COUNT == TERRAIN_LAYER_COUNT_5
+#  define TERRAIN_ACTIVE_LAYERS 5
+#else
+#  error "Unhandled TERRAIN_LAYER_COUNT value."
+#endif
+
+#if RENDER_PASS != RENDER_PASS_DEPTH_ONLY
+#  define USE_NORMAL
+#  define USE_TANGENT
+#  define USE_TEXCOORD0
 
 /// Custom interpolator carrying w2 (x) and w3 (y) from the VS to the PS.
 /// w0 and w1 are in TexCoord0.xy; w_fallback is reconstructed in the PS.
-#define CUSTOM_INTERPOLATOR float2 MatWeightsHi : TEXCOORD2;
+#  define CUSTOM_INTERPOLATOR float2 MatWeightsHi : TEXCOORD2;
+#endif
 
 [VERTEXSHADER]
 
@@ -128,8 +178,10 @@ VS_OUT main(VS_IN Input)
   // FillVertexData does not know about CUSTOM_INTERPOLATOR, so MatWeightsHi would stay
   // uninitialized here. The preview mesh also has no baked terrain weights at all, so
   // pin the blend to material slot 0 at full strength: w0 = 1, all other weights 0.
+#if defined(USE_TEXCOORD0)
   Output.TexCoord0 = float2(1.0, 0.0);
   Output.MatWeightsHi = float2(0.0, 0.0);
+#endif
 
   return Output;
 }
@@ -147,9 +199,25 @@ VS_OUT main(uint VertexID : SV_VertexID)
 
 [PIXELSHADER]
 
+#if RENDER_PASS == RENDER_PASS_DEPTH_ONLY
+
+#include <Shaders/Materials/MaterialPixelShader.h>
+
+float3 GetNormal()     { return float3(0, 0, 1); }
+float3 GetBaseColor()  { return float3(0, 0, 0); }
+float  GetRoughness()  { return 1.0f; }
+float  GetMetallic()   { return 0.0f; }
+float  GetReflectance(){ return 0.5f; }
+float  GetOpacity()    { return 1.0f; }
+
+#else
+
 #define CUSTOM_GLOBALS                 \
   float3 TpWeights;                   \
   float  Scale;                       \
+  TriplanarUVs Uvs;                   \
+  float  CamDistance;                 \
+  float  NormalLength;                \
   uint2  TexIndices1;                 \
   uint2  TexIndices2;                 \
   uint2  TexIndices3;                 \
@@ -161,9 +229,11 @@ VS_OUT main(uint VertexID : SV_VertexID)
   float  MatWeight3;                  \
   float  MatWeightFallback;
 
+#include <Shaders/Terrain/Rendering/TerrainLayerSamplingTypes.h>
 #include <Shaders/Materials/MaterialPixelShader.h>
 #include <Shaders/Terrain/Rendering/TerrainLayerSampling.h>
 #include <Shaders/Terrain/Rendering/HeightfieldRenderConstants.h>
+#include <Shaders/Terrain/Rendering/TerrainDistanceFade.h>
 
 Texture2DArray LayerBaseTexture BIND_GROUP(BG_MATERIAL);
 SamplerState LayerBaseTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
@@ -179,12 +249,58 @@ Texture2DArray LayerHeightTexture BIND_GROUP(BG_MATERIAL);
 SamplerState LayerHeightTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
 #endif
 
+/// Fades the weaker layers out with view distance and hands their weight to the fallback.
+void ApplyLayerDistanceFade()
+{
+  const float amount = GetMaterialData(LayerDistanceFade);
+  if (amount <= 0.0)
+    return;
+
+  const float fadeStart = GetMaterialData(DetailFadeStart);
+  const float span = GetMaterialData(DetailFadeEnd) - fadeStart;
+  if (span <= 0.0)
+    return;
+
+  const float dist = G.CamDistance;
+
+  // Band n covers [fadeStart + n*span, fadeStart + (n+1)*span]. Layer 3 uses band 0, layer 2
+  // band 1, layer 1 band 2. 'amount' scales how much of each layer is actually removed.
+  float freed = 0.0;
+
+  #if TERRAIN_ACTIVE_LAYERS >= 5
+  {
+    const float keep = lerp(1.0, TerrainLayerDistanceFade(dist, fadeStart, fadeStart + span), amount);
+    freed += G.MatWeight3 * (1.0 - keep);
+    G.MatWeight3 *= keep;
+  }
+  #endif
+
+  #if TERRAIN_ACTIVE_LAYERS >= 4
+  {
+    const float keep = lerp(1.0, TerrainLayerDistanceFade(dist, fadeStart + span, fadeStart + 2.0 * span), amount);
+    freed += G.MatWeight2 * (1.0 - keep);
+    G.MatWeight2 *= keep;
+  }
+  #endif
+
+  #if TERRAIN_ACTIVE_LAYERS >= 3
+  {
+    const float keep = lerp(1.0, TerrainLayerDistanceFade(dist, fadeStart + 2.0 * span, fadeStart + 3.0 * span), amount);
+    freed += G.MatWeight1 * (1.0 - keep);
+    G.MatWeight1 *= keep;
+  }
+  #endif
+
+  G.MatWeightFallback += freed;
+}
+
 /// Reads the cell-level material set and per-pixel blend weights from the VS interpolants.
 ///
 /// DataOffsets.y (nointerpolation) carries 4 cell-level material indices (sorted ascending by index),
 /// identical for all 6 vertices of the cell. TexCoord0.xy carries w0/w1, MatWeightsHi.xy carries w2/w3.
 /// The fallback material slot index comes from the FallbackMaterialSlot push constant.
-/// TERRAIN_LAYER_COUNT controls how many explicit slots are active (3=2 explicit, 4=3 explicit, 5=4 explicit).
+/// TERRAIN_ACTIVE_LAYERS counts the blended layers including the fallback, so it activates
+/// TERRAIN_ACTIVE_LAYERS-1 explicit slots (2=1 explicit, 3=2, 4=3, 5=4).
 void SampleTerrainMask()
 {
   // In the material preview there is no terrain: DataOffsets.y carries the mesh's custom
@@ -216,22 +332,34 @@ void SampleTerrainMask()
   G.TexIndices4 = MatTextureIndices[clamp(matIdx3, 0u, 15u)];
   G.TexIndicesFallback = MatTextureIndices[clamp(fallbackIdx, 0u, 15u)];
 
+  // Dropping a layer gives its weight to the fallback rather than renormalizing the survivors.
+  // The bake sorts the slots by descending coverage, so the ones dropped here are the weakest,
+  // and the fallback is what the terrain reads as anyway where nothing is painted.
   G.MatWeight0 = w0;
-  G.MatWeight1 = w1;
 
-  #if TERRAIN_LAYER_COUNT >= 5
+  #if TERRAIN_ACTIVE_LAYERS >= 5
+    G.MatWeight1 = w1;
     G.MatWeight2 = w2;
     G.MatWeight3 = w3;
     G.MatWeightFallback = max(0.0, 1.0 - w0 - w1 - w2 - w3);
-  #elif TERRAIN_LAYER_COUNT >= 4
+  #elif TERRAIN_ACTIVE_LAYERS == 4
+    G.MatWeight1 = w1;
     G.MatWeight2 = w2;
     G.MatWeight3 = 0.0;
     G.MatWeightFallback = max(0.0, 1.0 - w0 - w1 - w2);
-  #else // TERRAIN_LAYER_COUNT == 3
+  #elif TERRAIN_ACTIVE_LAYERS == 3
+    G.MatWeight1 = w1;
     G.MatWeight2 = 0.0;
     G.MatWeight3 = 0.0;
     G.MatWeightFallback = max(0.0, 1.0 - w0 - w1);
+  #else // TERRAIN_ACTIVE_LAYERS == 2: one explicit layer plus the fallback.
+    G.MatWeight1 = 0.0;
+    G.MatWeight2 = 0.0;
+    G.MatWeight3 = 0.0;
+    G.MatWeightFallback = max(0.0, 1.0 - w0);
   #endif
+
+  ApplyLayerDistanceFade();
 }
 
 #if TERRAIN_HEIGHT_BLEND
@@ -239,7 +367,7 @@ void SampleTerrainMask()
 /// Samples the height map of every active layer and redistributes the blend weights, so that the
 /// tallest layer at a pixel wins it instead of all layers cross-fading linearly.
 ///
-/// Disabled layers (TERRAIN_LAYER_COUNT < 5) already carry a weight of 0 from SampleTerrainMask,
+/// Disabled layers (TERRAIN_ACTIVE_LAYERS < 5) already carry a weight of 0 from SampleTerrainMask,
 /// which keeps them out of the result and lets the compiler drop their texture fetches.
 void ApplyHeightBlend()
 {
@@ -253,7 +381,7 @@ void ApplyHeightBlend()
     // Skipping the fetch for layers that do not contribute is the common case: most pixels are
     // covered by only one or two layers.
     heights[i] = (weights[i] > 0.0)
-      ? TriplanarSampleColorArray(LayerHeightTexture, LayerHeightTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, indices[i]).r
+      ? TriplanarSampleColorArrayGrad(LayerHeightTexture, LayerHeightTexture_AutoSampler, G.Uvs, G.TpWeights, indices[i]).r
       : 0.0;
   }
 
@@ -272,6 +400,12 @@ void FillCustomGlobals()
 {
   G.TpWeights = TriplanarWeights(G.Input.Normal);
   G.Scale = GetMaterialData(TextureScale);
+
+  G.Uvs = ComputeTriplanarUVs(G.Input.WorldPosition, G.Input.Normal, G.Scale);
+  G.CamDistance = length(GetCameraPosition() - G.Input.WorldPosition);
+
+  G.NormalLength = 1.0;
+
   SampleTerrainMask();
 
 #if TERRAIN_HEIGHT_BLEND
@@ -279,75 +413,109 @@ void FillCustomGlobals()
 #endif
 }
 
+#define TERRAIN_ACCUM_COLOR(tex, weight, indices)                                                       \
+  if (weight > 0.0)                                                                                     \
+  {                                                                                                     \
+    result += TriplanarSampleColorArrayGrad(tex, tex##_AutoSampler, G.Uvs, G.TpWeights, indices).rgb * weight; \
+  }
+
+#define TERRAIN_ACCUM_SCALAR(tex, weight, indices)                                                      \
+  if (weight > 0.0)                                                                                     \
+  {                                                                                                     \
+    result += TriplanarSampleColorArrayGrad(tex, tex##_AutoSampler, G.Uvs, G.TpWeights, indices).r * weight; \
+  }
+
+#define TERRAIN_ACCUM_NORMAL(tex, weight, indices)                                                      \
+  if (weight > 0.0)                                                                                     \
+  {                                                                                                     \
+    result += TriplanarSampleNormalArrayGrad(tex, tex##_AutoSampler, G.Uvs, G.TpWeights, indices) * weight; \
+  }
+
 float3 GetNormal()
 {
-  const float3 n0 = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices1);
-  const float3 n1 = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices2);
+  float3 result = float3(0.0, 0.0, 0.0);
 
-  float3 result = n0 * G.MatWeight0 + n1 * G.MatWeight1;
-
-  #if TERRAIN_LAYER_COUNT >= 4
-    const float3 n2 = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices3);
-    result += n2 * G.MatWeight2;
+  TERRAIN_ACCUM_NORMAL(LayerNormalTexture, G.MatWeight0, G.TexIndices1)
+  #if TERRAIN_ACTIVE_LAYERS >= 3
+    TERRAIN_ACCUM_NORMAL(LayerNormalTexture, G.MatWeight1, G.TexIndices2)
   #endif
 
-  #if TERRAIN_LAYER_COUNT >= 5
-    const float3 n3 = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices4);
-    result += n3 * G.MatWeight3;
+  #if TERRAIN_ACTIVE_LAYERS >= 4
+    TERRAIN_ACCUM_NORMAL(LayerNormalTexture, G.MatWeight2, G.TexIndices3)
   #endif
 
-  const float3 nFallback = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndicesFallback);
-  result += nFallback * G.MatWeightFallback;
+  #if TERRAIN_ACTIVE_LAYERS >= 5
+    TERRAIN_ACCUM_NORMAL(LayerNormalTexture, G.MatWeight3, G.TexIndices4)
+  #endif
 
-  return normalize(result);
+  TERRAIN_ACCUM_NORMAL(LayerNormalTexture, G.MatWeightFallback, G.TexIndicesFallback)
+
+  // A pixel whose weights all rounded to zero would leave result at 0; fall back to the
+  // interpolated vertex normal rather than normalizing a zero vector.
+  const float lenSq = dot(result, result);
+  if (lenSq < 1e-12)
+  {
+    G.NormalLength = 1.0;
+    return G.Input.Normal;
+  }
+
+  const float len = sqrt(lenSq);
+  G.NormalLength = len;
+
+  return result / len;
 }
 
 float3 GetBaseColor()
 {
-  const float3 c0 = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices1).rgb;
-  const float3 c1 = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices2).rgb;
+  float3 result = float3(0.0, 0.0, 0.0);
 
-  float3 result = c0 * G.MatWeight0 + c1 * G.MatWeight1;
-
-  #if TERRAIN_LAYER_COUNT >= 4
-    const float3 c2 = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices3).rgb;
-    result += c2 * G.MatWeight2;
+  TERRAIN_ACCUM_COLOR(LayerBaseTexture, G.MatWeight0, G.TexIndices1)
+  #if TERRAIN_ACTIVE_LAYERS >= 3
+    TERRAIN_ACCUM_COLOR(LayerBaseTexture, G.MatWeight1, G.TexIndices2)
   #endif
 
-  #if TERRAIN_LAYER_COUNT >= 5
-    const float3 c3 = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices4).rgb;
-    result += c3 * G.MatWeight3;
+  #if TERRAIN_ACTIVE_LAYERS >= 4
+    TERRAIN_ACCUM_COLOR(LayerBaseTexture, G.MatWeight2, G.TexIndices3)
   #endif
 
-  const float3 cFallback = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndicesFallback).rgb;
-  result += cFallback * G.MatWeightFallback;
+  #if TERRAIN_ACTIVE_LAYERS >= 5
+    TERRAIN_ACCUM_COLOR(LayerBaseTexture, G.MatWeight3, G.TexIndices4)
+  #endif
+
+  TERRAIN_ACCUM_COLOR(LayerBaseTexture, G.MatWeightFallback, G.TexIndicesFallback)
 
   return result;
 }
 
 float GetRoughness()
 {
-  const float r0 = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices1).r;
-  const float r1 = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices2).r;
+  float result = 0.0;
 
-  float result = r0 * G.MatWeight0 + r1 * G.MatWeight1;
-
-  #if TERRAIN_LAYER_COUNT >= 4
-    const float r2 = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices3).r;
-    result += r2 * G.MatWeight2;
+  TERRAIN_ACCUM_SCALAR(LayerRoughnessTexture, G.MatWeight0, G.TexIndices1)
+  #if TERRAIN_ACTIVE_LAYERS >= 3
+    TERRAIN_ACCUM_SCALAR(LayerRoughnessTexture, G.MatWeight1, G.TexIndices2)
   #endif
 
-  #if TERRAIN_LAYER_COUNT >= 5
-    const float r3 = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndices4).r;
-    result += r3 * G.MatWeight3;
+  #if TERRAIN_ACTIVE_LAYERS >= 4
+    TERRAIN_ACCUM_SCALAR(LayerRoughnessTexture, G.MatWeight2, G.TexIndices3)
   #endif
 
-  const float rFallback = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.TexIndicesFallback).r;
-  result += rFallback * G.MatWeightFallback;
+  #if TERRAIN_ACTIVE_LAYERS >= 5
+    TERRAIN_ACCUM_SCALAR(LayerRoughnessTexture, G.MatWeight3, G.TexIndices4)
+  #endif
 
-  return result + GetMaterialData(RoughnessBias);
+  TERRAIN_ACCUM_SCALAR(LayerRoughnessTexture, G.MatWeightFallback, G.TexIndicesFallback)
+
+  result += GetMaterialData(RoughnessBias);
+
+  result = TerrainNormalVarianceRoughness(result, G.NormalLength, GetMaterialData(NormalVarianceRoughness));
+
+  return TerrainDistanceRoughness(result, G.CamDistance,
+    GetMaterialData(DetailFadeStart), GetMaterialData(DetailFadeEnd), GetMaterialData(DistanceRoughness));
 }
 
 float GetMetallic()    { return 0.0f; }
 float GetReflectance() { return 0.5f; }
 float GetOpacity()     { return 1.0f; }
+
+#endif // RENDER_PASS != RENDER_PASS_DEPTH_ONLY

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldTerrainVS.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/HeightfieldTerrainVS.h
@@ -147,7 +147,10 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
   }
 
   float h = TerrainHeights[idx];
+
+#if defined(USE_NORMAL)
   float3 localNormal = DecodeTerrainNormal(TerrainNormals[idx]);
+#endif
 
   // LOD fade: pull the vertices that vanish at the next-coarser level toward the position they
   // interpolate to there. A vertex vanishes when its inner-grid index is odd along an axis; it then
@@ -167,16 +170,22 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
     const int sp = step * pitch;
 
     float targetH = h;
+#if defined(USE_NORMAL)
     float3 targetN = localNormal;
+#endif
     if (ox && !oy)
     {
       targetH = 0.5 * (TerrainHeights[idx - sx] + TerrainHeights[idx + sx]);
+#if defined(USE_NORMAL)
       targetN = 0.5 * (DecodeTerrainNormal(TerrainNormals[idx - sx]) + DecodeTerrainNormal(TerrainNormals[idx + sx]));
+#endif
     }
     else if (!ox && oy)
     {
       targetH = 0.5 * (TerrainHeights[idx - sp] + TerrainHeights[idx + sp]);
+#if defined(USE_NORMAL)
       targetN = 0.5 * (DecodeTerrainNormal(TerrainNormals[idx - sp]) + DecodeTerrainNormal(TerrainNormals[idx + sp]));
+#endif
     }
     else if (ox && oy)
     {
@@ -184,11 +193,15 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
       // lies exactly on that diagonal in the coarser LOD — its true height/normal there is the
       // average of the TR and BL corners only, not a bilinear blend of all 4 corners.
       targetH = 0.5 * (TerrainHeights[idx + sx - sp] + TerrainHeights[idx - sx + sp]);
+#if defined(USE_NORMAL)
       targetN = 0.5 * (DecodeTerrainNormal(TerrainNormals[idx + sx - sp]) + DecodeTerrainNormal(TerrainNormals[idx - sx + sp]));
+#endif
     }
 
     h = lerp(h, targetH, fade);
+#if defined(USE_NORMAL)
     localNormal = normalize(lerp(localNormal, targetN, fade));
+#endif
   }
 
   // Skirt vertices keep their real height and normal but are pushed down to hide seams between patches.
@@ -210,16 +223,36 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
   const float gridSpacing = GET_PUSH_CONSTANT(HeightfieldRenderConstants, GridSpacing);
   const float3 localPos = float3((float)bufX * gridSpacing, (float)bufY * gridSpacing, h + zOffset);
 
+  const float3 worldPos = mul(objectToWorld, float4(localPos, 1.0f)).xyz;
+
+#if defined(USE_NORMAL)
+  const float3 worldNormal = normalize(mul(objectToWorldNormal, localNormal));
+#endif
+
+#if defined(USE_TANGENT)
   // Analytical tangent for a heightfield: lies in the XZ plane, perpendicular to the normal.
   // Derived from dP/du = (GridSpacing, 0, dH/dx), orthogonalized: float3(n.z, 0, -n.x).
   const float3 localTangent = normalize(float3(localNormal.z, 0.0, -localNormal.x));
   const float3 localBitangent = cross(localNormal, localTangent);
 
-  const float3 worldPos = mul(objectToWorld, float4(localPos, 1.0f)).xyz;
-  const float3 worldNormal = normalize(mul(objectToWorldNormal, localNormal));
   const float3 worldTangent = normalize(mul(objectToWorldNormal, localTangent));
   const float3 worldBitangent = normalize(mul(objectToWorldNormal, localBitangent));
+#endif
 
+  VS_OUT Output;
+  Output.Position = mul(GetWorldToScreenMatrix(), float4(worldPos, 1.0f));
+  Output.WorldPosition = worldPos;
+
+#if defined(USE_NORMAL)
+  Output.Normal = worldNormal;
+#endif
+
+#if defined(USE_TANGENT)
+  Output.Tangent = worldTangent;
+  Output.BiTangent = worldBitangent;
+#endif
+
+#if defined(USE_TEXCOORD0)
   // A carved corner holds the sentinel, not weights. Its own vertex is culled, but it still
   // contributes to surviving vertices in the same cell, so it unpacks to zero weight.
   const float4 wTL = UnpackWeights(packedTL);
@@ -228,22 +261,11 @@ VS_OUT FillHeightfieldTerrainVertexOutput(uint vertexID)
   const float4 wBR = UnpackWeights(packedBR);
   const float4 w = lerp(lerp(wTL, wTR, fx), lerp(wBL, wBR, fx), fy);
 
-  const float w0 = w.x;
-  const float w1 = w.y;
-  const float w2 = w.z;
-  const float w3 = w.w;
-
-  VS_OUT Output;
-  Output.Position = mul(GetWorldToScreenMatrix(), float4(worldPos, 1.0f));
-  Output.WorldPosition = worldPos;
-  Output.Normal = worldNormal;
-  Output.Tangent = worldTangent;
-  Output.BiTangent = worldBitangent;
-
   // TexCoord0: w0, w1. MatWeightsHi: w2, w3 (via CUSTOM_INTERPOLATOR).
   // The PS reconstructs w_fallback = max(0, 1 - w0 - w1 - w2 - w3).
-  Output.TexCoord0 = float2(w0, w1);
-  Output.MatWeightsHi = float2(w2, w3);
+  Output.TexCoord0 = float2(w.x, w.y);
+  Output.MatWeightsHi = float2(w.z, w.w);
+#endif
 
   // DataOffsets.x: instance data offset.
   // DataOffsets.y: 4 cell-level material indices — identical for all 6 vertices of this cell.

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainDistanceFade.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainDistanceFade.h
@@ -1,0 +1,49 @@
+#pragma once
+
+/// Distance-driven quality reduction shared by the terrain and voxel material shaders.
+///
+/// Driven by distance to the camera rather than by the geometric LOD level on purpose: LOD is
+/// chosen from geometric error, while the right moment to drop a texture layer or damp a highlight
+/// depends on how many texels land in a pixel. Tying them together would make one system's tuning
+/// leak into the other's.
+
+/// Fade band for a layer, as distances from the camera. Full strength below 'fadeStart', gone
+/// above 'fadeEnd'. An empty or inverted band never fades.
+float TerrainLayerDistanceFade(float distance, float fadeStart, float fadeEnd)
+{
+  if (fadeEnd <= fadeStart)
+    return 1.0;
+
+  return 1.0 - smoothstep(fadeStart, fadeEnd, distance);
+}
+
+/// Raises roughness with distance, so that distant specular highlights dim instead of flickering
+/// as the camera moves.
+///
+/// 'amount' is how far roughness is pushed toward 1 at and beyond 'fadeEnd'; 0 disables the effect.
+float TerrainDistanceRoughness(float roughness, float distance, float fadeStart, float fadeEnd, float amount)
+{
+  if (amount <= 0.0 || fadeEnd <= fadeStart)
+    return roughness;
+
+  const float t = smoothstep(fadeStart, fadeEnd, distance);
+  return saturate(roughness + t * amount * (1.0 - roughness));
+}
+
+/// Converts sub-pixel normal variance into additional roughness (a Toksvig-style estimate).
+///
+/// 'blendedNormalLength' is the length of the summed, not-yet-normalized normal. Averaging normals
+/// that disagree shortens the sum, so a short vector means the surface varies faster than a pixel
+/// can resolve. Unlike TerrainDistanceRoughness this helps at any distance, wherever the terrain is
+/// higher frequency than a pixel. A length of 1 means the normals agreed and roughness is unchanged.
+float TerrainNormalVarianceRoughness(float roughness, float blendedNormalLength, float strength)
+{
+  if (strength <= 0.0)
+    return roughness;
+
+  const float len = saturate(blendedNormalLength);
+  if (len >= 0.999)
+    return roughness;
+
+  return saturate(roughness + (1.0 - len) * strength * (1.0 - roughness));
+}

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainLayerSampling.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainLayerSampling.h
@@ -1,7 +1,15 @@
 #pragma once
 
-/// Shared pixel-shader resources and triplanar sampling helpers used by all terrain and voxel material shaders.
-/// Include this after MaterialPixelShader.h so that DecodeNormalTexture is available.
+/// Triplanar sampling helpers shared by the terrain and voxel material shaders.
+/// Include after MaterialPixelShader.h, which provides DecodeNormalTexture.
+///
+/// Sampling only exists in explicit-gradient form. The shaders skip zero-weight layers inside
+/// branches, where a plain Sample's implicit derivatives would be undefined.
+
+/// Weight at which one projection covers the pixel on its own and the other two fetches are
+/// skipped. Weights sum to 1, so this leaves under a 1000th for the other two - less than an
+/// 8-bit texture can represent.
+#define TERRAIN_TRIPLANAR_DOMINANT 0.999
 
 /// Triplanar blend weights matching the formula used by the engine's SampleTexture3Way helper.
 float3 TriplanarWeights(float3 worldNormal)
@@ -11,43 +19,45 @@ float3 TriplanarWeights(float3 worldNormal)
   return w / (w.x + w.y + w.z);
 }
 
-/// Samples one layer of a 2D array texture using triplanar projection.
-/// UV sign flips follow SampleTexture3Way convention so textures are consistent on both sides of each axis.
-/// matIndex: x = top/Z-facing texture array layer, y = side/XY-facing texture array layer.
-float4 TriplanarSampleColorArray(Texture2DArray tex, SamplerState samp, float3 worldPos, float3 worldNormal, float3 weights, float scale, uint2 matIndex)
+/// Samples one layer of a 2D array texture using precomputed triplanar UVs and gradients.
+/// Safe inside divergent flow control.
+float4 TriplanarSampleColorArrayGrad(Texture2DArray tex, SamplerState samp, TriplanarUVs uv, float3 weights, uint2 matIndex)
 {
-  float2 layer = (float2)matIndex;
-  float3 ns = sign(worldNormal) * scale;
+  const float2 layer = (float2)matIndex;
 
-  float4 cX = tex.Sample(samp, float3(worldPos.yz * float2(-ns.x, -scale), layer.y));
-  float4 cY = tex.Sample(samp, float3(worldPos.xz * float2(ns.y, -scale), layer.y));
-  float4 cZ = tex.Sample(samp, float3(worldPos.xy * float2(ns.z, scale), layer.x));
+  // TriplanarWeights drives the off-axis weights to exactly 0 on near-axis-aligned surfaces,
+  // which on a heightfield is most of the screen.
+  if (weights.z >= TERRAIN_TRIPLANAR_DOMINANT)
+    return tex.SampleGrad(samp, float3(uv.UvZ, layer.x), uv.DdxZ, uv.DdyZ);
+
+  const float4 cX = tex.SampleGrad(samp, float3(uv.UvX, layer.y), uv.DdxX, uv.DdyX);
+  const float4 cY = tex.SampleGrad(samp, float3(uv.UvY, layer.y), uv.DdxY, uv.DdyY);
+  const float4 cZ = tex.SampleGrad(samp, float3(uv.UvZ, layer.x), uv.DdxZ, uv.DdyZ);
 
   return cX * weights.x + cY * weights.y + cZ * weights.z;
 }
 
-/// Samples one layer of a 2D array normal map using triplanar projection and returns a world-space normal.
-/// UV sign flips match TriplanarSampleColorArray; tangent frames are derived from those same UVs so the
-/// normals are consistent with the color textures on both sides of each axis.
-/// matIndex: x = top/Z-facing texture array layer, y = side/XY-facing texture array layer.
-float3 TriplanarSampleNormalArray(Texture2DArray tex, SamplerState samp, float3 worldPos, float3 worldNormal, float3 weights, float scale, uint2 matIndex)
+/// Normal-map counterpart of TriplanarSampleColorArrayGrad. Each projection's tangent-space normal
+/// is rotated into world space by swizzling, with the axis signs applied so that back faces of a
+/// projection are not mirrored.
+float3 TriplanarSampleNormalArrayGrad(Texture2DArray tex, SamplerState samp, TriplanarUVs uv, float3 weights, uint2 matIndex)
 {
-  float2 layer = (float2)matIndex;
-  float3 sn = sign(worldNormal);
-  float3 ns = sn * scale;
+  const float2 layer = (float2)matIndex;
+  const float3 sn = uv.SignN;
 
-  float3 nX = DecodeNormalTexture(tex.Sample(samp, float3(worldPos.yz * float2(-ns.x, -scale), layer.y)));
-  float3 nY = DecodeNormalTexture(tex.Sample(samp, float3(worldPos.xz * float2(ns.y, -scale), layer.y)));
-  float3 nZ = DecodeNormalTexture(tex.Sample(samp, float3(worldPos.xy * float2(ns.z, scale), layer.x)));
+  if (weights.z >= TERRAIN_TRIPLANAR_DOMINANT)
+  {
+    const float3 nOnly = DecodeNormalTexture(tex.SampleGrad(samp, float3(uv.UvZ, layer.x), uv.DdxZ, uv.DdyZ));
+    return normalize(float3(nOnly.x * sn.z, nOnly.y, nOnly.z * sn.z));
+  }
 
-  // Reorient each tangent-space normal into world space using the tangent frame implied by the UV mapping above.
-  // Tangent frames (T, B, N) are derived as cross(dPos/dU, dPos/dV):
-  //   X proj: T=(0,-sn.x,0), B=(0,0,-1), N=(sn.x,0,0)  ->  (nX.z*sn.x, -nX.x*sn.x, -nX.y)
-  //   Y proj: T=(sn.y, 0,0), B=(0,0,-1), N=(0,sn.y,0)  ->  (nY.x*sn.y,  nY.z*sn.y,  -nY.y)
-  //   Z proj: T=(sn.z, 0,0), B=(0, 1,0), N=(0,0,sn.z)  ->  (nZ.x*sn.z,  nZ.y,        nZ.z*sn.z)
-  float3 wsX = float3(nX.z * sn.x, -nX.x * sn.x, -nX.y);
-  float3 wsY = float3(nY.x * sn.y, nY.z * sn.y, -nY.y);
-  float3 wsZ = float3(nZ.x * sn.z, nZ.y, nZ.z * sn.z);
+  const float3 nX = DecodeNormalTexture(tex.SampleGrad(samp, float3(uv.UvX, layer.y), uv.DdxX, uv.DdyX));
+  const float3 nY = DecodeNormalTexture(tex.SampleGrad(samp, float3(uv.UvY, layer.y), uv.DdxY, uv.DdyY));
+  const float3 nZ = DecodeNormalTexture(tex.SampleGrad(samp, float3(uv.UvZ, layer.x), uv.DdxZ, uv.DdyZ));
+
+  const float3 wsX = float3(nX.z * sn.x, -nX.x * sn.x, -nX.y);
+  const float3 wsY = float3(nY.x * sn.y, nY.z * sn.y, -nY.y);
+  const float3 wsZ = float3(nZ.x * sn.z, nZ.y, nZ.z * sn.z);
 
   return normalize(wsX * weights.x + wsY * weights.y + wsZ * weights.z);
 }

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainLayerSamplingTypes.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainLayerSamplingTypes.h
@@ -36,8 +36,11 @@ TriplanarUVs ComputeTriplanarUVs(float3 worldPos, float3 worldNormal, float scal
   r.UvY = worldPos.xz * float2(ns.y, -scale);
   r.UvZ = worldPos.xy * float2(ns.z, scale);
 
-  r.DdxX = ddx(r.UvX); r.DdyX = ddy(r.UvX);
-  r.DdxY = ddx(r.UvY); r.DdyY = ddy(r.UvY);
-  r.DdxZ = ddx(r.UvZ); r.DdyZ = ddy(r.UvZ);
+  r.DdxX = ddx(r.UvX);
+  r.DdyX = ddy(r.UvX);
+  r.DdxY = ddx(r.UvY);
+  r.DdyY = ddy(r.UvY);
+  r.DdxZ = ddx(r.UvZ);
+  r.DdyZ = ddy(r.UvZ);
   return r;
 }

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainLayerSamplingTypes.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/TerrainLayerSamplingTypes.h
@@ -1,0 +1,43 @@
+#pragma once
+
+/// Triplanar UV types shared by the terrain and voxel material shaders.
+///
+/// Separate from TerrainLayerSampling.h because the pixel shaders name TriplanarUVs in their
+/// CUSTOM_GLOBALS macro, which MaterialPixelShader.h expands into PS_GLOBALS: the type must be
+/// declared before that header, while the sampling functions depend on it and must come after.
+
+/// Precomputed triplanar UVs and their screen-space derivatives.
+///
+/// The UVs depend only on world position and scale, never on the material index, so all layers of
+/// a blend share one of these. Sampling with the explicit gradients is what makes it legal to skip
+/// a layer's fetches inside a branch: a plain Sample derives its mip level from neighbouring lanes
+/// in the 2x2 quad, which is undefined when those lanes took the other side of the branch.
+struct TriplanarUVs
+{
+  float2 UvX;
+  float2 UvY;
+  float2 UvZ;
+  float2 DdxX, DdyX;
+  float2 DdxY, DdyY;
+  float2 DdxZ, DdyZ;
+  float3 SignN; ///< sign(worldNormal), needed to reorient normal maps.
+};
+
+/// Builds the triplanar UV set for a pixel. Must be called from uniform control flow - i.e. before
+/// any branch that skips a layer - because the ddx/ddy here are the gradients every later
+/// SampleGrad relies on.
+TriplanarUVs ComputeTriplanarUVs(float3 worldPos, float3 worldNormal, float scale)
+{
+  TriplanarUVs r;
+  r.SignN = sign(worldNormal);
+  const float3 ns = r.SignN * scale;
+
+  r.UvX = worldPos.yz * float2(-ns.x, -scale);
+  r.UvY = worldPos.xz * float2(ns.y, -scale);
+  r.UvZ = worldPos.xy * float2(ns.z, scale);
+
+  r.DdxX = ddx(r.UvX); r.DdyX = ddy(r.UvX);
+  r.DdxY = ddx(r.UvY); r.DdyY = ddy(r.UvY);
+  r.DdxZ = ddx(r.UvZ); r.DdyZ = ddy(r.UvZ);
+  return r;
+}

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/VoxelMeshMaterial.ezShader
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/VoxelMeshMaterial.ezShader
@@ -40,6 +40,21 @@ float TextureScale @Default(0.5) @Clamp(0.001, 100.0);
 
 float RoughnessBias @Default(0.0) @Clamp(-1.0, 1.0);
 
+/// Distance at which the distance-driven quality reductions begin, in world units.
+float DetailFadeStart @Default(50.0) @Clamp(0.0, 100000.0);
+
+/// Distance at which they reach full strength. Must be greater than DetailFadeStart,
+/// otherwise every distance-driven effect is disabled.
+float DetailFadeEnd @Default(150.0) @Clamp(0.0, 100000.0);
+
+/// How far roughness is pushed toward 1 at DetailFadeEnd. Dims distant reflections to stop
+/// specular flickering. 0 disables it.
+float DistanceRoughness @Default(0.3) @Clamp(0.0, 1.0);
+
+/// Turns sub-pixel normal variance into roughness, which removes specular shimmer on
+/// high-frequency terrain at any distance. 0 disables it.
+float NormalVarianceRoughness @Default(0.5) @Clamp(0.0, 4.0);
+
 /// Width of the transition between the base and the override material. Small values give hard,
 /// per-stone edges, large values approach a plain linear blend. TERRAIN_HEIGHT_BLEND only.
 float HeightBlendDepth @Default(0.15) @Clamp(0.001, 1.0);
@@ -77,6 +92,10 @@ int2 Material15TextureIndex @Default(0) @Clamp(0, 255);
 
 FLOAT1(TextureScale);
 FLOAT1(RoughnessBias);
+FLOAT1(DetailFadeStart);
+FLOAT1(DetailFadeEnd);
+FLOAT1(DistanceRoughness);
+FLOAT1(NormalVarianceRoughness);
 FLOAT1(HeightBlendDepth);
 FLOAT1(HeightBlendStrength);
 
@@ -99,13 +118,16 @@ INT2(Material15TextureIndex);
 
 [SHADER]
 
-#define USE_NORMAL
-#define USE_TANGENT
-#define USE_TEXCOORD0
 #define USE_SIMPLE_MATERIAL_MODEL
 #define USE_FOG
 #define USE_DECALS
 #define NO_SCREEN_SPACE_TECHNIQUES // deactivate AO on terrain geometry
+
+#if RENDER_PASS != RENDER_PASS_DEPTH_ONLY
+#  define USE_NORMAL
+#  define USE_TANGENT
+#  define USE_TEXCOORD0
+#endif
 
 [VERTEXSHADER]
 
@@ -122,7 +144,9 @@ VS_OUT main(VS_IN Input)
 
   // The preview mesh carries no per-vertex material strength. Pin it to 0 so only the
   // base material contributes, instead of whatever the mesh happens to have in TexCoord0.
+#if defined(USE_TEXCOORD0)
   Output.TexCoord0 = float2(0.0, 0.0);
+#endif
 
   return Output;
 }
@@ -140,16 +164,34 @@ VS_OUT main(uint VertexID : SV_VertexID)
 
 [PIXELSHADER]
 
+#if RENDER_PASS == RENDER_PASS_DEPTH_ONLY
+
+#include <Shaders/Materials/MaterialPixelShader.h>
+
+float3 GetNormal()     { return float3(0, 0, 1); }
+float3 GetBaseColor()  { return float3(0, 0, 0); }
+float  GetRoughness()  { return 1.0f; }
+float  GetMetallic()   { return 0.0f; }
+float  GetReflectance(){ return 0.5f; }
+float  GetOpacity()    { return 1.0f; }
+
+#else
+
 #define CUSTOM_GLOBALS \
   float3 TpWeights; \
   float  Scale;     \
+  TriplanarUVs Uvs; \
+  float  CamDistance; \
+  float  NormalLength; \
   uint2  BaseTexIdx; \
   uint2  OverTexIdx; \
   float  MatStrength;
 
+#include <Shaders/Terrain/Rendering/TerrainLayerSamplingTypes.h>
 #include <Shaders/Materials/MaterialPixelShader.h>
 #include <Shaders/Terrain/Rendering/VoxelMeshRenderConstants.h>
 #include <Shaders/Terrain/Rendering/TerrainLayerSampling.h>
+#include <Shaders/Terrain/Rendering/TerrainDistanceFade.h>
 
 Texture2DArray LayerBaseTexture BIND_GROUP(BG_MATERIAL);
 SamplerState LayerBaseTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
@@ -179,6 +221,11 @@ void FillCustomGlobals()
   G.TpWeights = TriplanarWeights(G.Input.Normal);
   G.Scale = GetMaterialData(TextureScale);
 
+  G.Uvs = ComputeTriplanarUVs(G.Input.WorldPosition, G.Input.Normal, G.Scale);
+  G.CamDistance = length(GetCameraPosition() - G.Input.WorldPosition);
+
+  G.NormalLength = 1.0;
+
   // In the material preview there is no volume: DataOffsets.y carries the mesh's custom
   // instance data offset rather than a material slot, and the render push constants are
   // not bound. Resolve both layers to material slot 0 instead.
@@ -207,8 +254,8 @@ void FillCustomGlobals()
     float weights[TERRAIN_MAX_BLEND_LAYERS] = { 1.0 - G.MatStrength, G.MatStrength, 0.0, 0.0, 0.0 };
     float heights[TERRAIN_MAX_BLEND_LAYERS] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-    heights[0] = (weights[0] > 0.0) ? TriplanarSampleColorArray(LayerHeightTexture, LayerHeightTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.BaseTexIdx).r : 0.0;
-    heights[1] = (weights[1] > 0.0) ? TriplanarSampleColorArray(LayerHeightTexture, LayerHeightTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.OverTexIdx).r : 0.0;
+    heights[0] = (weights[0] > 0.0) ? TriplanarSampleColorArrayGrad(LayerHeightTexture, LayerHeightTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx).r : 0.0;
+    heights[1] = (weights[1] > 0.0) ? TriplanarSampleColorArrayGrad(LayerHeightTexture, LayerHeightTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx).r : 0.0;
 
     TerrainHeightBlendWeights(weights, heights, GetMaterialData(HeightBlendDepth), GetMaterialData(HeightBlendStrength));
 
@@ -217,33 +264,77 @@ void FillCustomGlobals()
 #endif
 }
 
+/// The two layers are a lerp, so a pixel at either extreme needs only one of them, and painted
+/// voxel terrain is mostly at one extreme or the other. Safe only because the sampling uses
+/// gradients computed in FillCustomGlobals. Below this a layer contributes less than a 255th.
+#define VOXEL_BLEND_EPSILON 0.004
+
 float3 GetNormal()
 {
-  float matStrength = G.MatStrength;
+  const float matStrength = G.MatStrength;
 
-  float3 mainNormal     = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.BaseTexIdx);
-  float3 overrideNormal = TriplanarSampleNormalArray(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.OverTexIdx);
-  return normalize(lerp(mainNormal, overrideNormal, matStrength));
+  if (matStrength <= VOXEL_BLEND_EPSILON)
+    return TriplanarSampleNormalArrayGrad(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx);
+
+  if (matStrength >= 1.0 - VOXEL_BLEND_EPSILON)
+    return TriplanarSampleNormalArrayGrad(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx);
+
+  const float3 mainNormal = TriplanarSampleNormalArrayGrad(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx);
+  const float3 overrideNormal = TriplanarSampleNormalArrayGrad(LayerNormalTexture, LayerNormalTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx);
+
+  // Only the mixed case can shorten the sum; the two single-layer paths above return a normal
+  // that is already unit length, leaving G.NormalLength at its initial 1.
+  const float3 blended = lerp(mainNormal, overrideNormal, matStrength);
+  const float lenSq = dot(blended, blended);
+  if (lenSq < 1e-12)
+    return G.Input.Normal;
+
+  const float len = sqrt(lenSq);
+  G.NormalLength = len;
+  return blended / len;
 }
 
 float3 GetBaseColor()
 {
-  float matStrength = G.MatStrength;
+  const float matStrength = G.MatStrength;
 
-  float3 mainColor     = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.BaseTexIdx).rgb;
-  float3 overrideColor = TriplanarSampleColorArray(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.OverTexIdx).rgb;
+  if (matStrength <= VOXEL_BLEND_EPSILON)
+    return TriplanarSampleColorArrayGrad(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx).rgb;
+
+  if (matStrength >= 1.0 - VOXEL_BLEND_EPSILON)
+    return TriplanarSampleColorArrayGrad(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx).rgb;
+
+  const float3 mainColor = TriplanarSampleColorArrayGrad(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx).rgb;
+  const float3 overrideColor = TriplanarSampleColorArrayGrad(LayerBaseTexture, LayerBaseTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx).rgb;
   return lerp(mainColor, overrideColor, matStrength);
+}
+
+float ApplyRoughnessFalloff(float roughness)
+{
+  const float r = TerrainNormalVarianceRoughness(roughness, G.NormalLength, GetMaterialData(NormalVarianceRoughness));
+
+  return TerrainDistanceRoughness(r, G.CamDistance,
+    GetMaterialData(DetailFadeStart), GetMaterialData(DetailFadeEnd), GetMaterialData(DistanceRoughness));
 }
 
 float GetRoughness()
 {
-  float matStrength = G.MatStrength;
+  const float matStrength = G.MatStrength;
+  const float bias = GetMaterialData(RoughnessBias);
 
-  float mainRoughness     = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.BaseTexIdx).r;
-  float overrideRoughness = TriplanarSampleColorArray(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Input.WorldPosition, G.Input.Normal, G.TpWeights, G.Scale, G.OverTexIdx).r;
-  return lerp(mainRoughness, overrideRoughness, matStrength) + GetMaterialData(RoughnessBias);
+  if (matStrength <= VOXEL_BLEND_EPSILON)
+    return ApplyRoughnessFalloff(TriplanarSampleColorArrayGrad(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx).r + bias);
+
+  if (matStrength >= 1.0 - VOXEL_BLEND_EPSILON)
+    return ApplyRoughnessFalloff(TriplanarSampleColorArrayGrad(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx).r + bias);
+
+  const float mainRoughness = TriplanarSampleColorArrayGrad(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Uvs, G.TpWeights, G.BaseTexIdx).r;
+  const float overrideRoughness = TriplanarSampleColorArrayGrad(LayerRoughnessTexture, LayerRoughnessTexture_AutoSampler, G.Uvs, G.TpWeights, G.OverTexIdx).r;
+  return ApplyRoughnessFalloff(lerp(mainRoughness, overrideRoughness, matStrength) + bias);
 }
 
 float  GetMetallic()    { return 0.0f; }
 float  GetReflectance() { return 0.5f; }
 float  GetOpacity()     { return 1.0f; }
+
+#endif // RENDER_PASS != RENDER_PASS_DEPTH_ONLY

--- a/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/VoxelTerrainVS.h
+++ b/Data/Plugins/TerrainPlugin/Shaders/Terrain/Rendering/VoxelTerrainVS.h
@@ -29,17 +29,25 @@ VS_OUT FillVoxelTerrainVertexOutput(uint vertexID)
   const float3x3 objectToWorldNormal = TransformToRotation(instanceData.ObjectToWorldNormal);
 
   const float3 worldPos = mul(objectToWorld, float4(v.Position, 1.0f)).xyz;
-  const float3 worldNormal = normalize(mul(objectToWorldNormal, v.Normal));
-  const float3 worldTangent = normalize(mul(objectToWorldNormal, v.Tangent));
-  const float3 worldBitan = cross(worldNormal, worldTangent) * v.BitangentSign;
 
   VS_OUT Output;
   Output.Position = mul(GetWorldToScreenMatrix(), float4(worldPos, 1.0f));
   Output.WorldPosition = worldPos;
+
+#if defined(USE_NORMAL)
+  const float3 worldNormal = normalize(mul(objectToWorldNormal, v.Normal));
   Output.Normal = worldNormal;
+#endif
+
+#if defined(USE_TANGENT)
+  const float3 worldTangent = normalize(mul(objectToWorldNormal, v.Tangent));
   Output.Tangent = worldTangent;
-  Output.BiTangent = worldBitan;
+  Output.BiTangent = cross(worldNormal, worldTangent) * v.BitangentSign;
+#endif
+
+#if defined(USE_TEXCOORD0)
   Output.TexCoord0 = float2(v.MaterialStrength, 0.0f);
+#endif
   Output.DataOffsets = uint3(GET_PUSH_CONSTANT(VoxelMeshRenderConstants, InstanceDataOffset), v.Material, 0);
   return Output;
 }

--- a/Data/Samples/Testing Chambers/Materials/HeightfieldTerrain.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/HeightfieldTerrain.ezMaterialAsset
@@ -14,7 +14,7 @@ o
 			s{"Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader"}
 		}
 		Uuid %DocumentID{u4{2939980432966898598,5123535222320404264}}
-		u4 %Hash{2175574400443948647}
+		u4 %Hash{5176759378660577778}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -44,7 +44,14 @@ o
 	u3 %v{2}
 	p
 	{
+		f %DetailFadeEnd{0x00001643}
+		f %DetailFadeStart{0x00004842}
+		f %DistanceRoughness{0x9A99993E}
+		f %HeightBlendDepth{0x9A99193E}
+		f %HeightBlendStrength{0x0000803F}
 		s %LayerBaseTexture{"{ c658f867-d3f8-43a8-b32d-55326fac60b8 }"}
+		f %LayerDistanceFade{0x0000803F}
+		s %LayerHeightTexture{""}
 		s %LayerNormalTexture{"{ 6ce1da02-2df2-45b2-b832-05f2ca1c58b0 }"}
 		s %LayerRoughnessTexture{"{ fad8ea85-dca7-471c-8ed2-2aa362a6e98a }"}
 		Vec2i %Material0TextureIndex{i3{0,3}}
@@ -63,7 +70,10 @@ o
 		Vec2i %Material7TextureIndex{i3{0,0}}
 		Vec2i %Material8TextureIndex{i3{0,0}}
 		Vec2i %Material9TextureIndex{i3{0,0}}
+		f %NormalVarianceRoughness{0x0000003F}
 		f %RoughnessBias{0x9A99993E}
+		b %TERRAIN_HEIGHT_BLEND{0}
+		s %TERRAIN_LAYER_COUNT{"TERRAIN_LAYER_COUNT::TERRAIN_LAYER_COUNT_4"}
 		f %TextureScale{0x0000803E}
 	}
 }
@@ -101,6 +111,21 @@ Types
 {
 o
 {
+	Uuid %id{u4{12069708629301776720,67012498554694102}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{3}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"TERRAIN_LAYER_COUNT::TERRAIN_LAYER_COUNT_5"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
 	Uuid %id{u4{7369592584561371515,150400655728789348}}
 	s %t{"ezAssetBrowserAttribute"}
 	u3 %v{1}
@@ -113,12 +138,33 @@ o
 }
 o
 {
+	Uuid %id{u4{10672315248821158020,179910596886057100}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
 	Uuid %id{u4{9205541992466402666,186874392873755262}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %Category{"Constant"}
+		s %Category{"Texture 2D Array"}
+	}
+}
+o
+{
+	Uuid %id{u4{18308791882563814745,203515907974022957}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -128,7 +174,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Constant"}
+		s %Category{"Texture 2D Array"}
 	}
 }
 o
@@ -138,8 +184,8 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x00000000006AF840}
+		d %Min{0}
 	}
 }
 o
@@ -155,6 +201,61 @@ o
 }
 o
 {
+	Uuid %id{u4{16485452990292330254,1121001473970618846}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{12520160862183815312,1158941142778598753}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{17883027717386338810,17458077941186039043}}
+			Uuid{u4{6569368953563292095,16494892384683494934}}
+			Uuid{u4{9569518251607794526,6607092935971004369}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material11TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{16412303273944805495,1212576274389728207}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{1710323405866019760,1251243441414123688}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{2}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"TERRAIN_LAYER_COUNT::TERRAIN_LAYER_COUNT_4"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
 	Uuid %id{u4{15413940758266627569,1279269645272081217}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -164,13 +265,12 @@ o
 		{
 			Uuid{u4{7250675865458471679,14531238039950568399}}
 			Uuid{u4{9913575226874912632,15347216907554822691}}
-			Uuid{u4{14248664697253576779,2873200965269304292}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material0TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"LayerHeightTexture"}
+		s %Type{"ezString"}
 	}
 }
 o
@@ -209,8 +309,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material4TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"DetailFadeEnd"}
+		s %Type{"float"}
 	}
 }
 o
@@ -229,23 +329,46 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material14TextureIndex"}
+		s %Name{"Material4TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
 o
 {
-	Uuid %id{u4{8820087521711943202,1773338324845188565}}
-	s %t{"ezDefaultValueAttribute"}
+	Uuid %id{u4{16335394635301454693,1737494308735698540}}
+	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
 	p
 	{
-		d %Value{0x000000000000E03F}
+		s %Category{"Constant"}
 	}
 }
 o
 {
-	Uuid %id{u4{16464840001761193246,2198804663616932243}}
+	Uuid %id{u4{8820087521711943202,1773338324845188565}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
+	}
+}
+o
+{
+	Uuid %id{u4{18117489964292268012,1805092991287234378}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5652526738073281610,1952280738535507060}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
@@ -255,7 +378,17 @@ o
 }
 o
 {
-	Uuid %id{u4{8987311824184136364,2409447045907881852}}
+	Uuid %id{u4{16464840001761193246,2198804663616932243}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x0000000000C06240}
+	}
+}
+o
+{
+	Uuid %id{u4{4198074495338471950,2369286958872476224}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
@@ -266,13 +399,13 @@ o
 }
 o
 {
-	Uuid %id{u4{14248664697253576779,2873200965269304292}}
+	Uuid %id{u4{8987311824184136364,2409447045907881852}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x0000000000002040}
+		d %Min{0}
 	}
 }
 o
@@ -285,13 +418,12 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{13190717143765194437,8548150097298246046}}
-			Uuid{u4{5464329951760534644,12906048599693856869}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"LayerBaseTexture"}
-		s %Type{"ezString"}
+		s %Name{"TERRAIN_HEIGHT_BLEND"}
+		s %Type{"bool"}
 	}
 }
 o
@@ -301,7 +433,7 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		d %Value{0}
 	}
 }
 o
@@ -316,12 +448,53 @@ o
 }
 o
 {
+	Uuid %id{u4{11645471629338567715,3403615986446464018}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
 	Uuid %id{u4{1988912220773894488,3468905694479318033}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
 	{
+		d %Value{0x000000000000F03F}
+	}
+}
+o
+{
+	Uuid %id{u4{7529508801036155283,3658285239355829804}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
 		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5877074315639393525,3770462819600735557}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{37249423877281366,8276535100810871563}}
+			Uuid{u4{7529508801036155283,3658285239355829804}}
+			Uuid{u4{9045978581583065342,18428894937491690442}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material6TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -361,8 +534,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material9TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"HeightBlendStrength"}
+		s %Type{"float"}
 	}
 }
 o
@@ -381,8 +554,18 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material15TextureIndex"}
+		s %Name{"Material5TextureIndex"}
 		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{14601882517188426695,4525152091223970829}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
 	}
 }
 o
@@ -397,13 +580,33 @@ o
 }
 o
 {
+	Uuid %id{u4{12152399311985567776,4764872268882798184}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6036001158941637075,17802389732328037611}}
+			Uuid{u4{7581591733663768612,17992789728269732326}}
+			Uuid{u4{4198074495338471950,2369286958872476224}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material14TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
 	Uuid %id{u4{16476296193928194358,4786681196936811731}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x000000000000F03F}
+		d %Min{0xFCA9F1D24D62503F}
 	}
 }
 o
@@ -422,8 +625,19 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material1TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"TextureScale"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{17203298723546164386,5605781596748664585}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -452,7 +666,27 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material12TextureIndex"}
+		s %Name{"Material2TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{4583982028366450019,6161268091588636960}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{14601882517188426695,4525152091223970829}}
+			Uuid{u4{10672315248821158020,179910596886057100}}
+			Uuid{u4{11645471629338567715,3403615986446464018}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material9TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -463,8 +697,28 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x00000000006AF840}
+		d %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1336037387047791160,6454066589016885858}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6563016698852059067,17503352743004224854}}
+			Uuid{u4{2376981321516353237,9840032468653905571}}
+			Uuid{u4{18117489964292268012,1805092991287234378}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material12TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -474,8 +728,8 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x000000000000F03F}
+		d %Min{0}
 	}
 }
 o
@@ -494,8 +748,34 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material5TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"DistanceRoughness"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{8691052114951979646,6600019732779189274}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"TERRAIN_LAYER_COUNT::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{9569518251607794526,6607092935971004369}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -533,9 +813,53 @@ o
 			Uuid{u4{16331638923269598771,9456887736781520849}}
 			Uuid{u4{8990274543164517455,1581340151129969481}}
 			Uuid{u4{16958132923163242020,4502293605212118720}}
+			Uuid{u4{5877074315639393525,3770462819600735557}}
+			Uuid{u4{10332662905821166192,7394157695202134438}}
+			Uuid{u4{5182259047919394677,15929927060125901618}}
+			Uuid{u4{4583982028366450019,6161268091588636960}}
+			Uuid{u4{11085264537604208453,13611551932350270583}}
+			Uuid{u4{12520160862183815312,1158941142778598753}}
+			Uuid{u4{1336037387047791160,6454066589016885858}}
+			Uuid{u4{18066984931075501039,15749112657138355668}}
+			Uuid{u4{12152399311985567776,4764872268882798184}}
+			Uuid{u4{15888129782685754049,14678349001995441870}}
 		}
 		s %TypeName{"Shaders/Terrain/Rendering/HeightfieldTerrainMaterial.ezShader"}
 		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{13328727669727062355,6952870625715257493}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{8691052114951979646,6600019732779189274}}
+			Uuid{u4{13145545523292746002,15375711250010411577}}
+			Uuid{u4{7918194815859837583,13933425052954966241}}
+			Uuid{u4{1710323405866019760,1251243441414123688}}
+			Uuid{u4{12069708629301776720,67012498554694102}}
+		}
+		s %TypeName{"TERRAIN_LAYER_COUNT"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10904068194824620910,6957729818446917274}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
 	}
 }
 o
@@ -555,8 +879,8 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x0000000000005940}
+		d %Min{0xFCA9F1D24D62503F}
 	}
 }
 o
@@ -567,6 +891,37 @@ o
 	p
 	{
 		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{14718291313743502098,7208541282696313580}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{10332662905821166192,7394157695202134438}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{461432912756223032,8989465043873713048}}
+			Uuid{u4{9764287098515015059,15699503400351132839}}
+			Uuid{u4{17203298723546164386,5605781596748664585}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material7TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -587,7 +942,7 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		d %Value{0x0000000000004940}
 	}
 }
 o
@@ -606,8 +961,28 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material10TextureIndex"}
+		s %Name{"Material0TextureIndex"}
 		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
+	Uuid %id{u4{37249423877281366,8276535100810871563}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{13733969756782393792,8367871711637362742}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
 	}
 }
 o
@@ -626,8 +1001,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material3TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"DetailFadeStart"}
+		s %Type{"float"}
 	}
 }
 o
@@ -637,7 +1012,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Texture 2D Array"}
+		s %Category{"Permutation"}
 	}
 }
 o
@@ -678,13 +1053,12 @@ o
 		{
 			Uuid{u4{9205541992466402666,186874392873755262}}
 			Uuid{u4{8820087521711943202,1773338324845188565}}
-			Uuid{u4{17749391292166086983,15577698135042086177}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"TextureScale"}
-		s %Type{"float"}
+		s %Name{"LayerNormalTexture"}
+		s %Type{"ezString"}
 	}
 }
 o
@@ -703,8 +1077,18 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material6TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"NormalVarianceRoughness"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{461432912756223032,8989465043873713048}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
 	}
 }
 o
@@ -726,6 +1110,16 @@ o
 }
 o
 {
+	Uuid %id{u4{11816312644178277284,9396037123001561422}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
 	Uuid %id{u4{16331638923269598771,9456887736781520849}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -740,7 +1134,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material13TextureIndex"}
+		s %Name{"Material3TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -767,11 +1161,13 @@ o
 o
 {
 	Uuid %id{u4{5957660404394561304,9515383668883416018}}
-	s %t{"ezDefaultValueAttribute"}
+	s %t{"ezAssetBrowserAttribute"}
 	u3 %v{1}
 	p
 	{
-		d %Value{0}
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
 	}
 }
 o
@@ -784,13 +1180,22 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{16907322887811790051,13687322136943272676}}
-			Uuid{u4{4251194945262961408,11821115039431085430}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"LayerNormalTexture"}
-		s %Type{"ezString"}
+		s %Flags{"ezPropertyFlags::IsEnum"}
+		s %Name{"TERRAIN_LAYER_COUNT"}
+		s %Type{"TERRAIN_LAYER_COUNT"}
+	}
+}
+o
+{
+	Uuid %id{u4{2376981321516353237,9840032468653905571}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
 	}
 }
 o
@@ -819,7 +1224,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material11TextureIndex"}
+		s %Name{"Material1TextureIndex"}
 		s %Type{"ezVec2I32"}
 	}
 }
@@ -834,13 +1239,22 @@ o
 		{
 			Uuid{u4{16890735475343751395,438795542531386630}}
 			Uuid{u4{5957660404394561304,9515383668883416018}}
-			Uuid{u4{5916727006005447353,16807514780976745976}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"RoughnessBias"}
-		s %Type{"float"}
+		s %Name{"LayerRoughnessTexture"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{9148790651075073791,11257534082662237277}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
 	}
 }
 o
@@ -866,18 +1280,6 @@ o
 }
 o
 {
-	Uuid %id{u4{4251194945262961408,11821115039431085430}}
-	s %t{"ezAssetBrowserAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
-		s %Filter{";CompatibleAsset_Texture_2D;"}
-		s %RequiredTag{""}
-	}
-}
-o
-{
 	Uuid %id{u4{3331401452160560417,11930522611801557628}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -891,7 +1293,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"LayerRoughnessTexture"}
+		s %Name{"LayerBaseTexture"}
 		s %Type{"ezString"}
 	}
 }
@@ -922,8 +1324,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material2TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"RoughnessBias"}
+		s %Type{"float"}
 	}
 }
 o
@@ -938,14 +1340,13 @@ o
 }
 o
 {
-	Uuid %id{u4{5464329951760534644,12906048599693856869}}
-	s %t{"ezAssetBrowserAttribute"}
+	Uuid %id{u4{18305013262455841048,13229273622886424627}}
+	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
-		s %Filter{";CompatibleAsset_Texture_2D;"}
-		s %RequiredTag{""}
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -960,12 +1361,32 @@ o
 }
 o
 {
+	Uuid %id{u4{11085264537604208453,13611551932350270583}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{16412303273944805495,1212576274389728207}}
+			Uuid{u4{11816312644178277284,9396037123001561422}}
+			Uuid{u4{18305013262455841048,13229273622886424627}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material10TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
 	Uuid %id{u4{16907322887811790051,13687322136943272676}}
 	s %t{"ezCategoryAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %Category{"Texture 2D Array"}
+		s %Category{"Permutation"}
 	}
 }
 o
@@ -975,7 +1396,33 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		d %Value{0x000000000000E03F}
+	}
+}
+o
+{
+	Uuid %id{u4{7918194815859837583,13933425052954966241}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"TERRAIN_LAYER_COUNT::TERRAIN_LAYER_COUNT_3"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{9950643931557968123,14146833621878340295}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 o
@@ -996,7 +1443,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Constant"}
+		s %Category{"Texture 2D Array"}
 	}
 }
 o
@@ -1006,7 +1453,27 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		d %Value{0x000000000000E03F}
+	}
+}
+o
+{
+	Uuid %id{u4{15888129782685754049,14678349001995441870}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{16335394635301454693,1737494308735698540}}
+			Uuid{u4{9148790651075073791,11257534082662237277}}
+			Uuid{u4{9950643931557968123,14146833621878340295}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material15TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -1039,22 +1506,28 @@ o
 o
 {
 	Uuid %id{u4{9913575226874912632,15347216907554822691}}
-	s %t{"ezDefaultValueAttribute"}
+	s %t{"ezAssetBrowserAttribute"}
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
 	}
 }
 o
 {
-	Uuid %id{u4{17749391292166086983,15577698135042086177}}
-	s %t{"ezClampValueAttribute"}
-	u3 %v{1}
+	Uuid %id{u4{13145545523292746002,15375711250010411577}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
 	p
 	{
-		d %Max{0x0000000000005940}
-		d %Min{0xFCA9F1D24D62503F}
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"TERRAIN_LAYER_COUNT::TERRAIN_LAYER_COUNT_2"}
+		s %Type{"ezInt32"}
 	}
 }
 o
@@ -1069,13 +1542,43 @@ o
 }
 o
 {
+	Uuid %id{u4{9764287098515015059,15699503400351132839}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{18066984931075501039,15749112657138355668}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{10904068194824620910,6957729818446917274}}
+			Uuid{u4{13733969756782393792,8367871711637362742}}
+			Uuid{u4{14718291313743502098,7208541282696313580}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material13TextureIndex"}
+		s %Type{"ezVec2I32"}
+	}
+}
+o
+{
 	Uuid %id{u4{9799177655920870254,15804462813259033477}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x000000000000F03F}
+		d %Min{0}
 	}
 }
 o
@@ -1085,7 +1588,27 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		d %Value{0x333333333333D33F}
+	}
+}
+o
+{
+	Uuid %id{u4{5182259047919394677,15929927060125901618}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{16485452990292330254,1121001473970618846}}
+			Uuid{u4{5652526738073281610,1952280738535507060}}
+			Uuid{u4{18308791882563814745,203515907974022957}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Name{"Material8TextureIndex"}
+		s %Type{"ezVec2I32"}
 	}
 }
 o
@@ -1115,7 +1638,7 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Value{0}
+		d %Value{0x000000000000F03F}
 	}
 }
 o
@@ -1130,18 +1653,7 @@ o
 }
 o
 {
-	Uuid %id{u4{5916727006005447353,16807514780976745976}}
-	s %t{"ezClampValueAttribute"}
-	u3 %v{1}
-	p
-	{
-		d %Max{0x000000000000F03F}
-		d %Min{0x000000000000F0BF}
-	}
-}
-o
-{
-	Uuid %id{u4{901121186701669687,16911889839370700666}}
+	Uuid %id{u4{6569368953563292095,16494892384683494934}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
 	p
@@ -1151,13 +1663,23 @@ o
 }
 o
 {
+	Uuid %id{u4{901121186701669687,16911889839370700666}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x333333333333C33F}
+	}
+}
+o
+{
 	Uuid %id{u4{10110885146045856267,17055361430250250091}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x000000000000F03F}
+		d %Min{0x000000000000F0BF}
 	}
 }
 o
@@ -1176,8 +1698,28 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material8TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"HeightBlendDepth"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{17883027717386338810,17458077941186039043}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{6563016698852059067,17503352743004224854}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
 	}
 }
 o
@@ -1214,8 +1756,8 @@ o
 	u3 %v{1}
 	p
 	{
-		i4 %Max{255}
-		i4 %Min{0}
+		d %Max{0x0000000000001040}
+		d %Min{0}
 	}
 }
 o
@@ -1244,8 +1786,18 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType"}
-		s %Name{"Material7TextureIndex"}
-		s %Type{"ezVec2I32"}
+		s %Name{"LayerDistanceFade"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{6036001158941637075,17802389732328037611}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
 	}
 }
 o
@@ -1267,6 +1819,16 @@ o
 }
 o
 {
+	Uuid %id{u4{7581591733663768612,17992789728269732326}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Value{0}
+	}
+}
+o
+{
 	Uuid %id{u4{5030680158680079231,18410952876772242771}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -1280,6 +1842,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezMaterialAssetProperties"}
 		u3 %TypeVersion{4}
+	}
+}
+o
+{
+	Uuid %id{u4{9045978581583065342,18428894937491690442}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i4 %Max{255}
+		i4 %Min{0}
 	}
 }
 }


### PR DESCRIPTION
A bunch of performance optimizations for the terrain shaders:

* Don't sample material layers that don't need it.
* Handle DEPTH_ONLY permutation properly
* Added 'TERRAIN_LAYER_COUNT' permutation variable, for users to choose. Defaults to 3 instead of 5 now.
* Fade out weakest material layers at a distance.
* Raise roughness with distance and normal variance, to reduce specular flickering.

Visually there is no difference up close, and barely a difference in the distance. Since it smoothly fades over, there is no noticeable popping. Also 3 material layers (1 base layer + 2 overrides) covers the vast majority of cases well enough.