### PR TITLE
Terrain geometry export

### DIFF
--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/LongOpTool.cpp
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/LongOpTool.cpp
@@ -1,0 +1,356 @@
+#include <EditorPluginMcp/EditorPluginMcpPCH.h>
+
+#include <EditorPluginMcp/McpDocument.h>
+#include <EditorPluginMcp/McpTools/LongOpTool.h>
+#include <Mcp/McpJson.h>
+#include <Mcp/McpJsonWriter.h>
+
+#include <EditorEngineProcessFramework/LongOps/LongOpControllerManager.h>
+#include <EditorEngineProcessFramework/LongOps/LongOps.h>
+#include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Object/DocumentObjectManager.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMcpLongOpTool, 1, ezRTTIDefaultAllocator<ezMcpLongOpTool>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+namespace
+{
+  /// A long op that hasn't finished by then is reported as still running rather than waited for further.
+  constexpr ezTime TimeOut = ezTime::MakeFromMinutes(10);
+
+  /// Writes what identifies one operation: which document and component it belongs to, and its state.
+  void WriteOperation(ezMcpJsonWriter& ref_writer, const ezLongOpControllerManager::ProxyOpInfo& opInfo, ezStringView sName = ezStringView())
+  {
+    ezStringBuilder sTmp;
+
+    // Inside an array the object has to stay anonymous, inside another object it needs a name.
+    ref_writer.BeginObject(sName);
+
+    ref_writer.AddVariableString("guid", ezConversionUtils::ToString(opInfo.m_OperationGuid, sTmp));
+    ref_writer.AddVariableString("name", opInfo.m_pProxyOp->GetDisplayName());
+    ref_writer.AddVariableString("type", opInfo.m_pProxyOp->GetDynamicRTTI()->GetTypeName());
+    ref_writer.AddVariableString("component", ezConversionUtils::ToString(opInfo.m_ComponentGuid, sTmp));
+
+    if (ezDocument* pDoc = ezDocumentManager::GetDocumentByGuid(opInfo.m_DocumentGuid))
+    {
+      ref_writer.AddVariableString("document", pDoc->GetDocumentPath());
+
+      // The component itself carries no name, so the object it sits on is what a user would recognize.
+      if (const ezDocumentObject* pComponent = pDoc->GetObjectManager()->GetObject(opInfo.m_ComponentGuid))
+      {
+        ref_writer.AddVariableString("componentType", pComponent->GetType()->GetTypeName());
+
+        if (const ezDocumentObject* pOwner = pComponent->GetParent())
+        {
+          ref_writer.AddVariableString("object", ezMcpDocument::GetObjectName(pOwner));
+        }
+      }
+    }
+
+    ref_writer.AddVariableBool("running", opInfo.m_bIsRunning);
+    ref_writer.AddVariableFloat("completion", opInfo.m_fCompletion);
+
+    ref_writer.EndObject();
+  }
+} // namespace
+
+void ezMcpLongOpTool::GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const
+{
+  ezMcpToolDesc& list = out_tools.ExpandAndGetRef();
+  list.m_sName = "longop_list";
+  list.m_sDescription = "Lists the long ops currently available - the entries of the editor's 'Long Ops' panel. One is "
+                        "registered automatically for every component in an open scene that offers such an operation, for "
+                        "instance ezBakedProbesComponent (baking a scene). So a long op only exists while the document "
+                        "holding its component is open: add the component with object_modify first if the one you want is "
+                        "missing. Each entry "
+                        "reports the guid that longop_execute takes, plus whether it is running and how far along it is.";
+  list.m_sInputSchema = R"({"type":"object","properties":{)"
+                        R"("document":{"type":"string","description":"Guid or path of an open document. Only list the long ops belonging to it."},)"
+                        R"("contains":{"type":"string","description":"Only list long ops whose display name or component type contains this text, case insensitive."}}})";
+
+  ezMcpToolDesc& run = out_tools.ExpandAndGetRef();
+  run.m_sName = "longop_execute";
+  run.m_sDescription = "Runs one long op and waits for it to finish, then reports whether it succeeded. This is the "
+                       "equivalent of pressing its button in the property grid or the 'Long Ops' panel.\n"
+                       "The work happens in the engine process, and what it writes back is applied to the document as a "
+                       "single undoable step - so after this returns, object_tree shows the result and object_undo reverts "
+                       "it. Nothing is saved: call document_save to keep it.\n"
+                       "Unlike action_execute this call is asynchronous internally, so it does not block the editor while "
+                       "waiting. It can still take minutes for a large scene, so give curl a timeout of tens of minutes. "
+                       "Progress is not reported while waiting; call longop_list from another connection to see it.";
+  run.m_sInputSchema = R"({"type":"object","properties":{)"
+                       R"("guid":{"type":"string","description":"Guid of the long op to run, as reported by longop_list."},)"
+                       R"("document":{"type":"string","description":"Guid or path of an open document. Together with 'componentType' this picks the long op instead of naming its guid."},)"
+                       R"("componentType":{"type":"string","description":"Type name of the component the long op belongs to, e.g. 'ezBakedProbesComponent'. Needs 'document', and only works when that document has exactly one such component."}}})";
+}
+
+void ezMcpLongOpTool::Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  if (sToolName == "longop_list")
+  {
+    ExecuteList(arguments, out_result);
+  }
+  else if (sToolName == "longop_execute")
+  {
+    ExecuteRun(arguments, out_result);
+  }
+}
+
+void ezMcpLongOpTool::ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+  const ezStringView sContains = ezMcpJson::GetString(arguments, "contains");
+
+  ezDocument* pDocument = nullptr;
+
+  if (!sDocument.IsEmpty())
+  {
+    pDocument = ezMcpDocument::Find(sDocument);
+
+    if (pDocument == nullptr)
+    {
+      ezMcpDocument::SetNotOpenError(out_result, sDocument);
+      return;
+    }
+  }
+
+  ezLongOpControllerManager* pManager = ezLongOpControllerManager::GetSingleton();
+
+  if (pManager == nullptr)
+  {
+    out_result.SetError("The long op controller is not available.");
+    return;
+  }
+
+  ezMcpJsonWriter writer;
+  writer.BeginObject();
+
+  ezUInt32 uiCount = 0;
+
+  {
+    EZ_LOCK(pManager->m_Mutex);
+
+    writer.BeginArray("longOps");
+
+    for (const auto& pOpInfo : pManager->GetOperations())
+    {
+      if (pDocument != nullptr && pOpInfo->m_DocumentGuid != pDocument->GetGuid())
+        continue;
+
+      if (!sContains.IsEmpty())
+      {
+        ezStringBuilder sHaystack = pOpInfo->m_pProxyOp->GetDisplayName();
+
+        if (ezDocument* pDoc = ezDocumentManager::GetDocumentByGuid(pOpInfo->m_DocumentGuid))
+        {
+          if (const ezDocumentObject* pComponent = pDoc->GetObjectManager()->GetObject(pOpInfo->m_ComponentGuid))
+          {
+            sHaystack.Append(" ", pComponent->GetType()->GetTypeName());
+          }
+        }
+
+        if (sHaystack.FindSubString_NoCase(sContains) == nullptr)
+          continue;
+      }
+
+      WriteOperation(writer, *pOpInfo);
+      ++uiCount;
+    }
+
+    writer.EndArray();
+  }
+
+  writer.AddVariableUInt32("count", uiCount);
+
+  if (uiCount == 0)
+  {
+    writer.AddVariableString("note", "No long op matched. They only exist for components in open documents, so open the "
+                                     "document and make sure it has a component that offers one.");
+  }
+
+  writer.EndObject();
+
+  out_result.m_sText = writer.GetResult();
+}
+
+ezResult ezMcpLongOpTool::ResolveOperation(ezLongOpControllerManager& ref_manager, const ezVariantDictionary& arguments, ezUuid& out_opGuid, ezMcpToolResult& out_result)
+{
+  const ezStringView sGuid = ezMcpJson::GetString(arguments, "guid");
+  const ezStringView sDocument = ezMcpJson::GetString(arguments, "document");
+  const ezStringView sComponentType = ezMcpJson::GetString(arguments, "componentType");
+
+  if (!sGuid.IsEmpty())
+  {
+    if (ezConversionUtils::TryConvertStringToUuid(sGuid, out_opGuid).Failed())
+    {
+      out_result.SetError("'guid' is not a valid guid. Take it from longop_list.");
+      return EZ_FAILURE;
+    }
+
+    return EZ_SUCCESS;
+  }
+
+  if (sDocument.IsEmpty() || sComponentType.IsEmpty())
+  {
+    out_result.SetError("Pass either 'guid', or both 'document' and 'componentType', to say which long op to run. "
+                        "longop_list reports both.");
+    return EZ_FAILURE;
+  }
+
+  ezDocument* pDocument = ezMcpDocument::Find(sDocument);
+
+  if (pDocument == nullptr)
+  {
+    ezMcpDocument::SetNotOpenError(out_result, sDocument);
+    return EZ_FAILURE;
+  }
+
+  ezUInt32 uiMatches = 0;
+
+  {
+    EZ_LOCK(ref_manager.m_Mutex);
+
+    for (const auto& pOpInfo : ref_manager.GetOperations())
+    {
+      if (pOpInfo->m_DocumentGuid != pDocument->GetGuid())
+        continue;
+
+      const ezDocumentObject* pComponent = pDocument->GetObjectManager()->GetObject(pOpInfo->m_ComponentGuid);
+
+      if (pComponent == nullptr || pComponent->GetType()->GetTypeName() != sComponentType)
+        continue;
+
+      out_opGuid = pOpInfo->m_OperationGuid;
+      ++uiMatches;
+    }
+  }
+
+  ezStringBuilder sMsg;
+
+  if (uiMatches == 0)
+  {
+    sMsg.SetFormat("No long op for a component of type '{}' in that document. Use longop_list to see what is there.", sComponentType);
+    out_result.SetError(sMsg);
+    return EZ_FAILURE;
+  }
+
+  if (uiMatches > 1)
+  {
+    sMsg.SetFormat("The document has {} components of type '{}', so 'componentType' does not identify one. Pass 'guid' instead.", uiMatches, sComponentType);
+    out_result.SetError(sMsg);
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+void ezMcpLongOpTool::ExecuteRun(const ezVariantDictionary& arguments, ezMcpToolResult& out_result)
+{
+  ezLongOpControllerManager* pManager = ezLongOpControllerManager::GetSingleton();
+
+  if (pManager == nullptr)
+  {
+    out_result.SetError("The long op controller is not available.");
+    return;
+  }
+
+  ezUuid opGuid;
+  if (ResolveOperation(*pManager, arguments, opGuid, out_result).Failed())
+    return;
+
+  // A re-entered call carries the same arguments, so it resolves to the operation that is already
+  // being waited for and only has to look at its state. A different one is a second, concurrent
+  // request, which this tool cannot serve because it keeps the wait state only once.
+  if (m_WaitingForOp.IsValid())
+  {
+    if (m_WaitingForOp != opGuid)
+    {
+      out_result.SetError("Another long op is currently being waited for. Only one longop_execute can be in flight at a "
+                          "time - watch the running one with longop_list and try again once it is done.");
+      return;
+    }
+
+    bool bStillRunning = false;
+
+    {
+      EZ_LOCK(pManager->m_Mutex);
+
+      if (auto pOpInfo = pManager->GetOperation(m_WaitingForOp))
+      {
+        bStillRunning = pOpInfo->m_bIsRunning;
+      }
+      else
+      {
+        // The operation disappeared, which happens when its component or document went away mid-run.
+        m_WaitingForOp = ezUuid();
+        out_result.SetError("The long op disappeared while it was running. Its component or document was probably closed.");
+        return;
+      }
+    }
+
+    if (bStillRunning)
+    {
+      if (ezTime::Now() - m_WaitStarted > TimeOut)
+      {
+        m_WaitingForOp = ezUuid();
+        out_result.SetError("Timed out waiting for the long op to finish. It is still running - use longop_list to watch it.");
+        return;
+      }
+
+      out_result.m_bNotFinished = true;
+      return;
+    }
+
+    // Finished. The proxy op has applied its result to the document by now, since that happens in
+    // Finalize(), which runs before m_bIsRunning goes back to false.
+    ezMcpJsonWriter writer;
+    writer.BeginObject();
+
+    {
+      EZ_LOCK(pManager->m_Mutex);
+
+      if (auto pOpInfo = pManager->GetOperation(m_WaitingForOp))
+      {
+        WriteOperation(writer, *pOpInfo, "longOp");
+        writer.AddVariableDouble("durationSeconds", pOpInfo->m_StartOrDuration.GetSeconds());
+      }
+    }
+
+    writer.AddVariableString("note", "The long op finished. Whether it produced anything is up to the operation - check the "
+                                     "editor log with log_read, and the document with object_tree. Nothing is saved yet.");
+    writer.EndObject();
+
+    m_WaitingForOp = ezUuid();
+    out_result.m_sText = writer.GetResult();
+    return;
+  }
+
+  {
+    EZ_LOCK(pManager->m_Mutex);
+
+    auto pOpInfo = pManager->GetOperation(opGuid);
+
+    if (pOpInfo == nullptr)
+    {
+      out_result.SetError("No long op with that guid. They are per editor session, so a guid from an earlier run is stale - "
+                          "call longop_list again.");
+      return;
+    }
+
+    if (pOpInfo->m_bIsRunning)
+    {
+      out_result.SetError("That long op is already running. Wait for it to finish, watching it with longop_list.");
+      return;
+    }
+  }
+
+  pManager->StartOperation(opGuid);
+
+  m_WaitingForOp = opGuid;
+  m_WaitStarted = ezTime::Now();
+
+  // Answer only once the operation is done, which needs the host to pump in between.
+  out_result.m_bNotFinished = true;
+}

--- a/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/LongOpTool.h
+++ b/Code/EditorPlugins/Mcp/EditorPluginMcp/McpTools/LongOpTool.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Foundation/Time/Time.h>
+#include <Foundation/Types/Uuid.h>
+#include <Mcp/McpTool.h>
+
+/// Tools for listing and running long ops - the operations behind the "Long Ops" panel.
+///
+/// A long op is registered automatically for every component in a scene that has an ezLongOpAttribute,
+/// for instance baking a scene or placing reflection probes. They run in the engine process, so unlike
+/// an editor action they are asynchronous: longop_execute therefore waits for the operation to finish
+/// before it answers, which needs the host to keep pumping in between.
+class ezMcpLongOpTool : public ezMcpToolProvider
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezMcpLongOpTool, ezMcpToolProvider);
+
+public:
+  virtual void GetSupportedTools(ezDynamicArray<ezMcpToolDesc>& out_tools) const override;
+  virtual void Execute(ezStringView sToolName, const ezVariantDictionary& arguments, ezMcpToolResult& out_result) override;
+
+private:
+  void ExecuteList(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+  void ExecuteRun(const ezVariantDictionary& arguments, ezMcpToolResult& out_result);
+
+  /// Works out which operation the arguments name, either directly by guid or by document + component type.
+  ///
+  /// Writes the reason into out_result and fails when the arguments don't identify exactly one operation.
+  /// The result is only a guid, so it stays valid to call repeatedly for the same (re-entered) request.
+  static ezResult ResolveOperation(class ezLongOpControllerManager& ref_manager, const ezVariantDictionary& arguments, ezUuid& out_opGuid, ezMcpToolResult& out_result);
+
+  /// Guid of the operation that ExecuteRun() is currently waiting for, invalid while nothing is running.
+  ezUuid m_WaitingForOp;
+
+  /// When the wait started, so that a long op that never finishes doesn't block the caller forever.
+  ezTime m_WaitStarted;
+};

--- a/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
@@ -1,13 +1,16 @@
 #include <RendererCore/RendererCorePCH.h>
 
 #include <Core/Messages/SetColorMessage.h>
+#include <Core/ResourceManager/ResourceManager.h>
 #include <Core/WorldSerializer/WorldReader.h>
 #include <Core/WorldSerializer/WorldWriter.h>
 #include <RendererCore/Components/LodComponent.h>
 #include <RendererCore/Debug/DebugRenderer.h>
+#include <RendererCore/Meshes/CpuMeshResource.h>
 #include <RendererCore/Meshes/LodMeshComponent.h>
 #include <RendererCore/Pipeline/RenderDataManager.h>
 #include <RendererCore/Pipeline/View.h>
+#include <RendererCore/Utils/WorldGeoExtractionUtil.h>
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_TYPE(ezLodMeshLod, ezNoBase, 2, ezRTTIDefaultAllocator<ezLodMeshLod>)
@@ -47,6 +50,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezLodMeshComponent, 2, ezComponentMode::Static)
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
     EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
     EZ_MESSAGE_HANDLER(ezMsgSetCustomData, OnMsgSetCustomData),
