### PR TITLE
Added occluder mesh generation for terrain patches

### DIFF
--- a/Code/EditorPlugins/Terrain/EnginePluginTerrain/SceneExport/TerrainHeightfieldExportModifier.cpp
+++ b/Code/EditorPlugins/Terrain/EnginePluginTerrain/SceneExport/TerrainHeightfieldExportModifier.cpp
@@ -2,6 +2,8 @@
 
 #include <EnginePluginTerrain/SceneExport/TerrainHeightfieldExportModifier.h>
 
+#include <Foundation/Algorithm/HashStream.h>
+#include <Foundation/Configuration/CVar.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
 #include <JoltPlugin/Actors/JoltHeightfieldColliderComponent.h>
@@ -9,6 +11,7 @@
 #include <JoltPlugin/Resources/JoltMeshResourceWriter.h>
 #include <TerrainPlugin/Components/TerrainPatchComponent.h>
 #include <TerrainPlugin/TerrainSystem.h>
+#include <meshoptimizer/meshoptimizer.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneExportModifier_TerrainHeightfieldCollision, 1, ezRTTIDefaultAllocator<ezSceneExportModifier_TerrainHeightfieldCollision>)
@@ -34,6 +37,49 @@ static bool CheckExistingHeightfieldFileContentHash(ezStringView sPath, ezUInt64
   file >> uiStoredHash;
 
   return uiStoredHash == uiExpectedHash;
+}
+
+/// Bump this when BuildOccluderMesh() changes, to discard cached meshes from the older algorithm.
+static constexpr ezUInt8 g_uiOccluderAlgorithmVersion = 1;
+static constexpr ezUInt8 g_uiOccluderFileVersion = 1;
+
+/// Fails when the cache file doesn't exist or was built from different inputs.
+static ezResult ReadCachedOccluder(ezStringView sPath, ezUInt64 uiExpectedHash, ezDynamicArray<ezVec3>& out_vertices, ezDynamicArray<ezUInt32>& out_indices)
+{
+  ezFileReader file;
+  if (file.Open(sPath).Failed())
+    return EZ_FAILURE;
+
+  ezUInt8 uiVersion = 0;
+  file >> uiVersion;
+
+  if (uiVersion != g_uiOccluderFileVersion)
+    return EZ_FAILURE;
+
+  ezUInt64 uiStoredHash = 0;
+  file >> uiStoredHash;
+
+  if (uiStoredHash != uiExpectedHash)
+    return EZ_FAILURE;
+
+  EZ_SUCCEED_OR_RETURN(file.ReadArray(out_vertices));
+  EZ_SUCCEED_OR_RETURN(file.ReadArray(out_indices));
+
+  return EZ_SUCCESS;
+}
+
+static ezResult WriteCachedOccluder(ezStringView sPath, ezUInt64 uiContentHash, const ezDynamicArray<ezVec3>& vertices, const ezDynamicArray<ezUInt32>& indices)
+{
+  ezDeferredFileWriter file;
+  file.SetOutput(sPath);
+
+  file << g_uiOccluderFileVersion;
+  file << uiContentHash;
+
+  EZ_SUCCEED_OR_RETURN(file.WriteArray(vertices));
+  EZ_SUCCEED_OR_RETURN(file.WriteArray(indices));
+
+  return file.Close();
 }
 
 struct PatchGeometry
@@ -62,6 +108,160 @@ static void ComputePatchGeometry(const ezTerrainPatchComponent* pPatch, ezUInt32
   out_patchGeo.fColliderCenter = fLocalStart + out_patchGeo.fJoltHalfExtent;
 }
 
