### PR TITLE
Jolt material/surface debug rendering mode

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.cpp
@@ -2,7 +2,7 @@
 
 #include <EditorPluginAssets/SurfaceAsset/SurfaceAsset.h>
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceAssetDocument, 2, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceAssetDocument, 3, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezSurfaceAssetDocument::ezSurfaceAssetDocument(ezStringView sDocumentPath)

--- a/Code/Engine/Core/Physics/Implementation/SurfaceResourceDescriptor.cpp
+++ b/Code/Engine/Core/Physics/Implementation/SurfaceResourceDescriptor.cpp
@@ -26,7 +26,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezSurfaceInteraction, ezNoBase, 1, ezRTTIDefaultA
 }
 EZ_END_STATIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceResourceDescriptor, 2, ezRTTIDefaultAllocator<ezSurfaceResourceDescriptor>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceResourceDescriptor, 3, ezRTTIDefaultAllocator<ezSurfaceResourceDescriptor>)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -38,6 +38,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceResourceDescriptor, 2, ezRTTIDefaultAll
     EZ_ACCESSOR_PROPERTY("OnCollideInteraction", GetCollisionInteraction, SetCollisionInteraction)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum")),
     EZ_ACCESSOR_PROPERTY("SlideReaction", GetSlideReactionPrefabFile, SetSlideReactionPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("RollReaction", GetRollReactionPrefabFile, SetRollReactionPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
+    EZ_MEMBER_PROPERTY("DebugColor", m_DebugColor)->AddAttributes(new ezDefaultValueAttribute(ezColorGammaUB(255, 255, 255))),
     EZ_ARRAY_MEMBER_PROPERTY("Interactions", m_Interactions),
   }
   EZ_END_PROPERTIES;
@@ -90,7 +91,7 @@ void ezSurfaceResourceDescriptor::Load(ezStreamReader& inout_stream)
   ezUInt8 uiVersion = 0;
 
   inout_stream >> uiVersion;
-  EZ_ASSERT_DEV(uiVersion <= 8, "Invalid version {0} for surface resource", uiVersion);
+  EZ_ASSERT_DEV(uiVersion <= 9, "Invalid version {0} for surface resource", uiVersion);
 
   inout_stream >> m_fPhysicsRestitution;
   inout_stream >> m_fPhysicsFrictionStatic;
@@ -162,11 +163,16 @@ void ezSurfaceResourceDescriptor::Load(ezStreamReader& inout_stream)
   {
     inout_stream >> m_iGroundType;
   }
+
+  if (uiVersion >= 9)
+  {
+    inout_stream >> m_DebugColor;
+  }
 }
 
 void ezSurfaceResourceDescriptor::Save(ezStreamWriter& inout_stream) const
 {
-  const ezUInt8 uiVersion = 8;
+  const ezUInt8 uiVersion = 9;
 
   inout_stream << uiVersion;
   inout_stream << m_fPhysicsRestitution;
@@ -207,6 +213,9 @@ void ezSurfaceResourceDescriptor::Save(ezStreamWriter& inout_stream) const
 
   // version 8
   inout_stream << m_iGroundType;
+
+  // version 9
+  inout_stream << m_DebugColor;
 }
 
 void ezSurfaceResourceDescriptor::SetCollisionInteraction(const char* szName)

--- a/Code/Engine/Core/Physics/SurfaceResourceDescriptor.h
+++ b/Code/Engine/Core/Physics/SurfaceResourceDescriptor.h
@@ -5,6 +5,7 @@
 #include <Core/Prefabs/PrefabResource.h>
 #include <Core/ResourceManager/Resource.h>
 #include <Foundation/Containers/ArrayMap.h>
+#include <Foundation/Math/Color8UNorm.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Strings/HashedString.h>
 #include <Foundation/Types/RangeView.h>
@@ -88,6 +89,10 @@ public:
   ezHashedString m_sSlideInteractionPrefab;
   ezHashedString m_sRollInteractionPrefab;
   ezInt8 m_iGroundType = -1; ///< What kind of ground this is for navigation purposes. Ground type properties need to be specified elsewhere, this is just a number.
+
+  /// Color to use when visualizing which surface is assigned to which geometry (see the CVar 'Jolt.Visualize.Surfaces').
+  /// Has no effect on anything but debug visualizations.
+  ezColorGammaUB m_DebugColor = ezColorGammaUB(255, 255, 255);
 
   ezHybridArray<ezSurfaceInteraction, 16> m_Interactions;
 };