+    EZ_MESSAGE_HANDLER(ezMsgExtractGeometry, OnMsgExtractGeometry),
   }
   EZ_END_MESSAGEHANDLERS;
 }
@@ -191,6 +195,30 @@ void ezLodMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) con
     ezRenderData::Category category = ezMaterialResource::GetRenderDataCategory(hMaterial);
 
     msg.AddRenderData(pRenderData, category, ezRenderData::Caching::Never);
+  }
+}
+
+void ezLodMeshComponent::OnMsgExtractGeometry(ezMsgExtractGeometry& ref_msg) const
+{
+  if (ref_msg.m_Mode != ezWorldGeoExtractionUtil::ExtractionMode::RenderMesh)
+    return;
+
+  for (ezUInt32 i = m_Meshes.GetCount(); i > 0; --i)
+  {
+    const ezMeshResourceHandle& hMesh = m_Meshes[i - 1].m_hMesh;
+
+    if (!hMesh.IsValid())
+      continue;
+
+    // A procedurally created mesh only exists on the GPU side, there is no file to load a CPU mesh from.
+    {
+      ezResourceLock<ezMeshResource> pMesh(hMesh, ezResourceAcquireMode::PointerOnly);
+      if (pMesh->GetBaseResourceFlags().IsAnySet(ezResourceFlags::IsCreatedResource))
+        continue;
+    }
+
+    ref_msg.AddMeshObject(GetOwner()->GetGlobalTransform(), ezResourceManager::LoadResource<ezCpuMeshResource>(hMesh.GetResourceID()));
+    return;
   }
 }
 

