### PR TITLE
Improved asset data compression

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -7,7 +7,7 @@
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetDocument, 10, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetDocument, 11, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -58,7 +58,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 4, ezRTTIDefault
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetDocument, 6, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetDocument, 7, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -8,7 +8,7 @@
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetDocument, 15, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetDocument, 16, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/Engine/Core/CMakeLists.txt
+++ b/Code/Engine/Core/CMakeLists.txt
@@ -13,8 +13,6 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
   Foundation
   Texture
-
-  PRIVATE
   meshoptimizer
 )
 

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
@@ -11,6 +11,10 @@
 #include <ozz/animation/runtime/animation.h>
 #include <ozz/animation/runtime/skeleton.h>
 
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+#  include <Foundation/IO/CompressedStreamZstd.h>
+#endif
+
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipResource, 1, ezRTTIDefaultAllocator<ezAnimationClipResource>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
@@ -130,57 +134,108 @@ void ezAnimationClipResourceDescriptor::operator=(ezAnimationClipResourceDescrip
 
 ezResult ezAnimationClipResourceDescriptor::Serialize(ezStreamWriter& inout_stream) const
 {
-  inout_stream.WriteVersion(10);
+  inout_stream.WriteVersion(11);
+
+  ezUInt8 uiCompressionMode = 0;
+
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+  uiCompressionMode = 1;
+  ezCompressedStreamWriterZstd compressor(&inout_stream, 0, ezCompressedStreamWriterZstd::Compression::Average);
+  ezStreamWriter& stream = compressor;
+#else
+  ezStreamWriter& stream = inout_stream;
+#endif
+
+  // the compression mode is written to the uncompressed stream, everything after it is compressed
+  inout_stream << uiCompressionMode;
 
   const ezUInt16 uiNumJoints = static_cast<ezUInt16>(m_JointInfos.GetCount());
-  inout_stream << uiNumJoints;
+  stream << uiNumJoints;
   for (ezUInt32 i = 0; i < m_JointInfos.GetCount(); ++i)
   {
     const auto& val = m_JointInfos.GetValue(i);
 
-    inout_stream << m_JointInfos.GetKey(i);
-    inout_stream << val.m_uiPositionIdx;
-    inout_stream << val.m_uiPositionCount;
-    inout_stream << val.m_uiRotationIdx;
-    inout_stream << val.m_uiRotationCount;
-    inout_stream << val.m_uiScaleIdx;
-    inout_stream << val.m_uiScaleCount;
+    stream << m_JointInfos.GetKey(i);
+    stream << val.m_uiPositionIdx;
+    stream << val.m_uiPositionCount;
+    stream << val.m_uiRotationIdx;
+    stream << val.m_uiRotationCount;
+    stream << val.m_uiScaleIdx;
+    stream << val.m_uiScaleCount;
   }
 
-  inout_stream << m_Duration;
-  inout_stream << m_uiNumTotalPositions;
-  inout_stream << m_uiNumTotalRotations;
-  inout_stream << m_uiNumTotalScales;
+  stream << m_Duration;
+  stream << m_uiNumTotalPositions;
+  stream << m_uiNumTotalRotations;
+  stream << m_uiNumTotalScales;
 
-  EZ_SUCCEED_OR_RETURN(inout_stream.WriteArray(m_Transforms));
+  EZ_SUCCEED_OR_RETURN(stream.WriteArray(m_Transforms));
 
-  inout_stream << m_vConstantRootMotion;
+  stream << m_vConstantRootMotion;
 
-  m_EventTrack.Save(inout_stream);
+  m_EventTrack.Save(stream);
 
-  inout_stream << m_bAdditive;
+  stream << m_bAdditive;
 
   const ezUInt16 uiNumCustomCurves = static_cast<ezUInt16>(m_CustomCurves.GetCount());
-  inout_stream << uiNumCustomCurves;
+  stream << uiNumCustomCurves;
 
   for (const auto& cc : m_CustomCurves)
   {
-    inout_stream << cc.m_sName;
-    cc.m_Curve.Save(inout_stream);
+    stream << cc.m_sName;
+    cc.m_Curve.Save(stream);
   }
+
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+  EZ_SUCCEED_OR_RETURN(compressor.FinishCompressedStream());
+#endif
 
   return EZ_SUCCESS;
 }
 
 ezResult ezAnimationClipResourceDescriptor::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezTypeVersion uiVersion = inout_stream.ReadVersion(10);
+  const ezTypeVersion uiVersion = inout_stream.ReadVersion(11);
 
   if (uiVersion < 6)
     return EZ_FAILURE;
 
+  ezStreamReader* pStream = &inout_stream;
+
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+  ezCompressedStreamReaderZstd decompressor;
+#endif
+
+  if (uiVersion >= 11)
+  {
+    ezUInt8 uiCompressionMode = 0;
+    inout_stream >> uiCompressionMode;
+
+    switch (uiCompressionMode)
+    {
+      case 0:
+        break;
+
+      case 1:
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+        decompressor.SetInputStream(&inout_stream);
+        pStream = &decompressor;
+        break;
+#else
+        ezLog::Error("Animation clip is compressed with zstandard, but support for this compression scheme is not compiled in.");
+        return EZ_FAILURE;
+#endif
+
+      default:
+        ezLog::Error("Animation clip uses an unknown compression mode {}.", uiCompressionMode);
+        return EZ_FAILURE;
+    }
+  }
+
+  ezStreamReader& stream = *pStream;
+
   ezUInt16 uiNumJoints = 0;
-  inout_stream >> uiNumJoints;
+  stream >> uiNumJoints;
 
   m_JointInfos.Reserve(uiNumJoints);
 
@@ -188,53 +243,53 @@ ezResult ezAnimationClipResourceDescriptor::Deserialize(ezStreamReader& inout_st
 
   for (ezUInt16 i = 0; i < uiNumJoints; ++i)
   {
-    inout_stream >> hs;
+    stream >> hs;
 
     JointInfo ji;
-    inout_stream >> ji.m_uiPositionIdx;
-    inout_stream >> ji.m_uiPositionCount;
-    inout_stream >> ji.m_uiRotationIdx;
-    inout_stream >> ji.m_uiRotationCount;
-    inout_stream >> ji.m_uiScaleIdx;
-    inout_stream >> ji.m_uiScaleCount;
+    stream >> ji.m_uiPositionIdx;
+    stream >> ji.m_uiPositionCount;
+    stream >> ji.m_uiRotationIdx;
+    stream >> ji.m_uiRotationCount;
+    stream >> ji.m_uiScaleIdx;
+    stream >> ji.m_uiScaleCount;
 
     m_JointInfos.Insert(hs, ji);
   }
 
   m_JointInfos.Sort();
 
-  inout_stream >> m_Duration;
-  inout_stream >> m_uiNumTotalPositions;
-  inout_stream >> m_uiNumTotalRotations;
-  inout_stream >> m_uiNumTotalScales;
+  stream >> m_Duration;
+  stream >> m_uiNumTotalPositions;
+  stream >> m_uiNumTotalRotations;
+  stream >> m_uiNumTotalScales;
 
-  EZ_SUCCEED_OR_RETURN(inout_stream.ReadArray(m_Transforms));
+  EZ_SUCCEED_OR_RETURN(stream.ReadArray(m_Transforms));
 
   if (uiVersion >= 7)
   {
-    inout_stream >> m_vConstantRootMotion;
+    stream >> m_vConstantRootMotion;
   }
 
   if (uiVersion >= 8)
   {
-    m_EventTrack.Load(inout_stream);
+    m_EventTrack.Load(stream);
   }
 
   if (uiVersion >= 9)
   {
-    inout_stream >> m_bAdditive;
+    stream >> m_bAdditive;
   }
 
   if (uiVersion >= 10)
   {
     ezUInt16 uiNumCustomCurves = 0;
-    inout_stream >> uiNumCustomCurves;
+    stream >> uiNumCustomCurves;
 
     m_CustomCurves.SetCount(uiNumCustomCurves);
     for (auto& cc : m_CustomCurves)
     {
-      inout_stream >> cc.m_sName;
-      cc.m_Curve.Load(inout_stream);
+      stream >> cc.m_sName;
+      cc.m_Curve.Load(stream);
       cc.m_Curve.SortControlPoints();
       cc.m_Curve.CreateLinearApproximation();
     }

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshResourceDescriptor.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshResourceDescriptor.cpp
@@ -6,10 +6,29 @@
 #include <Foundation/IO/FileSystem/FileWriter.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
+#include <meshoptimizer/meshoptimizer.h>
 
 #ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
 #  include <Foundation/IO/CompressedStreamZstd.h>
 #endif
+
+namespace
+{
+  /// Number of mantissa bits that are kept when the position stream is stored with the exponential filter.
+  ///
+  /// The filter rounds every position component to a multiple of a power of two that is shared by all vertices,
+  /// which is the same precision that a 16 bit normalized position format would give, but the data stays float
+  /// in memory and on the GPU. Because the lowest byte of every component becomes zero, the generic compression
+  /// that is applied on top of this shrinks the position stream noticeably.
+  /// Do not raise this above 16 without measuring, the compression gain comes from the zeroed byte.
+  constexpr int s_iPositionFilterBits = 16;
+
+  enum class ezMeshPositionFilter : ezUInt8
+  {
+    None = 0,
+    Exponential = 1,
+  };
+} // namespace
 
 ezMeshResourceDescriptor::ezMeshResourceDescriptor()
 {
@@ -194,7 +213,16 @@ void ezMeshResourceDescriptor::Save(ezStreamWriter& inout_stream)
   }
 
   {
-    chunk.BeginChunk("VertexBuffer", 2);
+    chunk.BeginChunk("VertexBuffer", 3);
+
+    const auto& streamConfig = m_MeshBufferDescriptor.GetVertexStreamConfig();
+
+    // the position filter is lossy, so it is only applied to meshes that were not imported with high precision
+    const bool bFilterPositions = !streamConfig.m_bUseHighPrecision && streamConfig.GetPositionFormat() == ezGALResourceFormat::XYZFloat;
+
+    chunk << static_cast<ezUInt8>(bFilterPositions ? ezMeshPositionFilter::Exponential : ezMeshPositionFilter::None);
+
+    ezDynamicArray<ezUInt8> filteredPositions;
 
     const ezUInt32 uiNumBuffers = m_MeshBufferDescriptor.GetNumVertexBuffers();
     for (ezUInt32 i = 0; i < uiNumBuffers; ++i)
@@ -205,7 +233,19 @@ void ezMeshResourceDescriptor::Save(ezStreamWriter& inout_stream)
       // size in bytes
       chunk << data.GetCount();
 
-      if (!data.IsEmpty())
+      if (data.IsEmpty())
+        continue;
+
+      if (bFilterPositions && type == ezMeshVertexStreamType::Position)
+      {
+        filteredPositions.SetCountUninitialized(data.GetCount());
+
+        meshopt_encodeFilterExp(filteredPositions.GetData(), m_MeshBufferDescriptor.GetVertexCount(), streamConfig.GetPositionElementSize(),
+          s_iPositionFilterBits, reinterpret_cast<const float*>(data.GetData()), meshopt_EncodeExpSharedComponent);
+
+        chunk.WriteBytes(filteredPositions.GetData(), filteredPositions.GetCount()).IgnoreResult();
+      }
+      else
       {
         chunk.WriteBytes(data.GetData(), data.GetCount()).IgnoreResult();
       }
@@ -422,10 +462,18 @@ ezResult ezMeshResourceDescriptor::Load(ezStreamReader& inout_stream)
 
     if (ci.m_sChunkName == "VertexBuffer")
     {
-      if (ci.m_uiChunkVersion != 2)
+      if (ci.m_uiChunkVersion != 2 && ci.m_uiChunkVersion != 3)
       {
         ezLog::Error("Version of chunk '{0}' is invalid ({1})", ci.m_sChunkName, ci.m_uiChunkVersion);
         return EZ_FAILURE;
+      }
+
+      ezUInt8 uiPositionFilter = static_cast<ezUInt8>(ezMeshPositionFilter::None);
+
+      // Version 3: the position stream may be stored in a filtered representation
+      if (ci.m_uiChunkVersion >= 3)
+      {
+        chunk >> uiPositionFilter;
       }
 
       const ezUInt32 uiNumBuffers = m_MeshBufferDescriptor.GetNumVertexBuffers();
@@ -442,9 +490,14 @@ ezResult ezMeshResourceDescriptor::Load(ezStreamReader& inout_stream)
           return EZ_FAILURE;
         }
 
-        if (!data.IsEmpty())
+        if (data.IsEmpty())
+          continue;
+
+        chunk.ReadBytes(data.GetData(), data.GetCount());
+
+        if (type == ezMeshVertexStreamType::Position && uiPositionFilter == static_cast<ezUInt8>(ezMeshPositionFilter::Exponential))
         {
-          chunk.ReadBytes(data.GetData(), data.GetCount());
+          meshopt_decodeFilterExp(data.GetData(), m_MeshBufferDescriptor.GetVertexCount(), m_MeshBufferDescriptor.GetVertexStreamConfig().GetPositionElementSize());
         }
       }
     }

--- a/Code/Tools/Libs/ModelImporter2/Importer/Importer.cpp
+++ b/Code/Tools/Libs/ModelImporter2/Importer/Importer.cpp
@@ -4,9 +4,127 @@
 #include <ModelImporter2/Importer/Importer.h>
 #include <RendererCore/AnimationSystem/EditableSkeleton.h>
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
+#include <meshoptimizer/meshoptimizer.h>
 
 namespace ezModelImporter2
 {
+  namespace
+  {
+    /// Reorders the triangles of an imported mesh for GPU vertex cache efficiency and its vertices for fetch locality.
+    ///
+    /// Triangles are only reordered within a sub-mesh, so that the index range of every sub-mesh stays valid.
+    /// The vertex reordering is done across the entire mesh buffer and all indices are remapped accordingly.
+    /// Only indexed triangle meshes are touched, everything else is left as it is.
+    void OptimizeMeshForRendering(ezMeshResourceDescriptor& ref_desc)
+    {
+      ezMeshBufferResourceDescriptor& mb = ref_desc.MeshBufferDesc();
+
+      if (mb.GetTopology() != ezGALPrimitiveTopology::Triangles || !mb.HasIndexBuffer())
+        return;
+
+      const ezUInt32 uiVertexCount = mb.GetVertexCount();
+      const ezUInt32 uiIndexCount = mb.GetPrimitiveCount() * 3;
+
+      if (uiVertexCount == 0 || uiIndexCount == 0)
+        return;
+
+      // meshoptimizer only works on 32 bit indices, so 16 bit index data is widened here and narrowed again at the end
+      const bool bIndices32Bit = mb.Uses32BitIndices();
+
+      ezTempArray<ezUInt32> indices;
+      indices.SetCountUninitialized(uiIndexCount);
+
+      {
+        const auto& indexData = mb.GetIndexBufferData();
+
+        if (bIndices32Bit)
+        {
+          ezMemoryUtils::Copy(indices.GetData(), reinterpret_cast<const ezUInt32*>(indexData.GetData()), uiIndexCount);
+        }
+        else
+        {
+          const ezUInt16* pSrc = reinterpret_cast<const ezUInt16*>(indexData.GetData());
+
+          for (ezUInt32 i = 0; i < uiIndexCount; ++i)
+          {
+            indices[i] = pSrc[i];
+          }
+        }
+      }
+
+      // every sub-mesh is a separate draw call and thus has to be optimized on its own,
+      // otherwise triangles would move out of the index range that the sub-mesh refers to
+      for (const auto& subMesh : ref_desc.GetSubMeshes())
+      {
+        const ezUInt32 uiFirstIndex = subMesh.m_uiFirstPrimitive * 3;
+        const ezUInt32 uiNumIndices = subMesh.m_uiPrimitiveCount * 3;
+
+        if (uiNumIndices == 0 || uiFirstIndex + uiNumIndices > uiIndexCount)
+          continue;
+
+        meshopt_optimizeVertexCache(indices.GetData() + uiFirstIndex, indices.GetData() + uiFirstIndex, uiNumIndices, uiVertexCount);
+      }
+
+      // reorder the vertices in the order in which the (now optimized) index buffer references them
+      {
+        ezTempArray<ezUInt32> remap;
+        remap.SetCountUninitialized(uiVertexCount);
+
+        const ezUInt32 uiUniqueVertices = static_cast<ezUInt32>(meshopt_optimizeVertexFetchRemap(remap.GetData(), indices.GetData(), uiIndexCount, uiVertexCount));
+
+        // if the mesh contains vertices that no triangle references, the remap table would shrink the vertex buffer.
+        // that would require patching up everything that refers to vertex indices, so instead the vertex order is left alone in this case.
+        if (uiUniqueVertices == uiVertexCount)
+        {
+          ezTempArray<ezUInt32> remappedIndices;
+          remappedIndices.SetCountUninitialized(uiIndexCount);
+          meshopt_remapIndexBuffer(remappedIndices.GetData(), indices.GetData(), uiIndexCount, remap.GetData());
+          indices.Swap(remappedIndices);
+
+          ezDynamicArray<ezUInt8, ezAlignedAllocatorWrapper> remappedStream;
+
+          for (ezUInt32 i = 0; i < mb.GetNumVertexBuffers(); ++i)
+          {
+            const auto type = static_cast<ezMeshVertexStreamType::Enum>(i);
+            auto& streamData = mb.GetVertexBufferData(type);
+
+            if (streamData.IsEmpty())
+              continue;
+
+            const ezUInt32 uiElementSize = mb.GetVertexStreamConfig().GetStreamElementSize(type);
+
+            remappedStream.SetCountUninitialized(streamData.GetCount());
+            meshopt_remapVertexBuffer(remappedStream.GetData(), streamData.GetData(), uiVertexCount, uiElementSize, remap.GetData());
+            streamData = remappedStream;
+          }
+        }
+        else
+        {
+          ezLog::Dev("Mesh has {} unused vertices, skipping vertex fetch optimization.", uiVertexCount - uiUniqueVertices);
+        }
+      }
+
+      // write the indices back
+      {
+        auto& indexData = mb.GetIndexBufferData();
+
+        if (bIndices32Bit)
+        {
+          ezMemoryUtils::Copy(reinterpret_cast<ezUInt32*>(indexData.GetData()), indices.GetData(), uiIndexCount);
+        }
+        else
+        {
+          ezUInt16* pDst = reinterpret_cast<ezUInt16*>(indexData.GetData());
+
+          for (ezUInt32 i = 0; i < uiIndexCount; ++i)
+          {
+            pDst[i] = static_cast<ezUInt16>(indices[i]);
+          }
+        }
+      }
+    }
+  } // namespace
+
   Importer::Importer() = default;
   Importer::~Importer() = default;
 
@@ -28,6 +146,11 @@ namespace ezModelImporter2
       EZ_LOG_BLOCK("ModelImport", m_Options.m_sSourceFile);
 
       res = DoImport();
+
+      if (res.Succeeded() && m_Options.m_pMeshOutput != nullptr)
+      {
+        OptimizeMeshForRendering(*m_Options.m_pMeshOutput);
+      }
     }
 
 

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
@@ -62,12 +62,15 @@ namespace ezModelImporter2
     // JoinIdenticalVertices: Assimp doesn't use index buffer at all if this is not specified.
     // TransformUVCoords:     As of now we do not have a concept for uv transforms.
     // Process_FlipUVs:       Assimp assumes OpenGl style UV coordinate system otherwise.
-    // ImproveCacheLocality:  Reorders triangles for better vertex cache locality.
+    //
+    // Note: aiProcess_ImproveCacheLocality is deliberately not used. It optimizes every mesh in the source file
+    // on its own, whereas the importer merges those meshes into a single mesh buffer afterwards. The result is
+    // optimized with meshoptimizer once the merged buffer exists, which also produces better results.
 
     ezUInt32 uiAssimpFlags = 0;
     if (m_Options.m_pMeshOutput != nullptr)
     {
-      uiAssimpFlags |= aiProcess_Triangulate | aiProcess_TransformUVCoords | aiProcess_FlipUVs | aiProcess_ImproveCacheLocality;
+      uiAssimpFlags |= aiProcess_Triangulate | aiProcess_TransformUVCoords | aiProcess_FlipUVs;
 
       if (!m_Options.m_bImportSkinningData)
       {


### PR DESCRIPTION
* Use meshopt compression for mesh position streams when precision is not set to "high".
* Use zstd compression for animation clip data
* Reorder mesh vertices and indices for improved rendering and compression. This replaces assimp reordering, and makes more sense to do at the end of the pipeline, rather than during data import.