+/// Builds the coarse occluder mesh for one patch.
+///
+/// The heights are reduced to a grid of about fCellSize meters per cell, where every vertex takes the minimum
+/// of all full resolution heights of the cells it belongs to. Since a triangle never rises above its highest
+/// corner, the result stays below the real terrain, so it can't cull objects standing on it. Cells containing
+/// carved (tunnel, cave) samples are dropped; the resulting holes can only lose occlusion, never add any.
+///
+/// Decimation is the one step that isn't strictly conservative: meshopt only removes vertices, so the surface
+/// can rise across a narrow gully. The error budget (a tenth of the cell size) stays well below the pushdown
+/// that the min filter already produces on any real slope (roughly cell size * tan(slope)).
+static void BuildOccluderMesh(ezUInt32 uiCellsPerSide, float fPatchSize, float fCellSize, ezArrayPtr<const float> bakedHeights, ezArrayPtr<const ezUInt8> dominantMat, ezDynamicArray<ezVec3>& out_vertices, ezDynamicArray<ezUInt32>& out_indices)
+{
+  out_vertices.Clear();
+  out_indices.Clear();
+
+  const ezInt32 iStoredRowStride = static_cast<ezInt32>(uiCellsPerSide) + 9;
+  const float fFullSpacing = fPatchSize / static_cast<float>(uiCellsPerSide);
+
+  // Safety net only, the caller clamps to the collider grid spacing, which is coarser than this.
+  fCellSize = ezMath::Clamp(fCellSize, fFullSpacing, fPatchSize);
+  const ezUInt32 uiStride = ezMath::Clamp(static_cast<ezUInt32>(ezMath::RoundToInt(fCellSize / fFullSpacing)), 1u, uiCellsPerSide);
+
+  // Rounded up, so the grid spans the full patch. A stride that doesn't divide the patch evenly leaves the
+  // last row and column narrower than the rest.
+  const ezUInt32 uiCells = (uiCellsPerSide + uiStride - 1) / uiStride;
+  const ezUInt32 uiVerts = uiCells + 1;
+
+  const float fZSnap = fCellSize / 5.0f;
+  const bool bHasDominantIndices = dominantMat.GetCount() == bakedHeights.GetCount();
+
+  // Full resolution grid coordinate of each coarse grid line, clamped to the patch edge.
+  ezTempArray<ezUInt32> lineToFine;
+  lineToFine.SetCountUninitialized(uiVerts);
+  for (ezUInt32 i = 0; i < uiVerts; ++i)
+  {
+    lineToFine[i] = ezMath::Min(i * uiStride, uiCellsPerSide);
+  }
+
+  ezTempArray<float> heights;
+  heights.SetCountUninitialized(uiVerts * uiVerts);
+
+  for (ezUInt32 cy = 0; cy < uiVerts; ++cy)
+  {
+    for (ezUInt32 cx = 0; cx < uiVerts; ++cx)
+    {
+      // The stored grid has a 4 vertex border ring around the rendered patch, hence the +4.
+      const ezInt32 iCenterX = 4 + static_cast<ezInt32>(lineToFine[cx]);
+      const ezInt32 iCenterY = 4 + static_cast<ezInt32>(lineToFine[cy]);
+      const ezInt32 iRadius = static_cast<ezInt32>(uiStride);
+
+      float fMin = ezMath::MaxValue<float>();
+      bool bCarved = false;
+
+      for (ezInt32 dy = -iRadius; dy <= iRadius && !bCarved; ++dy)
+      {
+        const ezInt32 iY = ezMath::Clamp(iCenterY + dy, 0, iStoredRowStride - 1);
+
+        for (ezInt32 dx = -iRadius; dx <= iRadius; ++dx)
+        {
+          const ezInt32 iX = ezMath::Clamp(iCenterX + dx, 0, iStoredRowStride - 1);
+          const ezUInt32 uiIdx = static_cast<ezUInt32>(iY * iStoredRowStride + iX);
+
+          if (bHasDominantIndices && dominantMat[uiIdx] == 0xFFu)
+          {
+            bCarved = true;
+            break;
+          }
+
+          fMin = ezMath::Min(fMin, bakedHeights[uiIdx]);
+        }
+      }
+
+      // Snapping downwards stays conservative and makes near-flat regions exactly planar, so that the
+      // decimation can collapse them completely.
+      if (!bCarved)
+      {
+        fMin = ezMath::Floor(fMin / fZSnap) * fZSnap;
+      }
+
+      heights[cy * uiVerts + cx] = bCarved ? ezMath::NaN<float>() : fMin;
+    }
+  }
+
+  // Emit only the vertices that a kept cell actually uses.
+  ezTempArray<ezUInt32> vertexRemap;
+  vertexRemap.SetCount(uiVerts * uiVerts, ezInvalidIndex);
+
+  auto GetVertex = [&](ezUInt32 x, ezUInt32 y) -> ezUInt32
+  {
+    ezUInt32& uiRemapped = vertexRemap[y * uiVerts + x];
+
+    if (uiRemapped == ezInvalidIndex)
+    {
+      uiRemapped = out_vertices.GetCount();
+      out_vertices.PushBack(ezVec3(lineToFine[x] * fFullSpacing, lineToFine[y] * fFullSpacing, heights[y * uiVerts + x]));
+    }
+
+    return uiRemapped;
+  };
+
+  for (ezUInt32 y = 0; y + 1 < uiVerts; ++y)
+  {
+    for (ezUInt32 x = 0; x + 1 < uiVerts; ++x)
+    {
+      if (ezMath::IsNaN(heights[y * uiVerts + x]) || ezMath::IsNaN(heights[y * uiVerts + x + 1]) ||
+          ezMath::IsNaN(heights[(y + 1) * uiVerts + x]) || ezMath::IsNaN(heights[(y + 1) * uiVerts + x + 1]))
+        continue;
+
+      const ezUInt32 i00 = GetVertex(x, y);
+      const ezUInt32 i10 = GetVertex(x + 1, y);
+      const ezUInt32 i01 = GetVertex(x, y + 1);
+      const ezUInt32 i11 = GetVertex(x + 1, y + 1);
+
+      // Counter-clockwise seen from +Z, so the faces point up and are backface culled from below.
+      out_indices.PushBack(i00);
+      out_indices.PushBack(i10);
+      out_indices.PushBack(i11);
+
+      out_indices.PushBack(i00);
+      out_indices.PushBack(i11);
+      out_indices.PushBack(i01);
+    }
+  }
+
+  const ezUInt32 uiGridTriangles = out_indices.GetCount() / 3;
+
+  const float fError = fCellSize / 10.0f;
+
+  if (uiGridTriangles > 0)
+  {
+    ezTempArray<ezUInt32> simplified;
+    simplified.SetCountUninitialized(out_indices.GetCount());
+
+    float fResultError = 0.0f;
+    const size_t uiNumIndices = meshopt_simplify(simplified.GetData(), out_indices.GetData(), out_indices.GetCount(),
+      &out_vertices[0].x, out_vertices.GetCount(), sizeof(ezVec3), 0, fError, meshopt_SimplifyErrorAbsolute, &fResultError);
+
+    simplified.SetCount(static_cast<ezUInt32>(uiNumIndices));
+    out_indices = simplified;
+
+    // meshopt keeps referencing the original vertex buffer, so drop the vertices that no triangle uses anymore.
+    ezTempArray<ezVec3> compacted;
+    compacted.SetCountUninitialized(out_vertices.GetCount());
+
+    const size_t uiNumVertices = meshopt_optimizeVertexFetch(compacted.GetData(), out_indices.GetData(), out_indices.GetCount(),
+      out_vertices.GetData(), out_vertices.GetCount(), sizeof(ezVec3));
+
+    compacted.SetCount(static_cast<ezUInt32>(uiNumVertices));
+    out_vertices = compacted;
+
+    ezLog::Info("Terrain occluder: {} cells ({} m), {} -> {} triangles, error {} m", uiCells, ezArgF(fCellSize, 2), uiGridTriangles, out_indices.GetCount() / 3, ezArgF(fResultError, 3));
+  }
+}
+
 void ezSceneExportModifier_TerrainHeightfieldCollision::ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
   EZ_LOCK(ref_world.GetWriteMarker());