--- a/Code/Engine/RendererCore/Meshes/LodMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/LodMeshComponent.h
@@ -3,6 +3,8 @@
 #include <Core/World/World.h>
 #include <RendererCore/Meshes/MeshComponentBase.h>
 
+struct ezMsgExtractGeometry;
+
 using ezLodMeshComponentManager = ezComponentManager<class ezLodMeshComponent, ezBlockStorageType::Compact>;
 
 struct ezLodMeshLod
@@ -72,6 +74,11 @@ public:
 
   void OnMsgSetColor(ezMsgSetColor& ref_msg);           // [ msg handler ]
   void OnMsgSetCustomData(ezMsgSetCustomData& ref_msg); // [ msg handler ]
+
+  /// Provides the coarsest LOD that actually has a mesh, since the geometry is wanted for things like
+  /// exporting the scene, where the close-up detail is not useful. Only answers a request for render
+  /// geometry; collision geometry is expected to come from a dedicated collider component.
+  void OnMsgExtractGeometry(ezMsgExtractGeometry& ref_msg) const; // [ msg handler ]
 
 protected:
   void UpdateSelectedLod(const ezView& view) const;

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.cpp
@@ -12,7 +12,10 @@
 #include <Foundation/Types/TagRegistry.h>
 #include <RendererCore/Components/RenderComponent.h>
 #include <RendererCore/Material/MaterialResource.h>