--- a/Code/EnginePlugins/JoltPlugin/Resources/JoltMaterial.h
+++ b/Code/EnginePlugins/JoltPlugin/Resources/JoltMaterial.h
@@ -15,4 +15,5 @@ public:
 
   float m_fRestitution = 0.0f;
   float m_fFriction = 0.2f;
+  ezColor m_DebugColor = ezColor::White;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
@@ -223,6 +223,7 @@ void ezJoltCore::Startup()
 
   s_pDefaultMaterial = new ezJoltMaterial;
   s_pDefaultMaterial->AddRef();
+  s_pDefaultMaterial->m_DebugColor = ezColor::DimGrey;
   JPH::PhysicsMaterial::sDefault = s_pDefaultMaterial;
 
 #ifdef JPH_DEBUG_RENDERER
@@ -283,6 +284,7 @@ void ezJoltCore::SurfaceResourceEventHandler(const ezSurfaceResourceEvent& e)
       EZ_ASSERT_DEV(pJoltMat->m_pSurface == e.m_pSurface, "Invalid surface");
     }
 
+    pJoltMat->m_DebugColor = desc.m_DebugColor;
     pJoltMat->m_fRestitution = desc.m_fPhysicsRestitution;
     pJoltMat->m_fFriction = ezMath::Lerp(desc.m_fPhysicsFrictionStatic, desc.m_fPhysicsFrictionDynamic, 0.5f);
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -46,7 +46,8 @@ ezCVarBool cvar_JoltDebugDrawConstraintFrames("Jolt.DebugDraw.ConstraintFrames",
 ezCVarBool cvar_JoltDebugDrawBodies("Jolt.DebugDraw.Bodies", false, ezCVarFlags::None, "Visualize physics bodies.");
 #endif
 
-ezCVarBool cvar_JoltVisualizeGeometry("Jolt.Visualize.Geometry", false, ezCVarFlags::None, "Renders collision geometry.");
+ezCVarBool cvar_JoltVisualizeGeometry("Jolt.Visualize.Geometry", false, ezCVarFlags::None, "Renders collision geometry, color coded by shape type.");
+ezCVarBool cvar_JoltVisualizeSurfaces("Jolt.Visualize.Surfaces", false, ezCVarFlags::None, "Renders collision geometry, color coded by the debug color of the assigned surface. Takes precedence over 'Jolt.Visualize.Geometry'.");
 ezCVarBool cvar_JoltVisualizeGeometryExclusive("Jolt.Visualize.Exclusive", false, ezCVarFlags::Save, "Hides regularly rendered geometry.");
 ezCVarFloat cvar_JoltVisualizeDistance("Jolt.Visualize.Distance", 30.0f, ezCVarFlags::Save, "How far away objects to visualize.");
 
@@ -1062,7 +1063,11 @@ void ezJoltWorldModule::DebugDrawGeometry()
 
   const ezTag& tag = ezTagRegistry::GetGlobalRegistry().RegisterTag("PhysicsCollider");
 
-  if (cvar_JoltVisualizeGeometry && cvar_JoltVisualizeGeometryExclusive)
+  // both visualizations draw the same geometry, so only one of them is active at a time
+  const bool bSurfaceColors = cvar_JoltVisualizeSurfaces;
+  const bool bVisualize = cvar_JoltVisualizeGeometry || cvar_JoltVisualizeSurfaces;
+
+  if (bVisualize && cvar_JoltVisualizeGeometryExclusive)
   {
     // deactivate other geometry rendering
     pView->m_IncludeTags.Set(tag);
@@ -1072,18 +1077,32 @@ void ezJoltWorldModule::DebugDrawGeometry()
     pView->m_IncludeTags.Remove(tag);
   }
 
-  if (cvar_JoltVisualizeGeometry)
+  if (bSurfaceColors != m_bDebugGeoSurfaceColors)
+  {
+    // the colors are baked into the render components, so switching between the two visualizations has to rebuild them
+    m_bDebugGeoSurfaceColors = bSurfaceColors;
+
+    for (auto it : m_DebugDrawComponents)
+    {
+      GetWorld()->DeleteObjectDelayed(it.Value().m_hObject);
+    }
+
+    m_DebugDrawComponents.Clear();
+    m_DebugDrawShapeGeo.Clear();
+  }
+
+  if (bVisualize)
   {
     const ezVec3 vCenterPos = pView->GetCamera()->GetCenterPosition();
 
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Static, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Dynamic, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Query, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Ragdoll, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Trigger, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Rope, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Cloth, tag);
-    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Debris, tag);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Static, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Dynamic, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Query, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Ragdoll, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Trigger, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Rope, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Cloth, tag, bSurfaceColors);
+    DebugDrawGeometry(vCenterPos, cvar_JoltVisualizeDistance, ezPhysicsShapeType::Debris, tag, bSurfaceColors);
   }
 
   for (auto it = m_DebugDrawComponents.GetIterator(); it.IsValid();)