@@ -83,14 +283,26 @@ void ezSceneExportModifier_TerrainHeightfieldCollision::ModifyWorld(ezWorld& ref
     if (!pPatch->IsActive())
       continue;
 
-    if (pPatch->GetCollider() == ezTerrainPatchColliderMode::None)
+    const bool bWantsCollider = pPatch->GetCollider() != ezTerrainPatchColliderMode::None;
+    const bool bWantsOccluder = pPatch->GetOcclusionCellSize() > 0.0f;
+
+    if (!bWantsCollider)
+    {
+      if (bWantsOccluder)
+      {
+        ezLog::Warning("TerrainHeightfieldExportModifier: patch (stableId={}) has an occlusion cell size but no collider. The occluder is baked from the collider data and is skipped as well.", pPatch->GetStableId());
+      }
+
       continue;
+    }
 
     const ezUInt32 uiHeightfieldIdx = pPatch->GetHeightfieldIndex();
     if (uiHeightfieldIdx == ezInvalidIndex)
       continue;
 
     const ezUInt32 numCellsPerSide = pTerrain->GetHeightfieldCellsPerSide(uiHeightfieldIdx);
+    const float fFullGridSpacing = pPatch->GetSize() / static_cast<float>(numCellsPerSide);
+
     PatchGeometry patchGeo;
     ComputePatchGeometry(pPatch, numCellsPerSide, patchGeo);
 
@@ -99,19 +311,62 @@ void ezSceneExportModifier_TerrainHeightfieldCollision::ModifyWorld(ezWorld& ref
     ezStringBuilder sPath;
     sPath.SetFormat(":project/AssetCache/Generated/TerrainPatch_{}.ezBinJoltHeightfield", ezArgU(pPatch->GetStableId(), 16, true, 16, true));
 
-    const bool bFileUpToDate = CheckExistingHeightfieldFileContentHash(sPath, uiContentHash);
+    const bool bColliderFileUpToDate = CheckExistingHeightfieldFileContentHash(sPath, uiContentHash);
 
-    if (!bFileUpToDate)
+    // A detail level that's good enough for collision is also good enough for occlusion.
+    const float fOccluderCellSize = ezMath::Clamp(pPatch->GetOcclusionCellSize(), fFullGridSpacing * static_cast<float>(patchGeo.uiSubsampleStride), pPatch->GetSize());
+
+    ezStringBuilder sOccluderPath;
+    ezUInt64 uiOccluderHash = 0;
+    bool bOccluderCacheUpToDate = false;
+
+    ezTempArray<ezVec3> occluderVertices;
+    ezTempArray<ezUInt32> occluderIndices;
+
+    if (bWantsOccluder)
     {
-      // Issue synchronous GPU->CPU readback.
-      ezTempArray<float> bakedHeights;
-      ezTempArray<ezUInt8> dominantIndices;
-      if (pTerrain->ReadbackHeightfieldData(uiHeightfieldIdx, bakedHeights, dominantIndices).Failed())
+      ezHashStreamWriter64 hashWriter;
+      hashWriter << uiContentHash;
+      hashWriter << fOccluderCellSize;
+      hashWriter << numCellsPerSide;
+      hashWriter << g_uiOccluderAlgorithmVersion;
+      uiOccluderHash = hashWriter.GetHashValue();
+
+      sOccluderPath.SetFormat(":project/AssetCache/Generated/TerrainOccluder_{}.ezBinTerrainOccluder", ezArgU(pPatch->GetStableId(), 16, true, 16, true));
+
+      bOccluderCacheUpToDate = ReadCachedOccluder(sOccluderPath, uiOccluderHash, occluderVertices, occluderIndices).Succeeded();
+    }
+
+    // One readback serves both, it forces a full re-bake of the patch.
+    const bool bNeedsReadback = !bColliderFileUpToDate || (bWantsOccluder && !bOccluderCacheUpToDate);
+
+    ezTempArray<float> bakedHeights;
+    ezTempArray<ezUInt8> dominantIndices;
+
+    if (bNeedsReadback && pTerrain->ReadbackHeightfieldData(uiHeightfieldIdx, bakedHeights, dominantIndices).Failed())
+    {
+      ezLog::Warning("TerrainHeightfieldExportModifier: ReadbackHeightfieldData failed for patch (stableId={}), skipping baked collider and occluder.", pPatch->GetStableId());
+      continue;
+    }
+
+    if (bWantsOccluder)
+    {
+      if (!bOccluderCacheUpToDate)
       {
-        ezLog::Warning("TerrainHeightfieldExportModifier: ReadbackHeightfieldData failed for patch (stableId={}), skipping baked collider.", pPatch->GetStableId());
-        continue;
+        BuildOccluderMesh(numCellsPerSide, pPatch->GetSize(), fOccluderCellSize, bakedHeights, dominantIndices, occluderVertices, occluderIndices);
+
+        if (WriteCachedOccluder(sOccluderPath, uiOccluderHash, occluderVertices, occluderIndices).Failed())
+        {
+          // Not fatal, only costs bake time on the next run.
+          ezLog::Warning("TerrainHeightfieldExportModifier: failed to write occluder cache '{}'.", sOccluderPath);
+        }
       }
 
+      pPatch->SetBakedOccluder(occluderVertices, occluderIndices);
+    }
+
+    if (!bColliderFileUpToDate)
+    {
       const ezUInt32 uiStoredRowStride = numCellsPerSide + 9;
       const bool bHasDominantIndices = dominantIndices.GetCount() == bakedHeights.GetCount();
       constexpr float fJoltNoCollision = std::numeric_limits<float>::max();

--- a/Code/EditorPlugins/Terrain/EnginePluginTerrain/SceneExport/TerrainHeightfieldExportModifier.h
+++ b/Code/EditorPlugins/Terrain/EnginePluginTerrain/SceneExport/TerrainHeightfieldExportModifier.h
@@ -3,12 +3,16 @@
 #include <EditorEngineProcessFramework/SceneExport/SceneExportModifier.h>
 #include <EnginePluginTerrain/EnginePluginTerrainDLL.h>
 
-/// Scene export modifier that bakes terrain heightfield colliders to disk.
+/// Scene export modifier that bakes terrain heightfield colliders and occluders from the GPU height data.
 ///
-/// For each ezTerrainPatchComponent with a non-None collider mode, it reads back
-/// the GPU-baked height data, cooks a Jolt heightfield shape, and writes a
-/// .ezBinJoltHeightfield file to AssetCache/Generated/. A child game object named
-/// "TerrainCollider" is then created (or reused) with an ezJoltHeightfieldColliderComponent pointing to that file.
+/// For each ezTerrainPatchComponent with a non-None collider mode, it reads back the GPU-baked height data,
+/// cooks a Jolt heightfield shape, and writes a .ezBinJoltHeightfield file to AssetCache/Generated/. A child
+/// game object named "HeightfieldCollider" is then created (or reused) with an
+/// ezJoltHeightfieldColliderComponent pointing to that file.
+///
+/// For each patch with a non-zero occlusion cell size, it additionally computes a coarse, conservative mesh and
+/// stores it on the component, from where the patch builds its CPU occlusion culling geometry. Both use the
+/// same readback, which is why they live in one modifier: a readback forces a full re-bake of the patch.
 class EZ_ENGINEPLUGINTERRAIN_DLL ezSceneExportModifier_TerrainHeightfieldCollision : public ezSceneExportModifier
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezSceneExportModifier_TerrainHeightfieldCollision, ezSceneExportModifier);

--- a/Code/Engine/RendererCore/Components/Implementation/OccluderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/OccluderComponent.cpp
@@ -38,6 +38,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezOccluderComponent, 3, ezComponentMode::Static)
     new ezCategoryAttribute("Rendering"),
     new ezBoxVisualizerAttribute("Extents", 1.0f, ezColorScheme::LightUI(ezColorScheme::Blue)),
     new ezBoxManipulatorAttribute("Extents", 1.0f, true),
+    new ezShapeIconAlwaysVisibleAttribute(),
   }
   EZ_END_ATTRIBUTES;
 }

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainBrush2DComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainBrush2DComponent.cpp
@@ -30,7 +30,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainBrush2DComponent, 1, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("MaterialStrength", GetMaterialStrength, SetMaterialStrength)->AddAttributes(new ezDefaultValueAttribute(0.0f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("AffectPatches", GetAffectPatches, SetAffectPatches)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_ACCESSOR_PROPERTY("AffectVolumes", GetAffectVolumes, SetAffectVolumes)->AddAttributes(new ezDefaultValueAttribute(false)),
-    EZ_ACCESSOR_PROPERTY("Priority", GetPriority, SetPriority)->AddAttributes(new ezDefaultValueAttribute((ezInt8)0), new ezClampValueAttribute((ezInt8)-128, (ezInt8)127)),
+    EZ_ACCESSOR_PROPERTY("Priority", GetPriority, SetPriority)->AddAttributes(new ezDefaultValueAttribute((ezInt8)0), new ezClampValueAttribute((ezInt8)-8, (ezInt8)8)),
     EZ_SET_ACCESSOR_PROPERTY("TerrainTags", GetTags, Reflection_SetTag, Reflection_RemoveTag)->AddAttributes(new ezTagSetWidgetAttribute("Terrain")),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainBrush3DComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainBrush3DComponent.cpp
@@ -31,7 +31,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainBrush3DComponent, 1, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("MaterialStrength", GetMaterialStrength, SetMaterialStrength)->AddAttributes(new ezDefaultValueAttribute(0.0f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("AffectPatches", GetAffectPatches, SetAffectPatches)->AddAttributes(new ezDefaultValueAttribute(false)),
     EZ_ACCESSOR_PROPERTY("AffectVolumes", GetAffectVolumes, SetAffectVolumes)->AddAttributes(new ezDefaultValueAttribute(true)),
-    EZ_ACCESSOR_PROPERTY("Priority", GetPriority, SetPriority)->AddAttributes(new ezDefaultValueAttribute((ezInt8)0), new ezClampValueAttribute((ezInt8)-128, (ezInt8)127)),
+    EZ_ACCESSOR_PROPERTY("Priority", GetPriority, SetPriority)->AddAttributes(new ezDefaultValueAttribute((ezInt8)0), new ezClampValueAttribute((ezInt8)-8, (ezInt8)8)),
     EZ_SET_ACCESSOR_PROPERTY("TerrainTags", GetTags, Reflection_SetTag, Reflection_RemoveTag)->AddAttributes(new ezTagSetWidgetAttribute("Terrain")),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
@@ -1,5 +1,6 @@
 #include <TerrainPlugin/TerrainPluginPCH.h>
 
+#include <Core/Graphics/Geometry.h>
 #include <Core/Messages/TransformChangedMessage.h>
 #include <Core/Physics/SurfaceResource.h>
 #include <Core/ResourceManager/ResourceManager.h>
@@ -11,6 +12,7 @@
 #include <Foundation/Serialization/AbstractObjectGraph.h>
 #include <Foundation/Types/TagRegistry.h>
 #include <RendererCore/Components/RenderComponent.h>
+#include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/Material/MaterialResource.h>
 #include <RendererCore/Meshes/CpuMeshResource.h>
 #include <RendererCore/Meshes/MeshBufferUtils.h>
@@ -24,6 +26,8 @@
 #include <Foundation/Utilities/GraphicsUtils.h>
 #include <RendererCore/Pipeline/View.h>
 
+ezCVarBool cvar_TerrainVisOccluder("Terrain.VisOccluder", false, ezCVarFlags::Default, "Draws the occlusion culling geometry of all terrain patches. The occluder is baked when the simulation starts, so it only exists in a simulating or exported scene.");
+
 ezCVarFloat cvar_TerrainLodQuality("Terrain.LodQuality", 1.0f, ezCVarFlags::Default, "Global multiplier for every terrain patch's LodCellPixelSize. > 1 keeps more detail (patches switch LOD later), < 1 coarsens sooner.");
 
 /// View height that LodCellPixelSize is measured against. Fixed rather than the actual viewport, so
@@ -31,7 +35,7 @@ ezCVarFloat cvar_TerrainLodQuality("Terrain.LodQuality", 1.0f, ezCVarFlags::Defa
 static constexpr float g_fLodReferenceViewHeight = 1080.0f;
 
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 3, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -44,6 +48,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 3, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("HeightImageSize", GetHeightImageSize, SetHeightImageSize)->AddAttributes(new ezDefaultValueAttribute(ezVec2(1.0f))),
     EZ_ACCESSOR_PROPERTY("HeightImageScale", GetHeightImageScale, SetHeightImageScale)->AddAttributes(new ezDefaultValueAttribute(32.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_ENUM_ACCESSOR_PROPERTY("Collider", ezTerrainPatchColliderMode, GetCollider, SetCollider),
+    EZ_ACCESSOR_PROPERTY("OcclusionCellSize", GetOcclusionCellSize, SetOcclusionCellSize)->AddAttributes(new ezDefaultValueAttribute(2.0f), new ezClampValueAttribute(0.0f, 64.0f), new ezMinValueTextAttribute("Occlusion Disabled")),
     EZ_ACCESSOR_PROPERTY("LodCellPixelSize", GetLodCellPixelSize, SetLodCellPixelSize)->AddAttributes(new ezDefaultValueAttribute(16.0f), new ezClampValueAttribute(0.0f, ezVariant()), new ezMinValueTextAttribute("LOD Disabled")),
     EZ_ARRAY_ACCESSOR_PROPERTY("Surfaces", Surfaces_GetCount, Surfaces_GetValue, Surfaces_SetValue, Surfaces_Insert, Surfaces_Remove)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_SET_ACCESSOR_PROPERTY("TerrainTags", GetTags, Reflection_SetTag, Reflection_RemoveTag)->AddAttributes(new ezTagSetWidgetAttribute("Terrain")),
@@ -54,6 +59,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 3, ezComponentMode::Static)
     EZ_MESSAGE_HANDLER(ezMsgTransformChanged, OnMsgTransformChanged),
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
     EZ_MESSAGE_HANDLER(ezMsgExtractGeometry, OnMsgExtractGeometry),
+    EZ_MESSAGE_HANDLER(ezMsgExtractOccluderData, OnMsgExtractOccluderData),
   }
   EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_FUNCTIONS
@@ -146,6 +152,11 @@ void ezTerrainPatchComponent::SerializeComponent(ezWorldWriter& inout_stream) co
 
   // Version 3
   s << m_fLodCellPixelSize;
+
+  // Version 4
+  s << m_fOcclusionCellSize;
+  s.WriteArray(m_OccluderVertices).AssertSuccess();
+  s.WriteArray(m_OccluderIndices).AssertSuccess();
 }
 
 void ezTerrainPatchComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -182,6 +193,13 @@ void ezTerrainPatchComponent::DeserializeComponent(ezWorldReader& inout_stream)
   else if (uiVersion >= 3)
   {
     s >> m_fLodCellPixelSize;
+  }
+
+  if (uiVersion >= 4)
+  {
+    s >> m_fOcclusionCellSize;
+    s.ReadArray(m_OccluderVertices).AssertSuccess();
+    s.ReadArray(m_OccluderIndices).AssertSuccess();
   }
 }
 
@@ -302,11 +320,15 @@ void ezTerrainPatchComponent::OnActivated()
   data.m_vImageSize = m_vImageSize;
   data.m_fHeightScale = m_fHeightScale;
 
+  UpdateOccluder();
+
   TriggerLocalBoundsUpdate();
 }
 
 void ezTerrainPatchComponent::OnDeactivated()
 {
+  m_pOccluderObject.Clear();
+
   if (auto* pSystem = GetWorld()->GetModule<ezTerrainSystem>())
   {
     pSystem->RemoveHeightfieldTerrain(m_uiHeightfieldIndex);
@@ -338,6 +360,14 @@ ezResult ezTerrainPatchComponent::GetLocalBounds(ezBoundingBoxSphere& ref_bounds
   }
 
   ref_bounds = ezBoundingBoxSphere::MakeFromBox(ezBoundingBox::MakeFromMinMax(vMin, vMax));
+
+  // Registered separately, with its own (much tighter in Z) bounds, so that the occlusion query can
+  // ignore patches whose occluder geometry is off screen.
+  if (m_pOccluderObject != nullptr && m_OccluderBounds.IsValid())
+  {
+    ref_msg.AddBounds(ezBoundingBoxSphere::MakeFromBox(m_OccluderBounds), ezDefaultSpatialDataCategories::OcclusionStatic);
+  }
+
   return EZ_SUCCESS;
 }
 
@@ -467,6 +497,105 @@ void ezTerrainPatchComponent::OnMsgTransformChanged(ezMsgTransformChanged& msg)
 void ezTerrainPatchComponent::SetCollider(ezEnum<ezTerrainPatchColliderMode> mode)
 {
   m_ColliderMode = mode;
+}
+
+void ezTerrainPatchComponent::SetOcclusionCellSize(float fCellSize)
+{
+  fCellSize = ezMath::Max(fCellSize, 0.0f);
+
+  if (m_fOcclusionCellSize == fCellSize)
+    return;
+
+  // Only read during the bake, changing it has no effect on an already baked occluder.
+  m_fOcclusionCellSize = fCellSize;
+}
+
+void ezTerrainPatchComponent::SetBakedOccluder(ezArrayPtr<const ezVec3> vertices, ezArrayPtr<const ezUInt32> indices)
+{
+  if (vertices.IsEmpty() || indices.GetCount() < 3)
+  {
+    m_OccluderVertices.Clear();
+    m_OccluderIndices.Clear();
+  }
+  else
+  {
+    m_OccluderVertices = vertices;
+    m_OccluderIndices = indices;
+  }
+
+  UpdateOccluder();
+  TriggerLocalBoundsUpdate();
+}
+
+void ezTerrainPatchComponent::UpdateOccluder()
+{
+  m_pOccluderObject.Clear();
+  m_OccluderBounds = ezBoundingBox::MakeInvalid();
+
+  // Deliberately not checking m_fOcclusionCellSize: it is a bake time input and may have been changed
+  // afterwards, in which case it doesn't describe this mesh anymore.
+  if (m_OccluderVertices.IsEmpty() || m_OccluderIndices.GetCount() < 3)
+    return;
+
+  ezGeometry geo;
+
+  for (const ezVec3& vPos : m_OccluderVertices)
+  {
+    geo.AddVertex(vPos, ezVec3(0, 0, 1));
+    m_OccluderBounds.ExpandToInclude(vPos);
+  }
+
+  ezUInt32 idx[3];
+
+  for (ezUInt32 i = 0; i + 2 < m_OccluderIndices.GetCount(); i += 3)
+  {
+    idx[0] = m_OccluderIndices[i + 0];
+    idx[1] = m_OccluderIndices[i + 1];
+    idx[2] = m_OccluderIndices[i + 2];
+
+    geo.AddPolygon(idx, false);
+  }
+
+  ezHashStreamWriter64 hashWriter;
+  hashWriter.WriteBytes(m_OccluderVertices.GetData(), m_OccluderVertices.GetCount() * sizeof(ezVec3)).AssertSuccess();
+  hashWriter.WriteBytes(m_OccluderIndices.GetData(), m_OccluderIndices.GetCount() * sizeof(ezUInt32)).AssertSuccess();
+
+  // Only the geometry hash, so that patches with identical meshes share one object.
+  ezStringBuilder sName;
+  sName.SetFormat("TerrainOccluder-{}", ezArgU(hashWriter.GetHashValue(), 16, true, 16, true));
+
+  m_pOccluderObject = ezRasterizerObject::CreateMesh(sName, geo);
+}
+
+void ezTerrainPatchComponent::DebugDrawOccluder() const
+{
+  if (m_pOccluderObject == nullptr)
+    return;
+
+  const ezTransform tOwner = GetOwner()->GetGlobalTransform();
+
+  ezTempHybridArray<ezDebugRendererTriangle, 256> triangles;
+  triangles.Reserve(m_OccluderIndices.GetCount() / 3);
+
+  for (ezUInt32 i = 0; i + 2 < m_OccluderIndices.GetCount(); i += 3)
+  {
+    const ezVec3 v0 = tOwner * m_OccluderVertices[m_OccluderIndices[i + 0]];
+    const ezVec3 v1 = tOwner * m_OccluderVertices[m_OccluderIndices[i + 1]];
+    const ezVec3 v2 = tOwner * m_OccluderVertices[m_OccluderIndices[i + 2]];
+
+    triangles.PushBack(ezDebugRendererTriangle(v0, v1, v2));
+  }
+
+  // Single sided, to match the backface culling of the software rasterizer.
+  ezDebugRenderer::DrawSolidTriangles(GetWorld(), triangles, ezColor::Orange.WithAlpha(0.5f), false);
+}
+
+void ezTerrainPatchComponent::OnMsgExtractOccluderData(ezMsgExtractOccluderData& msg) const
+{
+  if (m_pOccluderObject == nullptr)
+    return;
+
+  msg.AddOccluder(m_pOccluderObject.Borrow(), GetOwner()->GetGlobalTransform());
 }
 
 void ezTerrainPatchComponent::OnObjectCreated(const ezAbstractObjectNode& node)
@@ -790,6 +919,11 @@ void ezTerrainPatchComponentManager::Update(const ezWorldModule::UpdateContext& 
           pSystem->ModifyHeightfieldTerrain(pComp->m_uiHeightfieldIndex); // marks patch dirty for rebake
           pComp->m_bHeightImageDirty = false;
         }
+      }
+
+      if (cvar_TerrainVisOccluder)
+      {
+        pComp->DebugDrawOccluder();
       }
     }
   }

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
@@ -5,11 +5,13 @@
 #include <GameEngine/Utils/ImageDataResource.h>
 #include <RendererCore/Components/RenderComponent.h>
 #include <RendererCore/Pipeline/RenderData.h>