+#include <RendererCore/Meshes/CpuMeshResource.h>
+#include <RendererCore/Meshes/MeshBufferUtils.h>
 #include <RendererCore/Pipeline/RenderDataManager.h>
+#include <RendererCore/Utils/WorldGeoExtractionUtil.h>
 #include <TerrainPlugin/Components/TerrainPatchComponent.h>
 #include <TerrainPlugin/Rendering/TerrainRenderData.h>
 #include <TerrainPlugin/TerrainSystem.h>
@@ -50,6 +53,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainPatchComponent, 3, ezComponentMode::Static)
   {
     EZ_MESSAGE_HANDLER(ezMsgTransformChanged, OnMsgTransformChanged),
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+    EZ_MESSAGE_HANDLER(ezMsgExtractGeometry, OnMsgExtractGeometry),
   }
   EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_FUNCTIONS
@@ -510,6 +514,185 @@ ezString ezTerrainPatchComponent::Surfaces_GetValue(ezUInt32 uiIndex) const
   if (uiIndex >= m_Surfaces.GetCount() || !m_Surfaces[uiIndex].IsValid())
     return {};
   return m_Surfaces[uiIndex].GetResourceID();
+}
+
+ezCpuMeshResourceHandle ezTerrainPatchComponent::GenerateCpuMesh(ezUInt32 uiStride) const
+{
+  if (m_uiHeightfieldIndex == ezInvalidIndex)
+    return ezCpuMeshResourceHandle();
+
+  // Geometry extraction only holds a read lock on the world, so the module must not be created here.
+  // Reading the heights back does mutate the terrain system, hence the const_cast.
+  const ezTerrainSystem* pConstTerrain = GetWorld()->GetModule<ezTerrainSystem>();
+  if (pConstTerrain == nullptr)
+    return ezCpuMeshResourceHandle();
+
+  ezTerrainSystem* pTerrain = const_cast<ezTerrainSystem*>(pConstTerrain);
+
+  const ezUInt32 uiCellsPerSide = pTerrain->GetHeightfieldCellsPerSide(m_uiHeightfieldIndex);
+  if (uiCellsPerSide < 2)
+    return ezCpuMeshResourceHandle();
+
+  // Sub-sampling has to divide the grid evenly, otherwise the mesh would not span the full patch, so a
+  // stride that doesn't is halved until it does. All the values that get passed in are powers of two.
+  uiStride = ezMath::Max(1u, uiStride);
+  while (uiStride > 1 && (uiCellsPerSide % uiStride) != 0)
+  {
+    uiStride /= 2;
+  }
+
+  // The stride differs per extraction mode, so each mode gets its own cache slot. Slot 0 holds the
+  // full-resolution mesh, which is what the render geometry asks for.
+  const ezUInt32 uiCacheSlot = (uiStride <= 1) ? 0 : 1;
+
+  // The hash covers everything that changes the shape of the mesh, so as long as it matches, the
+  // cached mesh is still the right one. Without this check, edits to the terrain would go unnoticed.
+  const ezUInt64 uiContentHash = ComputeColliderContentHash(pTerrain->GetHeightfieldBrushOverlapHash(m_uiHeightfieldIndex));
+
+  if (m_hCpuMesh[uiCacheSlot].IsValid() && m_uiCpuMeshHash[uiCacheSlot] == uiContentHash)
+    return m_hCpuMesh[uiCacheSlot];
+
+  m_hCpuMesh[uiCacheSlot].Invalidate();
+  m_uiCpuMeshHash[uiCacheSlot] = uiContentHash;
+
+  // The stride is not part of the content hash, so it has to be part of the name: the same patch can
+  // have a render-resolution and a collider-resolution mesh alive at the same time.
+  ezStringBuilder sResourceName;
+  sResourceName.SetFormat("TerrainPatchCpuMesh:{}-{}-{}", ezArgU(m_uiStableId, 16, true, 16, true), uiContentHash, uiStride);
+
+  m_hCpuMesh[uiCacheSlot] = ezResourceManager::GetExistingResource<ezCpuMeshResource>(sResourceName);
+  if (m_hCpuMesh[uiCacheSlot].IsValid())
+    return m_hCpuMesh[uiCacheSlot];
+
+  // Reading back from the GPU blocks, so this is deliberately only done on demand.
+  ezTempArray<float> bakedHeights;
+  ezTempArray<ezUInt8> dominantIndices;
+  if (pTerrain->ReadbackHeightfieldData(m_uiHeightfieldIndex, bakedHeights, dominantIndices).Failed())
+  {
+    ezLog::Warning("ezTerrainPatchComponent: could not read back the height data, the patch provides no geometry.");
+    return ezCpuMeshResourceHandle();
+  }
+
+  // The stored grid carries 4 border rings on each side beyond the rendered vertices.
+  constexpr ezUInt32 uiBorder = 4;
+  const ezUInt32 uiStoredRowStride = uiCellsPerSide + 2 * uiBorder + 1;
+
+  if (bakedHeights.GetCount() < uiStoredRowStride * uiStoredRowStride)
+    return ezCpuMeshResourceHandle();
+
+  const ezUInt32 uiNumVertices = (uiCellsPerSide / uiStride) + 1;
+  const ezUInt32 uiNumCells = uiNumVertices - 1;
+
+  const bool bHasDominantIndices = dominantIndices.GetCount() == bakedHeights.GetCount();
+
+  // Index of the stored sample that grid coordinate (x, y) of the mesh reads from. Only the rendered
+  // vertices are covered - the border rings exist for the skirt and for normal computation, and the
+  // skirt is deliberately left out here, since it only hides seams against a coarser LOD neighbor.
+  auto SourceIndex = [&](ezUInt32 x, ezUInt32 y) -> ezUInt32
+  {
+    return (uiBorder + y * uiStride) * uiStoredRowStride + (uiBorder + x * uiStride);
+  };
+
+  // Cells that were carved away have no surface and get no triangles - the shaders drop those vertices
+  // too, so they are holes on screen as well. Counting them up front keeps the index buffer free of
+  // degenerate triangles, which every consumer of the mesh would have to process, since they read the
+  // mesh buffer rather than the submesh.
+  ezUInt32 uiNumTriangles = uiNumCells * uiNumCells * 2;
+
+  if (bHasDominantIndices)
+  {
+    uiNumTriangles = 0;
+
+    for (ezUInt32 y = 0; y < uiNumCells; ++y)
+    {
+      for (ezUInt32 x = 0; x < uiNumCells; ++x)
+      {
+        if (dominantIndices[SourceIndex(x, y)] != 0xFFu)
+          uiNumTriangles += 2;
+      }
+    }
+  }
+
+  if (uiNumTriangles == 0)
+    return ezCpuMeshResourceHandle();
+
+  ezMeshResourceDescriptor desc;
+  desc.SetMaterial(0, "{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"); // Data/Base/Materials/Common/Pattern.ezMaterialAsset
+  desc.MeshBufferDesc().AddCommonStreams();
+
+  auto& mb = desc.MeshBufferDesc();
+  mb.AllocateStreams(uiNumVertices * uiNumVertices, ezGALPrimitiveTopology::Triangles, uiNumTriangles);
+
+  // The patch occupies [0; m_fSize] in its own space, with the origin at a corner rather than the
+  // center - the same convention that GetLocalBounds() and the LOD selection use.
+  const float fGridSpacing = m_fSize / (float)uiCellsPerSide * (float)uiStride;
+
+  auto positionData = mb.GetPositionData();
+
+  ezBoundingBox bounds = ezBoundingBox::MakeInvalid();
+
+  for (ezUInt32 y = 0; y < uiNumVertices; ++y)
+  {
+    for (ezUInt32 x = 0; x < uiNumVertices; ++x)
+    {
+      const ezVec3 vPos(x * fGridSpacing, y * fGridSpacing, bakedHeights[SourceIndex(x, y)]);
+
+      positionData.GetPtr()[y * uiNumVertices + x] = vPos;
+      bounds.ExpandToInclude(vPos);
+    }
+  }
+
+  // Only positions are filled in; normals and texture coordinates carry no information that a
+  // consumer of this mesh (navmesh generation, geometry export) would use.
+
+  ezUInt32 uiTriangleIdx = 0;
+
+  for (ezUInt32 y = 0; y < uiNumCells; ++y)
+  {
+    for (ezUInt32 x = 0; x < uiNumCells; ++x)
+    {
+      if (bHasDominantIndices && dominantIndices[SourceIndex(x, y)] == 0xFFu)
+        continue;
+
+      const ezUInt32 uiIdx = y * uiNumVertices + x;
+
+      mb.SetTriangleIndices(uiTriangleIdx + 0, uiIdx, uiIdx + 1, uiIdx + uiNumVertices);
+      mb.SetTriangleIndices(uiTriangleIdx + 1, uiIdx + 1, uiIdx + uiNumVertices + 1, uiIdx + uiNumVertices);
+      uiTriangleIdx += 2;
+    }
+  }
+
+  EZ_ASSERT_DEBUG(uiTriangleIdx == uiNumTriangles, "Triangle count doesn't match what was allocated.");
+
+  desc.SetBounds(ezBoundingBoxSphere::MakeFromBox(bounds));
+  desc.AddSubMesh(mb.GetPrimitiveCount(), 0, 0);
+
+  m_hCpuMesh[uiCacheSlot] = ezResourceManager::GetOrCreateResource<ezCpuMeshResource>(sResourceName, std::move(desc), sResourceName);
+  return m_hCpuMesh[uiCacheSlot];
+}
+
+void ezTerrainPatchComponent::OnMsgExtractGeometry(ezMsgExtractGeometry& msg) const
+{
+  ezUInt32 uiStride = 1;
+
+  if (msg.m_Mode == ezWorldGeoExtractionUtil::ExtractionMode::CollisionMesh)
+  {
+    // A patch without a collider is not part of the world's physical representation, so it stays out of
+    // navmeshes and collision exports.
+    if (m_ColliderMode == ezTerrainPatchColliderMode::None)
+      return;
+
+    // The enumerator value is the vertex stride, so the collision mesh is as coarse as the collider.
+    uiStride = (ezUInt32)m_ColliderMode.GetValue();
+  }
+
+  // Render geometry is provided at the full render resolution (stride 1).
+  ezCpuMeshResourceHandle hMesh = GenerateCpuMesh(uiStride);
+
+  if (!hMesh.IsValid())
+    return;
+
+  msg.AddMeshObject(GetOwner()->GetGlobalTransform(), hMesh);
 }
 
 ezUInt64 ezTerrainPatchComponent::ComputeColliderContentHash(ezUInt64 uiBrushOverlapHash) const

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainPatchComponent.h
@@ -8,12 +8,14 @@
 #include <TerrainPlugin/TerrainPluginDLL.h>
 #include <TerrainPlugin/TerrainSystem.h>
 