@@ -1112,7 +1131,7 @@ void ezJoltWorldModule::DebugDrawGeometry()
   }
 }
 
-void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, ezPhysicsShapeType::Enum shapeType, const ezTag& tag)
+void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, ezPhysicsShapeType::Enum shapeType, const ezTag& tag, bool bSurfaceColors)
 {
   const ezVec3 vAabbMin = vCenter - ezVec3(fRadius);
   const ezVec3 vAabbMax = vCenter + ezVec3(fRadius);
@@ -1142,6 +1161,8 @@ void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, 
 
   ezTempHybridArray<ezVec3, cMaxTriangles * 3> positionsTmp2;
   ezTempHybridArray<const JPH::PhysicsMaterial*, cMaxTriangles> materialsTmp2;
+  ezTempHybridArray<const JPH::PhysicsMaterial*, 8> distinctMaterials;
+  ezTempHybridArray<ezVec3, cMaxTriangles * 3> partPositions;
 
   for (const JPH::TransformedShape& ts : collector.mHits)
   {
@@ -1180,7 +1201,7 @@ void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, 
     positionsTmp2.Clear();
     materialsTmp2.Clear();
 
-    if (!shapeGeo.m_hMesh.IsValid() || (geo.m_bMutableGeometry && lock.GetBody().IsActive()))
+    if (shapeGeo.m_Parts.IsEmpty() || (geo.m_bMutableGeometry && lock.GetBody().IsActive()))
     {
       shapeGeo.m_Bounds = ezBoundingBox::MakeInvalid();
 
@@ -1200,36 +1221,68 @@ void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, 
 
       if (positionsTmp2.GetCount() >= 3)
       {
-        ezDynamicMeshBufferResourceDescriptor desc;
-        desc.m_Topology = ezGALPrimitiveTopology::Triangles;
-        desc.m_uiMaxVertices = positionsTmp2.GetCount();
-        desc.m_uiMaxPrimitives = positionsTmp2.GetCount() / 3;
-        desc.m_IndexType = ezGALIndexType::None;
-        desc.m_bColorStream = false;
-
-        ezStringBuilder sGuid;
-        sGuid.SetFormat("ColMeshVisGeo_{}", s_iColMeshVisGeoCounter.Increment());
-
-        if (!shapeGeo.m_hMesh.IsValid())
+        distinctMaterials.Clear();
+        for (const JPH::PhysicsMaterial* pMaterial : materialsTmp2)
         {
-          shapeGeo.m_hMesh = ezResourceManager::CreateResource<ezDynamicMeshBufferResource>(sGuid, std::move(desc));
+          if (!distinctMaterials.Contains(pMaterial))
+            distinctMaterials.PushBack(pMaterial);
         }
 
-        ezResourceLock<ezDynamicMeshBufferResource> pMeshBuf(shapeGeo.m_hMesh, ezResourceAcquireMode::BlockTillLoaded);
+        shapeGeo.m_Parts.SetCount(distinctMaterials.GetCount());
 
-        auto positionData = pMeshBuf->AccessPositionData();
-        auto nttData = pMeshBuf->AccessNormalTangentTexCoord0Data();
-        for (ezUInt32 vtxIdx = 0; vtxIdx < positionData.GetCount(); ++vtxIdx)
+        for (ezUInt32 uiPart = 0; uiPart < distinctMaterials.GetCount(); ++uiPart)
         {
-          const auto& pos = positionsTmp2[vtxIdx];
-          positionData[vtxIdx] = pos;
+          const JPH::PhysicsMaterial* pPartMaterial = distinctMaterials[uiPart];
 
-          auto& vtx = nttData[vtxIdx];
-          vtx.m_vTexCoord.SetZero();
-          vtx.m_vEncodedNormal.SetZero();
-          vtx.m_vEncodedTangent.SetZero();
+          partPositions.Clear();
+          for (ezUInt32 uiTriIdx = 0; uiTriIdx < materialsTmp2.GetCount(); ++uiTriIdx)
+          {
+            if (materialsTmp2[uiTriIdx] == pPartMaterial)
+            {
+              partPositions.PushBackRange(positionsTmp2.GetArrayPtr().GetSubArray(uiTriIdx * 3, 3));
+            }
+          }
 
-          shapeGeo.m_Bounds.ExpandToInclude(pos);
+          auto& part = shapeGeo.m_Parts[uiPart];
+
+          // every material that Jolt hands out is an ezJoltMaterial, because ezJoltCore also replaces Jolt's default material
+          part.m_SurfaceColor = pPartMaterial ? static_cast<const ezJoltMaterial*>(pPartMaterial)->m_DebugColor : ezColor::White;
+
+          if (!part.m_hMesh.IsValid())
+          {
+            ezDynamicMeshBufferResourceDescriptor desc;
+            desc.m_Topology = ezGALPrimitiveTopology::Triangles;
+            desc.m_uiMaxVertices = partPositions.GetCount();
+            desc.m_uiMaxPrimitives = partPositions.GetCount() / 3;
+            desc.m_IndexType = ezGALIndexType::None;
+            desc.m_bColorStream = false;
+
+            ezStringBuilder sGuid;
+            sGuid.SetFormat("ColMeshVisGeo_{}", s_iColMeshVisGeoCounter.Increment());
+
+            part.m_hMesh = ezResourceManager::CreateResource<ezDynamicMeshBufferResource>(sGuid, std::move(desc));
+          }
+
+          ezResourceLock<ezDynamicMeshBufferResource> pMeshBuf(part.m_hMesh, ezResourceAcquireMode::BlockTillLoaded);
+
+          auto positionData = pMeshBuf->AccessPositionData();
+          auto nttData = pMeshBuf->AccessNormalTangentTexCoord0Data();
+
+          // for mutable geometry the mesh is reused, so it may not have the same size as the new data
+          const ezUInt32 uiNumVertices = ezMath::Min(positionData.GetCount(), partPositions.GetCount());
+
+          for (ezUInt32 vtxIdx = 0; vtxIdx < uiNumVertices; ++vtxIdx)
+          {
+            const auto& pos = partPositions[vtxIdx];
+            positionData[vtxIdx] = pos;
+
+            auto& vtx = nttData[vtxIdx];
+            vtx.m_vTexCoord.SetZero();
+            vtx.m_vEncodedNormal.SetZero();
+            vtx.m_vEncodedTangent.SetZero();
+
+            shapeGeo.m_Bounds.ExpandToInclude(pos);
+          }
         }
       }
     }
@@ -1248,16 +1301,21 @@ void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, 
     geo.m_hObject = GetWorld()->CreateObject(gd, pObj);
     geo.m_bMutableGeometry = lock.GetBody().IsSoftBody();
 
-    ezCustomMeshComponent* pMesh;
-    ezCustomMeshComponent::CreateComponent(pObj, pMesh);
-
     const bool bKinematic = (lock.GetBody().GetMotionType() == JPH::EMotionType::Kinematic);
     const auto& vis = s_Vis[ezMath::FirstBitLow((ezUInt32)shapeType)][bKinematic ? 1 : 0];
 
-    pMesh->SetMeshResource(shapeGeo.m_hMesh);
-    pMesh->SetBounds(shapeGeo.m_Bounds);
-    pMesh->SetMaterialFile(vis.m_szMaterial);
-    pMesh->SetColor(vis.m_Color);
+    for (const auto& part : shapeGeo.m_Parts)
+    {
+      ezCustomMeshComponent* pMesh;
+      ezCustomMeshComponent::CreateComponent(pObj, pMesh);
+
+      pMesh->SetMeshResource(part.m_hMesh);
+      pMesh->SetBounds(shapeGeo.m_Bounds);
+      pMesh->SetMaterialFile(vis.m_szMaterial);
+
+      // the material of the shape type is kept either way, so that for example triggers stay transparent
+      pMesh->SetColor(bSurfaceColors ? part.m_SurfaceColor.WithAlpha(vis.m_Color.a) : vis.m_Color);
+    }
   }
 }
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -225,7 +225,7 @@ private:
   ezTime CalculateUpdateSteps();
 
   void DebugDrawGeometry();