+#include <RendererCore/Rasterizer/RasterizerObject.h>
 #include <TerrainPlugin/TerrainPluginDLL.h>
 #include <TerrainPlugin/TerrainSystem.h>
 
 struct ezMsgExtractGeometry;
 struct ezMsgExtractRenderData;
+struct ezMsgExtractOccluderData;
 struct ezMsgTransformChanged;
 struct ezResourceEvent;
 class ezAbstractObjectNode;
@@ -57,6 +59,7 @@ protected:
 protected:
   virtual ezResult GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg) override;
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
+  void OnMsgExtractOccluderData(ezMsgExtractOccluderData& msg) const;
 
   void OnMsgTransformChanged(ezMsgTransformChanged& msg);
 
@@ -121,6 +124,23 @@ public:
   float GetLodCellPixelSize() const { return m_fLodCellPixelSize; } // [ property ]
   void SetLodCellPixelSize(float fPixels);                          // [ property ]
 
+  /// Size in meters of one cell of the CPU occlusion culling geometry. 0 disables the occluder.
+  ///
+  /// The occluder is a coarse mesh, baked during scene export and when the editor starts the simulation, so a
+  /// patch has no occluder in the plain editor viewport. The value is only read during that bake, changing it
+  /// afterwards has no effect until the next one. A patch whose Collider mode is 'None' gets no occluder,
+  /// since both are baked from the same data, and the value is clamped to the collider's grid spacing.
+  float GetOcclusionCellSize() const { return m_fOcclusionCellSize; } // [ property ]
+  void SetOcclusionCellSize(float fCellSize);                         // [ property ]
+
+  /// Replaces the baked occluder mesh (local space). Called by the scene export modifier, empty arrays
+  /// remove the occluder.
+  void SetBakedOccluder(ezArrayPtr<const ezVec3> vertices, ezArrayPtr<const ezUInt32> indices);
+
+  /// Draws the occluder geometry as solid, single sided triangles. Called for all patches while the CVar
+  /// 'Terrain.VisOccluder' is enabled.
+  void DebugDrawOccluder() const;
+
   const ezTagSet& GetTags() const { return m_Tags; }                // [ property ]
   void Reflection_SetTag(const char* szTagName);                    // [ property ]
   void Reflection_RemoveTag(const char* szTagName);                 // [ property ]