+struct ezMsgExtractGeometry;
 struct ezMsgExtractRenderData;
 struct ezMsgTransformChanged;
 struct ezResourceEvent;
 class ezAbstractObjectNode;
 
 using ezMaterialResourceHandle = ezTypedResourceHandle<class ezMaterialResource>;
+using ezCpuMeshResourceHandle = ezTypedResourceHandle<class ezCpuMeshResource>;
 
 class EZ_TERRAINPLUGIN_DLL ezTerrainPatchComponentManager : public ezComponentManager<class ezTerrainPatchComponent, ezBlockStorageType::Compact>
 {
@@ -57,6 +59,17 @@ protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
 
   void OnMsgTransformChanged(ezMsgTransformChanged& msg);
+
+  /// Provides the terrain surface as a triangle mesh, for navmesh generation, geometry export and similar.
+  ///
+  /// The heights only exist on the GPU, so this reads them back, which is slow and only possible on the
+  /// main thread. The mesh is therefore built on demand and cached.
+  ///
+  /// Render geometry is provided at the full render resolution, collision geometry at the resolution the
+  /// collider setting asks for. Neither includes the skirt, which only exists to hide LOD seams. A patch
+  /// with the collider disabled provides nothing for a collision mesh, since it is not meant to be part
+  /// of the world's physical representation, but it still provides its render geometry.
+  void OnMsgExtractGeometry(ezMsgExtractGeometry& msg) const;
 
   //////////////////////////////////////////////////////////////////////////
   // ezTerrainPatchComponent
@@ -132,6 +145,23 @@ public:
 
 private:
   void OnObjectCreated(const ezAbstractObjectNode& node);
+
+  /// Builds (or returns the cached) CPU mesh of the terrain surface. Empty handle if unavailable.
+  ///
+  /// uiStride is the spacing, in full-resolution cells, between the mesh's vertices. 1 reproduces the
+  /// render resolution, higher values sub-sample it. It has to divide the cell count evenly, otherwise
+  /// the mesh would not span the whole patch.
+  ///
+  /// Blocks on a GPU readback of the height data, so this is only meant to be called for an explicit
+  /// user action (exporting the scene, generating a navmesh), not per frame. It requires the terrain
+  /// system to exist already, since it may only take a read lock on the world.
+  ezCpuMeshResourceHandle GenerateCpuMesh(ezUInt32 uiStride) const;
+
+  /// One cache slot per ezWorldGeoExtractionUtil::ExtractionMode, since the two resolutions differ.
+  mutable ezCpuMeshResourceHandle m_hCpuMesh[2];
+
+  /// ComputeColliderContentHash() of each cached mesh, to detect that the terrain changed underneath it.
+  mutable ezUInt64 m_uiCpuMeshHash[2] = {0, 0};
 
   ezUInt32 m_uiHeightfieldIndex = ezInvalidIndex;
   ezUInt64 m_uiStableId = 0;

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainVolumeComponent.cpp
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainVolumeComponent.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/Messages/TransformChangedMessage.h>
 #include <Core/Physics/SurfaceResource.h>
+#include <Core/ResourceManager/ResourceManager.h>
 #include <Core/WorldSerializer/WorldReader.h>
 #include <Core/WorldSerializer/WorldWriter.h>
 #include <Foundation/Algorithm/HashStream.h>
@@ -10,7 +11,10 @@
 #include <Foundation/Serialization/AbstractObjectGraph.h>
 #include <Foundation/Types/TagRegistry.h>
 #include <RendererCore/Material/MaterialResource.h>
+#include <RendererCore/Meshes/CpuMeshResource.h>
+#include <RendererCore/Meshes/MeshBufferUtils.h>
 #include <RendererCore/Pipeline/RenderDataManager.h>
+#include <RendererCore/Utils/WorldGeoExtractionUtil.h>
 #include <TerrainPlugin/Components/TerrainVolumeComponent.h>
 #include <TerrainPlugin/Rendering/TerrainRenderData.h>
 #include <TerrainPlugin/TerrainSystem.h>
@@ -35,6 +39,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTerrainVolumeComponent, 1, ezComponentMode::Static)
   {
     EZ_MESSAGE_HANDLER(ezMsgTransformChanged, OnMsgTransformChanged),
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+    EZ_MESSAGE_HANDLER(ezMsgExtractGeometry, OnMsgExtractGeometry),
   }
   EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_FUNCTIONS