-  void DebugDrawGeometry(const ezVec3& vCenter, float fRadius, ezPhysicsShapeType::Enum shapeType, const ezTag& tag);
+  void DebugDrawGeometry(const ezVec3& vCenter, float fRadius, ezPhysicsShapeType::Enum shapeType, const ezTag& tag, bool bSurfaceColors);
 
   struct DebugGeo
   {
@@ -234,9 +234,17 @@ private:
     bool m_bMutableGeometry = false;
   };
 
-  struct DebugGeoShape
+  /// The triangles of a shape that use one surface. A mesh can only be drawn with a single color,
+  /// so shapes whose triangles use different surfaces are split into several of these.
+  struct DebugGeoShapePart
   {
     ezDynamicMeshBufferResourceHandle m_hMesh;
+    ezColor m_SurfaceColor = ezColor::White;
+  };
+
+  struct DebugGeoShape
+  {
+    ezSmallArray<DebugGeoShapePart, 1> m_Parts;
     ezBoundingBox m_Bounds;
     ezUInt32 m_uiLastSeenCounter = 0;
   };
@@ -263,6 +271,7 @@ private:
   ezUInt64 m_uiJoltUpdateCounter = 0;
 
   ezUInt32 m_uiDebugGeoLastSeenCounter = 0;
