### PR TITLE
ezBlackboardCondition is now shown in one line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs/
 .vscode/
 .claude/*
 !.claude/settings.json

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -41,6 +41,7 @@
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <EditorFramework/Project/ProjectCreation.h>
 #include <EditorFramework/PropertyGrid/AssetBrowserPropertyWidget.moc.h>
+#include <EditorFramework/PropertyGrid/BlackboardConditionWidget.moc.h>
 #include <EditorFramework/PropertyGrid/DynamicEnumPropertyWidget.moc.h>
 #include <EditorFramework/PropertyGrid/DynamicStringEnumPropertyWidget.moc.h>
 #include <EditorFramework/PropertyGrid/ExposedBoneWidget.moc.h>
@@ -75,10 +76,11 @@
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/UIServices/ImageCache.moc.h>
 #include <GuiFoundation/UIServices/QtProgressbar.h>
-#include <QSvgRenderer>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 #include <ToolsFoundation/Document/PrefabCache.h>
 #include <ToolsFoundation/Document/PrefabUtils.h>
+
+#include <QSvgRenderer>
 #include <ads/DockManager.h>
 
 void ezCompilerPreferences_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
@@ -168,6 +170,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezExposedParametersAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtExposedParametersPropertyWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezGameObjectReferenceAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtGameObjectReferencePropertyWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezExposedBone>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtExposedBoneWidget(); });
+    ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezBlackboardCondition>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtBlackboardConditionWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezCompilerPreferences>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtCompilerPreferencesWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezCodeEditorPreferences>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtCodeEditorPreferencesWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezImageSliderUiAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtPropertyEditorSliderWidget(); });
@@ -225,6 +228,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezGameObjectReferenceAttribute>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezExposedParametersAttribute>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezExposedBone>());
+    ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezBlackboardCondition>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezCompilerPreferences>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezCodeEditorPreferences>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezImageSliderUiAttribute>());

--- a/Code/Editor/EditorFramework/PropertyGrid/BlackboardConditionWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/BlackboardConditionWidget.moc.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Core/Utils/Blackboard.h>
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h>
+
+class QHBoxLayout;
+class QComboBox;
+class ezQtDoubleSpinBox;
+class ezQtDynamicStringEnumMenuButton;
+
+/// Displays all properties of ezBlackboardCondition (entry name, operator and comparison value) in a single row.
+///
+/// ezBlackboardCondition is a custom variant type, so the entire condition is edited as a single value. The entry
+/// name reuses ezQtDynamicStringEnumMenuButton with the "BlackboardKeysEnum" dynamic string enum that is registered
+/// on the reflected property.
+class EZ_EDITORFRAMEWORK_DLL ezQtBlackboardConditionWidget : public ezQtStandardPropertyWidget
+{
+  Q_OBJECT;
+
+public:
+  ezQtBlackboardConditionWidget();
+  virtual ~ezQtBlackboardConditionWidget();
+
+protected Q_SLOTS:
+  void onOperatorChanged(int iIndex);
+  void onBeginTemporary();
+  void onEndTemporary();
+  void onValueChanged();
+
+protected:
+  virtual void OnInit() override;
+  virtual void InternalSetValue(const ezVariant& value) override;
+
+  void SetEntryName(ezStringView sName);
+  void BroadcastCurrentValue();
+
+  bool m_bTemporaryCommand = false;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtDynamicStringEnumMenuButton* m_pEntryButton = nullptr;
+  QComboBox* m_pOperator = nullptr;
+  ezQtDoubleSpinBox* m_pComparisonValue = nullptr;
+  ezBlackboardCondition m_CurrentValue;
+};

--- a/Code/Editor/EditorFramework/PropertyGrid/DynamicStringEnumMenuButton.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/DynamicStringEnumMenuButton.moc.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <Foundation/Containers/Map.h>
+#include <Foundation/Strings/String.h>
+
+#include <QPushButton>
+
+class QMenu;
+class ezDocument;
+class ezDynamicStringEnum;
+class ezQtSearchableMenu;
+
+/// A push button with a searchable drop-down menu that lets the user pick a value from an ezDynamicStringEnum.
+///
+/// Emits ValueSelected once the user picks a value. If the enum supports editing (storage file or edit command), an
+/// entry to edit the available values is added as well. This is the shared building block used wherever a dynamic
+/// string enum has to be edited, e.g. the property grid widget for ezDynamicStringEnumAttribute.
+class EZ_EDITORFRAMEWORK_DLL ezQtDynamicStringEnumMenuButton : public QPushButton
+{
+  Q_OBJECT;
+
+public:
+  explicit ezQtDynamicStringEnumMenuButton(QWidget* pParent = nullptr);
+
+  /// Selects which dynamic string enum the menu presents.
+  void SetEnum(ezStringView sEnumName);
+  ezDynamicStringEnum* GetEnum() const { return m_pEnum; }
+
+  /// The document is passed along when refreshing values and when invoking the enum's edit command. May be null.
+  void SetDocument(const ezDocument* pDocument) { m_pDocument = pDocument; }
+
+  /// Updates the text shown on the button to the currently selected value.
+  void SetCurrentValue(ezStringView sValue);
+
+Q_SIGNALS:
+  void ValueSelected(const QString& sValue);
+
+private Q_SLOTS:
+  void onMenuAboutToShow();
+
+private:
+  const ezDocument* m_pDocument = nullptr;
+  ezDynamicStringEnum* m_pEnum = nullptr;
+  QMenu* m_pMenu = nullptr;
+  ezQtSearchableMenu* m_pSearchableMenu = nullptr;
+  ezString m_sEnumName;
+
+  static ezMap<ezString, QString> s_LastSearch;
+};

--- a/Code/Editor/EditorFramework/PropertyGrid/DynamicStringEnumPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/DynamicStringEnumPropertyWidget.moc.h
@@ -4,8 +4,7 @@
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
 
 class QHBoxLayout;
-class ezDynamicStringEnum;
-class ezQtSearchableMenu;
+class ezQtDynamicStringEnumMenuButton;
 
 class EZ_EDITORFRAMEWORK_DLL ezQtDynamicStringEnumPropertyWidget : public ezQtStandardPropertyWidget
 {
@@ -13,9 +12,6 @@ class EZ_EDITORFRAMEWORK_DLL ezQtDynamicStringEnumPropertyWidget : public ezQtSt
 
 public:
   ezQtDynamicStringEnumPropertyWidget();
-
-protected slots:
-  void onMenuAboutToShow();
 
 protected:
   virtual void OnInit() override;
@@ -25,10 +21,5 @@ protected:
 
 protected:
   QHBoxLayout* m_pLayout = nullptr;
-  ezDynamicStringEnum* m_pEnum = nullptr;
-  QPushButton* m_pButton = nullptr;
-  QMenu* m_pMenu = nullptr;
-  ezQtSearchableMenu* m_pSearchableMenu = nullptr;
-  ezString m_sEnumAttribute;
-  static ezMap<ezString, QString> s_LastSearch;
+  ezQtDynamicStringEnumMenuButton* m_pButton = nullptr;
 };

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/BlackboardConditionWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/BlackboardConditionWidget.cpp
@@ -1,0 +1,151 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/PropertyGrid/BlackboardConditionWidget.moc.h>
+#include <EditorFramework/PropertyGrid/DynamicStringEnumMenuButton.moc.h>
+#include <Foundation/Reflection/ReflectionUtils.h>
+#include <Foundation/Strings/TranslationLookup.h>
+#include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
+#include <GuiFoundation/Widgets/DoubleSpinBox.moc.h>
+
+ezQtBlackboardConditionWidget::ezQtBlackboardConditionWidget()
+{
+  m_pLayout = new QHBoxLayout(this);
+  m_pLayout->setContentsMargins(0, 0, 0, 0);
+  m_pLayout->setSpacing(1);
+  setLayout(m_pLayout);
+
+  m_pEntryButton = new ezQtDynamicStringEnumMenuButton(this);
+  m_pEntryButton->installEventFilter(this);
+  m_pLayout->addWidget(m_pEntryButton, 2);
+
+  m_pOperator = new QComboBox(this);
+  m_pOperator->installEventFilter(this);
+  m_pLayout->addWidget(m_pOperator, 1);
+
+  m_pComparisonValue = new ezQtDoubleSpinBox(this);
+  m_pComparisonValue->setMinimum(-ezMath::Infinity<double>());
+  m_pComparisonValue->setMaximum(ezMath::Infinity<double>());
+  m_pComparisonValue->setSingleStep(0.1);
+  m_pComparisonValue->setAccelerated(true);
+  m_pComparisonValue->installEventFilter(m_pComparisonValue);
+  m_pLayout->addWidget(m_pComparisonValue, 1);
+}
+
+ezQtBlackboardConditionWidget::~ezQtBlackboardConditionWidget() = default;
+
+void ezQtBlackboardConditionWidget::OnInit()
+{
+  // Populate the operator drop down from the reflected enum.
+  {
+    ezQtScopedBlockSignals bs(m_pOperator);
+
+    ezHybridArray<ezReflectionUtils::EnumKeyValuePair, 16> enumValues;
+    ezReflectionUtils::GetEnumKeysAndValues(ezGetStaticRTTI<ezComparisonOperator>(), enumValues);
+    for (auto& val : enumValues)
+    {
+      m_pOperator->addItem(ezMakeQString(ezTranslate(val.m_sKey)), val.m_iValue);
+    }
+
+    connect(m_pOperator, SIGNAL(currentIndexChanged(int)), this, SLOT(onOperatorChanged(int)));
+  }
+
+  // Retrieve the dynamic string enum used for the entry name from the reflected property.
+  {
+    if (const ezAbstractProperty* pEntryProp = ezGetStaticRTTI<ezBlackboardCondition>()->FindPropertyByName("EntryName"))
+    {
+      if (const ezDynamicStringEnumAttribute* pAttr = pEntryProp->GetAttributeByType<ezDynamicStringEnumAttribute>())
+      {
+        m_pEntryButton->SetEnum(pAttr->GetDynamicEnumName());
+        m_pEntryButton->SetDocument(m_pGrid->GetDocument());
+      }
+    }
+
+    connect(m_pEntryButton, &ezQtDynamicStringEnumMenuButton::ValueSelected, this,
+      [this](const QString& sValue)
+      { SetEntryName(sValue.toUtf8().data()); });
+  }
+
+  connect(m_pComparisonValue, SIGNAL(editingFinished()), this, SLOT(onEndTemporary()));
+  connect(m_pComparisonValue, SIGNAL(valueChanged(double)), this, SLOT(onValueChanged()));
+}
+
+void ezQtBlackboardConditionWidget::InternalSetValue(const ezVariant& value)
+{
+  ezQtScopedBlockSignals bs(m_pOperator, m_pComparisonValue);
+
+  if (value.IsValid())
+  {
+    m_CurrentValue = value.Get<ezBlackboardCondition>();
+
+    m_pEntryButton->SetCurrentValue(m_CurrentValue.m_sEntryName.GetView());
+
+    for (int i = 0; i < m_pOperator->count(); ++i)
+    {
+      if (m_pOperator->itemData(i).toInt() == m_CurrentValue.m_Operator.GetValue())
+      {
+        m_pOperator->setCurrentIndex(i);
+        break;
+      }
+    }
+
+    m_pComparisonValue->setValue(m_CurrentValue.m_fComparisonValue);
+  }
+  else
+  {
+    m_CurrentValue = ezBlackboardCondition();
+    m_pEntryButton->setText(QStringLiteral("<Multiple Values>"));
+    m_pOperator->setCurrentIndex(-1);
+    m_pComparisonValue->setValueInvalid();
+  }
+}
+
+void ezQtBlackboardConditionWidget::BroadcastCurrentValue()
+{
+  ezVariant v;
+  v.CopyTypedObject(&m_CurrentValue, ezGetStaticRTTI<ezBlackboardCondition>());
+  BroadcastValueChanged(v);
+}
+
+void ezQtBlackboardConditionWidget::SetEntryName(ezStringView sName)
+{
+  m_CurrentValue.m_sEntryName.Assign(sName);
+  m_pEntryButton->SetCurrentValue(sName);
+
+  BroadcastCurrentValue();
+}
+
+void ezQtBlackboardConditionWidget::onOperatorChanged(int iIndex)
+{
+  if (iIndex < 0)
+    return;
+
+  m_CurrentValue.m_Operator.SetValue(static_cast<ezComparisonOperator::StorageType>(m_pOperator->currentData().toInt()));
+
+  BroadcastCurrentValue();
+}
+
+void ezQtBlackboardConditionWidget::onBeginTemporary()
+{
+  if (!m_bTemporaryCommand)
+  {
+    Broadcast(ezPropertyEvent::Type::BeginTemporary);
+    m_bTemporaryCommand = true;
+  }
+}
+
+void ezQtBlackboardConditionWidget::onEndTemporary()
+{
+  if (m_bTemporaryCommand)
+    Broadcast(ezPropertyEvent::Type::EndTemporary);
+
+  m_bTemporaryCommand = false;
+}
+
+void ezQtBlackboardConditionWidget::onValueChanged()
+{
+  onBeginTemporary();
+
+  m_CurrentValue.m_fComparisonValue = m_pComparisonValue->value();
+
+  BroadcastCurrentValue();
+}

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumMenuButton.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumMenuButton.cpp
@@ -1,0 +1,99 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Dialogs/EditDynamicEnumsDlg.moc.h>
+#include <EditorFramework/PropertyGrid/DynamicStringEnumMenuButton.moc.h>
+#include <GuiFoundation/Action/ActionManager.h>
+#include <GuiFoundation/UIServices/DynamicStringEnum.h>
+#include <GuiFoundation/Widgets/SearchableMenu.moc.h>
+#include <ToolsFoundation/Document/Document.h>
+
+ezMap<ezString, QString> ezQtDynamicStringEnumMenuButton::s_LastSearch;
+
+ezQtDynamicStringEnumMenuButton::ezQtDynamicStringEnumMenuButton(QWidget* pParent)
+  : QPushButton(pParent)
+{
+  setText("Select");
+  setStyleSheet("QPushButton { text-align:left; padding-left:5px; padding-top:3px; padding-bottom:3px; }");
+
+  m_pMenu = new QMenu(this);
+  m_pMenu->setToolTipsVisible(false);
+  connect(m_pMenu, &QMenu::aboutToShow, this, &ezQtDynamicStringEnumMenuButton::onMenuAboutToShow);
+  setMenu(m_pMenu);
+}
+
+void ezQtDynamicStringEnumMenuButton::SetEnum(ezStringView sEnumName)
+{
+  m_sEnumName = sEnumName;
+  m_pEnum = &ezDynamicStringEnum::GetDynamicEnum(m_sEnumName);
+}
+
+void ezQtDynamicStringEnumMenuButton::SetCurrentValue(ezStringView sValue)
+{
+  setText(ezMakeQString(sValue));
+}
+
+void ezQtDynamicStringEnumMenuButton::onMenuAboutToShow()
+{
+  if (m_pEnum == nullptr)
+    return;
+
+  m_pMenu->clear();
+
+  m_pSearchableMenu = new ezQtSearchableMenu(m_pMenu);
+
+  connect(m_pSearchableMenu, &ezQtSearchableMenu::MenuItemTriggered, m_pMenu, [this](const QString& sName, const QVariant& variant)
+    {
+      if (variant.toString() == "<item>")
+      {
+        Q_EMIT ValueSelected(sName);
+      }
+      else if (variant.toString() == "<edit>")
+      {
+        ezQtEditDynamicEnumsDlg dlg(m_pEnum, this);
+        if (dlg.exec() == QDialog::Accepted)
+        {
+          ezInt32 iEnum = dlg.GetSelectedItem();
+          if (iEnum >= 0)
+          {
+            Q_EMIT ValueSelected(ezMakeQString(m_pEnum->GetAllValidValues()[iEnum]));
+          }
+        }
+      }
+      else if (variant.toString() == "<cmd>")
+      {
+        ezActionManager::ExecuteAction({}, m_pEnum->GetEditCommand(), ezActionContext(const_cast<ezDocument*>(m_pDocument)), m_pEnum->GetEditCommandValue()).AssertSuccess();
+      }
+
+      m_pMenu->close(); });
+
+  connect(m_pSearchableMenu, &ezQtSearchableMenu::SearchTextChanged, m_pMenu,
+    [this](const QString& sText)
+    { s_LastSearch[m_sEnumName] = sText; });
+
+  {
+    ezDynamicStringEnum::RefreshValuesEvent e;
+    e.m_sEnumName = m_sEnumName;
+    e.m_pDocument = m_pDocument;
+    e.m_pEnum = m_pEnum;
+    ezDynamicStringEnum::s_RefreshValuesEvent.Broadcast(e);
+  }
+
+  for (const auto& val : m_pEnum->GetAllValidValues())
+  {
+    m_pSearchableMenu->AddItem(val, "", QString("<item>"));
+  }
+
+  if (!m_pEnum->GetEditCommand().IsEmpty())
+  {
+    m_pSearchableMenu->AddItem("< Edit Values... >", "", QString("<cmd>"), QIcon(":/GuiFoundation/Icons/Edit.svg"));
+  }
+  else if (!m_pEnum->GetStorageFile().IsEmpty())
+  {
+    m_pSearchableMenu->AddItem("< Edit Values... >", "", QString("<edit>"), QIcon(":/GuiFoundation/Icons/Edit.svg"));
+  }
+
+  m_pMenu->addAction(m_pSearchableMenu);
+
+  // important to do this last to make sure the search bar gets focus
+  m_pSearchableMenu->Finalize(s_LastSearch[m_sEnumName]);
+}

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
@@ -1,12 +1,9 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
-#include <EditorFramework/Dialogs/EditDynamicEnumsDlg.moc.h>
+#include <EditorFramework/PropertyGrid/DynamicStringEnumMenuButton.moc.h>
 #include <EditorFramework/PropertyGrid/DynamicStringEnumPropertyWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/UIServices/DynamicStringEnum.h>
-#include <GuiFoundation/Widgets/SearchableMenu.moc.h>
-
-ezMap<ezString, QString> ezQtDynamicStringEnumPropertyWidget::s_LastSearch;
 
 ezQtDynamicStringEnumPropertyWidget::ezQtDynamicStringEnumPropertyWidget()
   : ezQtStandardPropertyWidget()
@@ -15,13 +12,15 @@ ezQtDynamicStringEnumPropertyWidget::ezQtDynamicStringEnumPropertyWidget()
   m_pLayout->setContentsMargins(0, 0, 0, 0);
   setLayout(m_pLayout);
 
-  m_pButton = new QPushButton(this);
-  m_pButton->setText("Select");
-  m_pButton->setStyleSheet("QPushButton { text-align:left; padding-left:5px; padding-top:3px; padding-bottom:3px; }");
+  m_pButton = new ezQtDynamicStringEnumMenuButton(this);
 
   QSizePolicy policy = m_pButton->sizePolicy();
   policy.setHorizontalStretch(0);
   m_pButton->setSizePolicy(policy);
+
+  connect(m_pButton, &ezQtDynamicStringEnumMenuButton::ValueSelected, this,
+    [this](const QString& sValue)
+    { SetNewValue(sValue.toUtf8().data()); });
 
   m_pLayout->addWidget(m_pButton);
 }
@@ -36,24 +35,18 @@ void ezQtDynamicStringEnumPropertyWidget::OnInit()
 
   const ezDynamicStringEnumAttribute* pAttr = m_pProp->GetAttributeByType<ezDynamicStringEnumAttribute>();
 
-  m_sEnumAttribute = pAttr->GetDynamicEnumName();
-
-  m_pEnum = &ezDynamicStringEnum::GetDynamicEnum(m_sEnumAttribute);
+  m_pButton->SetEnum(pAttr->GetDynamicEnumName());
+  m_pButton->SetDocument(m_pGrid->GetDocument());
 
   if (auto pDefaultValueAttr = m_pProp->GetAttributeByType<ezDefaultValueAttribute>())
   {
-    m_pEnum->AddValidValue(pDefaultValueAttr->GetValue().ConvertTo<ezString>(), true);
+    m_pButton->GetEnum()->AddValidValue(pDefaultValueAttr->GetValue().ConvertTo<ezString>(), true);
   }
-
-  m_pMenu = new QMenu(m_pButton);
-  m_pMenu->setToolTipsVisible(false);
-  connect(m_pMenu, &QMenu::aboutToShow, this, &ezQtDynamicStringEnumPropertyWidget::onMenuAboutToShow);
-  m_pButton->setMenu(m_pMenu);
 }
 
 void ezQtDynamicStringEnumPropertyWidget::InternalSetValue(const ezVariant& value)
 {
-  m_pButton->setText(value.ConvertTo<ezString>().GetData());
+  m_pButton->SetCurrentValue(value.ConvertTo<ezString>());
 }
 
 void ezQtDynamicStringEnumPropertyWidget::SetNewValue(ezStringView sNewValue)
@@ -77,71 +70,4 @@ void ezQtDynamicStringEnumPropertyWidget::SetNewValue(ezStringView sNewValue)
 
   InternalSetValue(v);
   BroadcastValueChanged(v);
-}
-
-void ezQtDynamicStringEnumPropertyWidget::onMenuAboutToShow()
-{
-  m_pMenu->clear();
-
-  m_pSearchableMenu = new ezQtSearchableMenu(m_pMenu);
-
-  connect(m_pSearchableMenu, &ezQtSearchableMenu::MenuItemTriggered, m_pMenu, [this](const QString& sName, const QVariant& variant)
-    {
-      if (variant.toString() == "<item>")
-      {
-        SetNewValue(sName.toUtf8().data());
-      }
-      else if (variant.toString() == "<edit>")
-      {
-        ezQtEditDynamicEnumsDlg dlg(m_pEnum, this);
-        if (dlg.exec() == QDialog::Accepted)
-        {
-          ezInt32 iEnum = dlg.GetSelectedItem();
-          if (iEnum >= 0)
-          {
-            SetNewValue(m_pEnum->GetAllValidValues()[iEnum]);
-          }
-        }
-      }
-      else if (variant.toString() == "<cmd>")
-      {
-        ezActionManager::ExecuteAction({}, m_pEnum->GetEditCommand(), ezActionContext(const_cast<ezDocument*>(m_pGrid->GetDocument())), m_pEnum->GetEditCommandValue()).AssertSuccess();
-      }
-
-      m_pMenu->close();
-      //
-    });
-
-  connect(m_pSearchableMenu, &ezQtSearchableMenu::SearchTextChanged, m_pMenu,
-    [this](const QString& sText)
-    { s_LastSearch[m_sEnumAttribute] = sText; });
-
-  {
-    ezDynamicStringEnum::RefreshValuesEvent e;
-    e.m_sEnumName = m_sEnumAttribute;
-    e.m_pDocument = m_pGrid->GetDocument();
-    e.m_pEnum = m_pEnum;
-    ezDynamicStringEnum::s_RefreshValuesEvent.Broadcast(e);
-  }
-
-  const auto& AllValues = m_pEnum->GetAllValidValues();
-
-  for (const auto& val : AllValues)
-  {
-    m_pSearchableMenu->AddItem(val, "", QString("<item>"));
-  }
-
-  if (!m_pEnum->GetEditCommand().IsEmpty())
-  {
-    m_pSearchableMenu->AddItem("< Edit Values... >", "", QString("<cmd>"), QIcon(":/GuiFoundation/Icons/Edit.svg"));
-  }
-  else if (!m_pEnum->GetStorageFile().IsEmpty())
-  {
-    m_pSearchableMenu->AddItem("< Edit Values... >", "", QString("<edit>"), QIcon(":/GuiFoundation/Icons/Edit.svg"));
-  }
-
-  m_pMenu->addAction(m_pSearchableMenu);
-
-  // important to do this last to make sure the search bar gets focus
-  m_pSearchableMenu->Finalize(s_LastSearch[m_sEnumAttribute]);
 }

--- a/Code/Engine/Core/Utils/Blackboard.h
+++ b/Code/Engine/Core/Utils/Blackboard.h
@@ -250,9 +250,6 @@ struct EZ_CORE_DLL ezBlackboardCondition
 
   bool IsConditionMet(const ezBlackboard& blackboard) const;
 
-  ezResult Serialize(ezStreamWriter& inout_stream) const;
-  ezResult Deserialize(ezStreamReader& inout_stream);
-
   bool operator==(const ezBlackboardCondition& rhs) const
   {
     return m_sEntryName == rhs.m_sEntryName && m_fComparisonValue == rhs.m_fComparisonValue && m_Operator == rhs.m_Operator;
@@ -262,15 +259,16 @@ struct EZ_CORE_DLL ezBlackboardCondition
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_CORE_DLL, ezBlackboardCondition);
 EZ_DECLARE_CUSTOM_VARIANT_TYPE(ezBlackboardCondition);
 
-EZ_CORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezBlackboardCondition& value);
-EZ_CORE_DLL void operator>>(ezStreamReader& inout_stream, ezBlackboardCondition& ref_value);
+EZ_CORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezBlackboardCondition& cond);
+EZ_CORE_DLL void operator>>(ezStreamReader& inout_stream, ezBlackboardCondition& ref_cond);
 
 template <>
 struct ezHashHelper<ezBlackboardCondition>
 {
   EZ_ALWAYS_INLINE static ezUInt32 Hash(const ezBlackboardCondition& cond)
   {
-    ezUInt32 uiHash = ezHashingUtils::xxHash32(&cond.m_fComparisonValue, sizeof(double), cond.m_sEntryName.GetHash());
+    ezUInt32 uiHash = ezHashHelper<ezUInt64>::Hash(cond.m_sEntryName.GetHash());
+    uiHash = ezHashingUtils::xxHash32(&cond.m_fComparisonValue, sizeof(double), uiHash);
     const ezComparisonOperator::StorageType uiOperator = cond.m_Operator.GetValue();
     uiHash = ezHashingUtils::xxHash32(&uiOperator, sizeof(uiOperator), uiHash);
 

--- a/Code/Engine/Core/Utils/Blackboard.h
+++ b/Code/Engine/Core/Utils/Blackboard.h
@@ -252,6 +252,30 @@ struct EZ_CORE_DLL ezBlackboardCondition
 
   ezResult Serialize(ezStreamWriter& inout_stream) const;
   ezResult Deserialize(ezStreamReader& inout_stream);
+
+  bool operator==(const ezBlackboardCondition& rhs) const
+  {
+    return m_sEntryName == rhs.m_sEntryName && m_fComparisonValue == rhs.m_fComparisonValue && m_Operator == rhs.m_Operator;
+  }
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_CORE_DLL, ezBlackboardCondition);
+EZ_DECLARE_CUSTOM_VARIANT_TYPE(ezBlackboardCondition);
+
+EZ_CORE_DLL void operator<<(ezStreamWriter& inout_stream, const ezBlackboardCondition& value);
+EZ_CORE_DLL void operator>>(ezStreamReader& inout_stream, ezBlackboardCondition& ref_value);
+
+template <>
+struct ezHashHelper<ezBlackboardCondition>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(const ezBlackboardCondition& cond)
+  {
+    ezUInt32 uiHash = ezHashingUtils::xxHash32(&cond.m_fComparisonValue, sizeof(double), cond.m_sEntryName.GetHash());
+    const ezComparisonOperator::StorageType uiOperator = cond.m_Operator.GetValue();
+    uiHash = ezHashingUtils::xxHash32(&uiOperator, sizeof(uiOperator), uiHash);
+
+    return uiHash;
+  }
+
+  EZ_ALWAYS_INLINE static bool Equal(const ezBlackboardCondition& a, const ezBlackboardCondition& b) { return a == b; }
+};

--- a/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
+++ b/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/IO/Stream.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Reflection/Reflection.h>
+#include <Foundation/Types/VariantTypeRegistry.h>
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_BITFLAGS(ezBlackboardEntryFlags, 1)
@@ -388,6 +389,8 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezBlackboardCondition, ezNoBase, 1, ezRTTIDefault
   EZ_END_PROPERTIES;
 }
 EZ_END_STATIC_REFLECTED_TYPE;
+
+EZ_DEFINE_CUSTOM_VARIANT_TYPE(ezBlackboardCondition);
 // clang-format on
 
 bool ezBlackboardCondition::IsConditionMet(const ezBlackboard& blackboard) const
@@ -423,6 +426,16 @@ ezResult ezBlackboardCondition::Deserialize(ezStreamReader& inout_stream)
   inout_stream >> m_Operator;
   inout_stream >> m_fComparisonValue;
   return EZ_SUCCESS;
+}
+
+void operator<<(ezStreamWriter& inout_stream, const ezBlackboardCondition& value)
+{
+  value.Serialize(inout_stream).AssertSuccess();
+}
+
+void operator>>(ezStreamReader& inout_stream, ezBlackboardCondition& ref_value)
+{
+  ref_value.Deserialize(inout_stream).AssertSuccess();
 }
 
 EZ_STATICLINK_FILE(Core, Core_Utils_Implementation_Blackboard);

--- a/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
+++ b/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
@@ -407,35 +407,23 @@ bool ezBlackboardCondition::IsConditionMet(const ezBlackboard& blackboard) const
 
 constexpr ezTypeVersion s_BlackboardConditionVersion = 1;
 
-ezResult ezBlackboardCondition::Serialize(ezStreamWriter& inout_stream) const
+void operator<<(ezStreamWriter& inout_stream, const ezBlackboardCondition& cond)
 {
   inout_stream.WriteVersion(s_BlackboardConditionVersion);
 
-  inout_stream << m_sEntryName;
-  inout_stream << m_Operator;
-  inout_stream << m_fComparisonValue;
-  return EZ_SUCCESS;
+  inout_stream << cond.m_sEntryName;
+  inout_stream << cond.m_Operator;
+  inout_stream << cond.m_fComparisonValue;
 }
 
-ezResult ezBlackboardCondition::Deserialize(ezStreamReader& inout_stream)
+void operator>>(ezStreamReader& inout_stream, ezBlackboardCondition& ref_cond)
 {
   const ezTypeVersion uiVersion = inout_stream.ReadVersion(s_BlackboardConditionVersion);
   EZ_IGNORE_UNUSED(uiVersion);
 
-  inout_stream >> m_sEntryName;
-  inout_stream >> m_Operator;
-  inout_stream >> m_fComparisonValue;
-  return EZ_SUCCESS;
-}
-
-void operator<<(ezStreamWriter& inout_stream, const ezBlackboardCondition& value)
-{
-  value.Serialize(inout_stream).AssertSuccess();
-}
-
-void operator>>(ezStreamReader& inout_stream, ezBlackboardCondition& ref_value)
-{
-  ref_value.Deserialize(inout_stream).AssertSuccess();
+  inout_stream >> ref_cond.m_sEntryName;
+  inout_stream >> ref_cond.m_Operator;
+  inout_stream >> ref_cond.m_fComparisonValue;
 }
 
 EZ_STATICLINK_FILE(Core, Core_Utils_Implementation_Blackboard);

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
@@ -1,7 +1,11 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Foundation/IO/TypeVersionContext.h>
 #include <GameEngine/StateMachine/StateMachineBuiltins.h>
+
+#include <Foundation/IO/TypeVersionContext.h>
+#include <Foundation/Serialization/AbstractObjectGraph.h>
+#include <Foundation/Serialization/GraphPatch.h>
+#include <Foundation/Serialization/RttiConverter.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineState_NestedStateMachine, 1, ezRTTIDefaultAllocator<ezStateMachineState_NestedStateMachine>)
@@ -237,7 +241,7 @@ EZ_END_STATIC_REFLECTED_ENUM;
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineTransition_BlackboardConditions, 1, ezRTTIDefaultAllocator<ezStateMachineTransition_BlackboardConditions>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineTransition_BlackboardConditions, 2, ezRTTIDefaultAllocator<ezStateMachineTransition_BlackboardConditions>)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -286,6 +290,61 @@ ezResult ezStateMachineTransition_BlackboardConditions::Deserialize(ezStreamRead
   inout_stream >> m_Operator;
   return inout_stream.ReadArray(m_Conditions);
 }
+
+// Before version 2 each ezBlackboardCondition was a reflected class, so the "Conditions" array stored references to
+// separate sub-nodes. ezBlackboardCondition is now a custom variant type, so the conditions are inlined as values into
+// the array. This patch rebuilds the condition objects from the referenced sub-nodes and removes those nodes.
+class ezStateMachineTransition_BlackboardConditions_1_2 : public ezGraphPatch
+{
+public:
+  ezStateMachineTransition_BlackboardConditions_1_2()
+    : ezGraphPatch("ezStateMachineTransition_BlackboardConditions", 2)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    auto* pConditions = pNode->FindProperty("Conditions");
+    if (pConditions == nullptr || !pConditions->m_Value.IsA<ezVariantArray>())
+      return;
+
+    const ezVariantArray oldArray = pConditions->m_Value.Get<ezVariantArray>();
+
+    ezVariantArray newArray;
+    newArray.Reserve(oldArray.GetCount());
+
+    for (const ezVariant& element : oldArray)
+    {
+      if (!element.IsA<ezUuid>())
+      {
+        // Already inlined (e.g. patched before), keep as-is.
+        newArray.PushBack(element);
+        continue;
+      }
+
+      const ezUuid guid = element.Get<ezUuid>();
+      ezAbstractObjectNode* pConditionNode = pGraph->GetNode(guid);
+      if (pConditionNode == nullptr)
+        continue;
+
+      ezRttiConverterContext context;
+      ezRttiConverterReader reader(pGraph, &context);
+      void* pObject = reader.CreateObjectFromNode(pConditionNode);
+      if (pObject == nullptr)
+        continue;
+
+      ezVariant value;
+      value.MoveTypedObject(pObject, ezGetStaticRTTI<ezBlackboardCondition>());
+      newArray.PushBack(value);
+
+      pGraph->RemoveNode(guid);
+    }
+
+    pConditions->m_Value = newArray;
+  }
+};
+
+ezStateMachineTransition_BlackboardConditions_1_2 g_ezStateMachineTransition_BlackboardConditions_1_2;
 
 //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
When you have a couple of conditions the UI became very cluttered.
Before:
<img width="572" height="220" alt="Screenshot 2026-09-08 114043" src="https://github.com/user-attachments/assets/482dda97-e477-4fe6-bc88-203998753ab7" />
After:
<img width="575" height="99" alt="Screenshot 2026-09-08 114240" src="https://github.com/user-attachments/assets/e6d1e90c-57d4-45fc-9c95-0d3969fadd06" />

* Made ezBlackboardCondition a custom variant type including patch for state machine transitions.
* New widget to fit everything in one line.
* Extracted dynamic enum button/menu logic into its own class to make it re-usable