@@ -370,6 +375,102 @@ void ezTerrainVolumeComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& ms
     msg.AddDependency(hIdxs, ezDefaultRenderDataCategories::LitOpaque, ezGALResourceState::ShaderResource, ezGALShaderStageFlags::VertexShader);
   if (!hDrawArgs.IsInvalidated())
     msg.AddDependency(hDrawArgs, ezDefaultRenderDataCategories::LitOpaque, ezGALResourceState::DrawIndirect);
+}
+
+ezCpuMeshResourceHandle ezTerrainVolumeComponent::GenerateCpuMesh() const
+{
+  if (m_uiVoxelIndex == ezInvalidIndex)
+    return ezCpuMeshResourceHandle();
+
+  // Geometry extraction only holds a read lock on the world, so the module must not be created here.
+  // Reading the mesh back does mutate the terrain system, hence the const_cast.
+  const ezTerrainSystem* pConstTerrain = GetWorld()->GetModule<ezTerrainSystem>();
+  if (pConstTerrain == nullptr)
+    return ezCpuMeshResourceHandle();
+
+  ezTerrainSystem* pTerrain = const_cast<ezTerrainSystem*>(pConstTerrain);
+
+  // The hash covers everything that changes the shape of the mesh, so as long as it matches, the
+  // cached mesh is still the right one. Without this check, edits to the volume would go unnoticed.
+  const ezUInt64 uiContentHash = ComputeColliderContentHash(pTerrain->GetVoxelBrushOverlapHash(m_uiVoxelIndex));
+
+  if (m_hCpuMesh.IsValid() && m_uiCpuMeshHash == uiContentHash)
+    return m_hCpuMesh;
+
+  m_hCpuMesh.Invalidate();
+  m_uiCpuMeshHash = uiContentHash;
+
+  ezStringBuilder sResourceName;
+  sResourceName.SetFormat("TerrainVolumeCpuMesh:{}-{}", ezArgU(m_uiStableId, 16, true, 16, true), uiContentHash);
+
+  m_hCpuMesh = ezResourceManager::GetExistingResource<ezCpuMeshResource>(sResourceName);
+  if (m_hCpuMesh.IsValid())
+    return m_hCpuMesh;
+
+  // Reading back from the GPU blocks, so this is deliberately only done on demand.
+  ezTempArray<VoxelGpuVertex> verts;
+  ezTempArray<ezUInt32> indices;
+  ezUInt32 uiVertexCount = 0;
+  ezUInt32 uiTriangleCount = 0;
+
+  if (pTerrain->ReadbackVoxelData(m_uiVoxelIndex, verts, indices, uiVertexCount, uiTriangleCount).Failed())
+  {
+    ezLog::Warning("ezTerrainVolumeComponent: could not read back the voxel mesh, the volume provides no geometry.");
+    return ezCpuMeshResourceHandle();
+  }
+
+  // An empty volume is the normal case for one that no brush overlaps.
+  if (uiVertexCount == 0 || uiTriangleCount == 0)
+    return ezCpuMeshResourceHandle();
+
+  if (verts.GetCount() < uiVertexCount || indices.GetCount() < uiTriangleCount * 3)
+    return ezCpuMeshResourceHandle();
+
+  ezMeshResourceDescriptor desc;
+  desc.SetMaterial(0, "{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"); // Data/Base/Materials/Common/Pattern.ezMaterialAsset
+  desc.MeshBufferDesc().AddCommonStreams();
+
+  auto& mb = desc.MeshBufferDesc();
+  mb.AllocateStreams(uiVertexCount, ezGALPrimitiveTopology::Triangles, uiTriangleCount);
+
+  // Only positions are filled in; normals and texture coordinates carry no information that a
+  // consumer of this mesh (navmesh generation, geometry export) would use.
+  auto positionData = mb.GetPositionData();
+
+  ezBoundingBox bounds = ezBoundingBox::MakeInvalid();
+
+  for (ezUInt32 i = 0; i < uiVertexCount; ++i)
+  {
+    positionData.GetPtr()[i] = verts[i].Position;
+    bounds.ExpandToInclude(verts[i].Position);
+  }
+
+  for (ezUInt32 uiTriangle = 0; uiTriangle < uiTriangleCount; ++uiTriangle)
+  {
+    mb.SetTriangleIndices(uiTriangle, indices[uiTriangle * 3 + 0], indices[uiTriangle * 3 + 1], indices[uiTriangle * 3 + 2]);
+  }
+
+  desc.SetBounds(ezBoundingBoxSphere::MakeFromBox(bounds));
+  desc.AddSubMesh(mb.GetPrimitiveCount(), 0, 0);
+
+  m_hCpuMesh = ezResourceManager::GetOrCreateResource<ezCpuMeshResource>(sResourceName, std::move(desc), sResourceName);
+  return m_hCpuMesh;
+}
+
+void ezTerrainVolumeComponent::OnMsgExtractGeometry(ezMsgExtractGeometry& msg) const
+{
+  // A volume without a collider is not part of the world's physical representation, so it stays out of
+  // navmeshes and collision exports. It is still included when the render geometry is what's wanted.
+  if (msg.m_Mode == ezWorldGeoExtractionUtil::ExtractionMode::CollisionMesh && !m_bEnableCollider)
+    return;
+
+  ezCpuMeshResourceHandle hMesh = GenerateCpuMesh();
+
+  if (!hMesh.IsValid())
+    return;
+
+  // The voxel vertices are in the volume's own space, the same space the baked Jolt collider uses.
+  msg.AddMeshObject(GetOwner()->GetGlobalTransform(), hMesh);
 }
 
 ezUInt64 ezTerrainVolumeComponent::ComputeColliderContentHash(ezUInt64 uiBrushOverlapHash) const