+  bool m_bDebugGeoSurfaceColors = false; ///< which of the two visualizations the cached debug geometry was built for
   ezMap<DebugBodyShapeKey, DebugGeo> m_DebugDrawComponents;
   ezMap<const void*, DebugGeoShape> m_DebugDrawShapeGeo;
 

--- a/Data/Samples/Testing Chambers/Surfaces/Ceramic.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Ceramic.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{2057549140837799317,5628083065315903200}}
-		u4 %Hash{17137608572169645788}
+		u4 %Hash{8902500773831071602}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -33,10 +33,11 @@ o
 {
 	Uuid %id{u4{1292480348028545197,4746862408255961576}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 14bf3313-89f3-4692-873c-d127980bf748 }"}
+		ColorGamma %DebugColor{u1{106,176,197,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Default.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Default.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{9792722692401254016,4982072354546932053}}
-		u4 %Hash{7268015459874377857}
+		u4 %Hash{13472379486539336395}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -136,10 +136,11 @@ o
 {
 	Uuid %id{u4{7976948093863279760,5116577666127728256}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 8f19ce05-bf1e-4626-9659-e6acc058dee5 }"}
+		ColorGamma %DebugColor{u1{255,0,196,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -240,7 +241,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Fabric.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Fabric.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{12817809891629497739,5129659926182446297}}
-		u4 %Hash{16203861523253127534}
+		u4 %Hash{8805215291484419363}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -49,10 +49,11 @@ o
 {
 	Uuid %id{u4{6538444430572296374,4800258516969875445}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{167,68,68,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Flesh.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Flesh.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{17348597575240957102,5764298418626958774}}
-		u4 %Hash{1576004144550142433}
+		u4 %Hash{1097606001816013127}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -33,10 +33,11 @@ o
 {
 	Uuid %id{u4{16961761115058694818,5017810455938446912}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{238,17,17,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Glass.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Glass.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{10025688183499857836,5231213208591960990}}
-		u4 %Hash{7817525437087873239}
+		u4 %Hash{9621382473583941494}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -49,10 +49,11 @@ o
 {
 	Uuid %id{u4{17150390421160160129,5124127796172148969}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{130,194,217,255}}
 		f %DynamicFriction{0xCDCC4C3D}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Ground-Soft.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Ground-Soft.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{15335209113862514604,5420249647901145269}}
-		u4 %Hash{4860498877416011407}
+		u4 %Hash{4122089742480552492}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -33,10 +33,11 @@ o
 {
 	Uuid %id{u4{2729883397439234195,5191508142931869670}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 2987eede-0d7c-4750-9043-0215249e52c0 }"}
+		ColorGamma %DebugColor{u1{59,146,62,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Ground.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Ground.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{13858312881180918672,5138622001753616094}}
-		u4 %Hash{87664719702223463}
+		u4 %Hash{10645819162272433664}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -50,10 +50,11 @@ o
 {
 	Uuid %id{u4{15610360347705610146,4844218173671098363}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{118,94,54,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -115,7 +116,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Ice.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Ice.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{13548701741464106169,5084124959224755499}}
-		u4 %Hash{15401948094684409396}
+		u4 %Hash{3069045506928907175}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -32,10 +32,11 @@ o
 {
 	Uuid %id{u4{5019678712678519184,5533314101674757294}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{116,202,213,255}}
 		f %DynamicFriction{0xCDCC4C3D}
 		i1 %GroundType{-1}
 		VarArray %Interactions{}
@@ -77,7 +78,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Liquid.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Liquid.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{1614352151654136493,5727897176130082366}}
-		u4 %Hash{5335228345426610831}
+		u4 %Hash{1796186402472615348}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps{}
@@ -26,10 +26,11 @@ o
 {
 	Uuid %id{u4{18387330072411900589,5350718490671076047}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{""}
+		ColorGamma %DebugColor{u1{183,98,198,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions{}
@@ -71,7 +72,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Metal.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Metal.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{15510886848221585289,5341648796429410170}}
-		u4 %Hash{3699291899895682078}
+		u4 %Hash{5115320235723550631}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -35,10 +35,11 @@ o
 {
 	Uuid %id{u4{16778435064196641670,4832911445518222033}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{121,142,142,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -116,7 +117,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/None.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/None.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{16563774064073005462,5054937769740717573}}
-		u4 %Hash{5903357343180572052}
+		u4 %Hash{16779873232600278817}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps{}
@@ -26,10 +26,11 @@ o
 {
 	Uuid %id{u4{17663968034794809262,4952101623057282098}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{""}
+		ColorGamma %DebugColor{u1{0,0,0,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions{}
@@ -71,7 +72,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Paper.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Paper.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{9753618612338378646,4890478201592266617}}
-		u4 %Hash{8519365199911373840}
+		u4 %Hash{18378623203014289524}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -49,10 +49,11 @@ o
 {
 	Uuid %id{u4{2109382039210662577,5676546169070438888}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{167,167,167,255}}
 		f %DynamicFriction{0x9A99993E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Plant.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Plant.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{17522690627324596629,4619730018867816803}}
-		u4 %Hash{6734006279473759592}
+		u4 %Hash{420011493567945100}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -66,10 +66,11 @@ o
 {
 	Uuid %id{u4{1412654252048292498,5262054477921715519}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{52,134,36,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -115,7 +116,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Plastic.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Plastic.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{10214679513334657166,5563728569889941470}}
-		u4 %Hash{6829854849977548655}
+		u4 %Hash{795597218904771633}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -33,10 +33,11 @@ o
 {
 	Uuid %id{u4{17459790737411196586,5132150868456359046}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{158,68,152,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Stone.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Stone.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{5257683838109301895,5085278606372844307}}
-		u4 %Hash{16853629589290985720}
+		u4 %Hash{6830955763144763608}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -49,10 +49,11 @@ o
 {
 	Uuid %id{u4{18126293318050665900,5368927281796558003}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{151,151,151,255}}
 		f %DynamicFriction{0xCDCC4C3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Water.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Water.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{2629173459460707971,5175946381366488332}}
-		u4 %Hash{13657377541000310688}
+		u4 %Hash{10686041015220387538}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -49,10 +49,11 @@ o
 {
 	Uuid %id{u4{7173774501372172217,4800803224915448728}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 4d32563e-9422-4f7d-ad7a-bb8dba546716 }"}
+		ColorGamma %DebugColor{u1{61,149,207,255}}
 		f %DynamicFriction{0xCDCCCC3D}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -97,7 +98,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Surfaces/Wood.ezSurfaceAsset
+++ b/Data/Samples/Testing Chambers/Surfaces/Wood.ezSurfaceAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Surface"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{10443522772994204319,5520629884345664304}}
-		u4 %Hash{14654358228198156759}
+		u4 %Hash{16059688172151253493}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -50,10 +50,11 @@ o
 {
 	Uuid %id{u4{4280903650760852916,5318024670694204982}}
 	s %t{"ezSurfaceResourceDescriptor"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		s %BaseSurface{"{ 0a105955-e069-4523-80ce-7b9867bde687 }"}
+		ColorGamma %DebugColor{u1{144,104,41,255}}
 		f %DynamicFriction{0xCDCCCC3E}
 		i1 %GroundType{-1}
 		VarArray %Interactions
@@ -98,7 +99,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSurfaceResourceDescriptor"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o


### PR DESCRIPTION
Surface assets got a "Debug Color" property. CVar "Jolt.Visualize.Surfaces" enables new Jolt material debug rendering overlay. Uses the surface colors to show where which surface is being used.

<img width="878" height="537" alt="image" src="https://github.com/user-attachments/assets/4c1e05bd-7e87-4d2e-9149-7035468cfbf2" />