@@ -162,6 +182,10 @@ private:
 
   /// ComputeColliderContentHash() of each cached mesh, to detect that the terrain changed underneath it.
   mutable ezUInt64 m_uiCpuMeshHash[2] = {0, 0};
+  
+  /// (Re)creates m_pOccluderObject and m_OccluderBounds from the baked mesh. Clears both when no mesh
+  /// has been baked.
+  void UpdateOccluder();
 
   ezUInt32 m_uiHeightfieldIndex = ezInvalidIndex;
   ezUInt64 m_uiStableId = 0;
@@ -181,4 +205,10 @@ private:
   float m_fHeightScale = 32.0f;
   float m_fLodCellPixelSize = 16.0f;
   bool m_bHeightImageDirty = false; ///< Set when the image resource reloads
+
+  float m_fOcclusionCellSize = 0.0f;
+  ezDynamicArray<ezVec3> m_OccluderVertices; ///< Local space vertices of the baked occluder mesh.
+  ezDynamicArray<ezUInt32> m_OccluderIndices;
+  ezBoundingBox m_OccluderBounds;            ///< Local space bounds of the occluder geometry. Invalid when there is none.
+  ezSharedPtr<const ezRasterizerObject> m_pOccluderObject;
 };

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
@@ -182,7 +182,7 @@ private:
 
   /// ComputeColliderContentHash() of each cached mesh, to detect that the terrain changed underneath it.
   mutable ezUInt64 m_uiCpuMeshHash[2] = {0, 0};
-  
+
   /// (Re)creates m_pOccluderObject and m_OccluderBounds from the baked mesh. Clears both when no mesh
   /// has been baked.
   void UpdateOccluder();


### PR DESCRIPTION
Generates a low-res, decimated representation of the terrain mesh, uses that for software occlusion culling.