--- a/Code/EnginePlugins/TerrainPlugin/Components/TerrainVolumeComponent.h
+++ b/Code/EnginePlugins/TerrainPlugin/Components/TerrainVolumeComponent.h
@@ -7,11 +7,13 @@
 #include <TerrainPlugin/TerrainPluginDLL.h>
 #include <TerrainPlugin/TerrainSystem.h>
 
+struct ezMsgExtractGeometry;
 struct ezMsgExtractRenderData;
 struct ezMsgTransformChanged;
 
 using ezMaterialResourceHandle = ezTypedResourceHandle<class ezMaterialResource>;
 using ezSurfaceResourceHandle = ezTypedResourceHandle<class ezSurfaceResource>;
+using ezCpuMeshResourceHandle = ezTypedResourceHandle<class ezCpuMeshResource>;
 
 using ezTerrainVolumeComponentManager = ezComponentManager<class ezTerrainVolumeComponent, ezBlockStorageType::Compact>;
 
@@ -42,6 +44,13 @@ protected:
   virtual ezResult GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg) override;
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
   void OnMsgTransformChanged(ezMsgTransformChanged& msg);
+
+  /// Provides the triangulated voxel surface, for navmesh generation, geometry export and similar.
+  ///
+  /// The mesh only exists on the GPU, so this reads it back, which is slow. The result is cached.
+  /// A volume with the collider disabled provides nothing for a collision mesh, since it is not meant
+  /// to be part of the world's physical representation, but it still provides its render geometry.
+  void OnMsgExtractGeometry(ezMsgExtractGeometry& msg) const;
 
   //////////////////////////////////////////////////////////////////////////
   // ezTerrainVolumeComponent
@@ -94,6 +103,18 @@ public:
 
 private:
   void OnObjectCreated(const ezAbstractObjectNode& node);
+
+  /// Builds (or returns the cached) CPU mesh of the voxel surface. Empty handle if unavailable.
+  ///
+  /// Blocks on a GPU readback, so this is only meant to be called for an explicit user action
+  /// (exporting the scene, generating a navmesh), not per frame. It requires the terrain system to
+  /// exist already, since it may only take a read lock on the world.
+  ezCpuMeshResourceHandle GenerateCpuMesh() const;
+
+  mutable ezCpuMeshResourceHandle m_hCpuMesh;
+
+  /// ComputeColliderContentHash() of the cached mesh, to detect that the volume changed underneath it.
+  mutable ezUInt64 m_uiCpuMeshHash = 0;
 
   ezUInt32 m_uiVoxelIndex = ezInvalidIndex;
   ezUInt64 m_uiStableId = 0;


### PR DESCRIPTION
Added geometry export (render + collider geometry) to the terrain components (patches + volumes) and the LOD mesh component.

Also includes MCP tool for editor long-ops, but this is unused at the moment, since there are no long-ops.