### PR TITLE
Prefab deletion fix

### DIFF
--- a/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -334,12 +334,19 @@ void ezPrefabReferenceComponent::ClearPreviousInstances()
     for (ezUInt32 ip1 = comps.GetCount(); ip1 > 0; ip1--)
     {
       const ezUInt32 i = ip1 - 1;
+      ezComponent* pComp = comps[i];
 
-      if (comps[i] != this && // don't try to delete yourself
-          comps[i]->WasCreatedByPrefab())
+      if (pComp == this || // don't try to delete yourself
+          pComp->WasCreatedByPrefab() == false)
+        continue;
+
+      // Prevent other prefab components from deleting its instances. This might lead to an endless loop of prefab components deleting each other.
+      if (pComp->IsInstanceOf<ezPrefabReferenceComponent>())
       {
-        comps[i]->DeleteComponent();
+        pComp->SetUserFlag((ezUInt8)PrefabComponentFlags::SelfDeletion, true);
       }
+
+      pComp->DeleteComponent();
     }
 
     for (auto it = GetOwner()->GetChildren(); it.IsValid(); ++it)


### PR DESCRIPTION
This fixes an endless recursion when you have the following constellations:

```
Prefab asset
|- Any object
   |- Prefab reference component
   |- Prefab reference component
```
or more obscure
```
Prefab asset A
|- Root object (<Prefab-Root>)
   |- Prefab reference component

Prefab asset B
|- Any object
   |- Prefab reference component (referencing A)
```
which will end up as the same as above when instanciated.

After the fix, the first prefab component will take care of deleting all components and objects marked as "created by prefab" and prevents any other prefab components on the same object from doing the same, they should only delete itself.